### PR TITLE
WIP: Ignore DirectoryStore dir/file ending in .partial

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -805,7 +805,11 @@ class DirectoryStore(MutableMapping):
             directories = [(self.path, '')]
             while directories:
                 dir_name, prefix = directories.pop()
+                if dir_name.endswith('.partial'):
+                    continue
                 for name in os.listdir(dir_name):
+                    if name.endswith('.partial'):
+                        continue
                     path = os.path.join(dir_name, name)
                     if os.path.isfile(path):
                         yield prefix + name


### PR DESCRIPTION
If a directory name or file name ends in `.partial`, exclude them from `keys`. These are effectively internal spec that no one should be touching or interacting with.