### PR TITLE
WIP: google cloud storage class

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1939,7 +1939,7 @@ class GCSStore(MutableMapping):
 
         self.bucket_name = bucket_name
         self.prefix = normalize_storage_path(prefix)
-        self.client_kwargs = {}
+        self.client_kwargs = client_kwargs
         self.initialize_bucket()
 
     def initialize_bucket(self):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1886,3 +1886,157 @@ class LRUStoreCache(MutableMapping):
         with self._mutex:
             self._invalidate_keys()
             self._invalidate_value(key)
+
+
+# utility functions for object stores
+
+
+def _strip_prefix_from_path(path, prefix):
+    # normalized things will not have any leading or trailing slashes
+    path_norm = normalize_storage_path(path)
+    prefix_norm = normalize_storage_path(prefix)
+    if path_norm.startswith(prefix_norm):
+        return path_norm[(len(prefix_norm)+1):]
+    else:
+        return path
+
+
+def _append_path_to_prefix(path, prefix):
+    return '/'.join([normalize_storage_path(prefix),
+                     normalize_storage_path(path)])
+
+
+def atexit_rmgcspath(bucket, path):
+    from google.cloud import storage
+    client = storage.Client()
+    bucket = client.get_bucket(bucket)
+    bucket.delete_blobs(bucket.list_blobs(prefix=path))
+    print('deleted blobs')
+
+
+class GCSStore(MutableMapping):
+
+    def __init__(self, bucket_name, prefix=None, client_kwargs={}):
+
+        self.bucket_name = bucket_name
+        self.prefix = normalize_storage_path(prefix)
+        self.client_kwargs = {}
+        self.initialize_bucket()
+
+    def initialize_bucket(self):
+        from google.cloud import storage
+        # run `gcloud auth application-default login` from shell
+        client = storage.Client(**self.client_kwargs)
+        self.bucket = client.get_bucket(self.bucket_name)
+        # need to properly handle excpetions
+        import google.api_core.exceptions as exceptions
+        self.exceptions = exceptions
+
+    # needed for pickling
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state['bucket']
+        del state['exceptions']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.initialize_bucket()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def __getitem__(self, key):
+        blob_name = _append_path_to_prefix(key, self.prefix)
+        blob = self.bucket.get_blob(blob_name)
+        if blob:
+            return blob.download_as_string()
+        else:
+            raise KeyError('Blob %s not found' % blob_name)
+
+    def __setitem__(self, key, value):
+        blob_name = _append_path_to_prefix(key, self.prefix)
+        blob = self.bucket.blob(blob_name)
+        blob.upload_from_string(value)
+
+    def __delitem__(self, key):
+        blob_name = _append_path_to_prefix(key, self.prefix)
+        try:
+            self.bucket.delete_blob(blob_name)
+        except self.exceptions.NotFound as er:
+            raise KeyError(er.message)
+
+    def __contains__(self, key):
+        blob_name = _append_path_to_prefix(key, self.prefix)
+        return self.bucket.get_blob(blob_name) is not None
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, GCSMap) and
+            self.bucket_name == other.bucket_name and
+            self.prefix == other.prefix
+        )
+
+    def __iter__(self):
+        blobs = self.bucket.list_blobs(prefix=self.prefix)
+        for blob in blobs:
+            yield _strip_prefix_from_path(blob.name, self.prefix)
+
+    def __len__(self):
+        iterator = self.bucket.list_blobs(prefix=self.prefix)
+        return len(list(iterator))
+
+    def list_gcs_directory_blobs(self, path):
+        """Return list of all blobs *directly* under a gcs prefix."""
+        prefix = normalize_storage_path(path) + '/'
+        return [blob.name for blob in
+                self.bucket.list_blobs(prefix=prefix, delimiter='/')]
+
+    # from https://github.com/GoogleCloudPlatform/google-cloud-python/issues/920#issuecomment-326125992
+    def list_gcs_subdirectories(self, path):
+        """Return set of all "subdirectories" from a gcs prefix."""
+        prefix = normalize_storage_path(path) + '/'
+        iterator = self.bucket.list_blobs(prefix=prefix, delimiter='/')
+        prefixes = set()
+        for page in iterator.pages:
+            prefixes.update(page.prefixes)
+        # need to strip trailing slash to be consistent with os.listdir
+        return [path[:-1] for path in prefixes]
+
+    def list_gcs_directory(self, prefix, strip_prefix=True):
+        """Return a list of all blobs and subdirectories from a gcs prefix."""
+        items = set()
+        items.update(self.list_gcs_directory_blobs(prefix))
+        items.update(self.list_gcs_subdirectories(prefix))
+        items = list(items)
+        if strip_prefix:
+            items = [_strip_prefix_from_path(path, prefix) for path in items]
+        return items
+
+    def dir_path(self, path=None):
+        dir_path = _append_path_to_prefix(path, self.prefix)
+        return dir_path
+
+    def listdir(self, path=None):
+        dir_path = self.dir_path(path)
+        return sorted(self.list_gcs_directory(dir_path, strip_prefix=True))
+
+    def rename(self, src_path, dst_path):
+        raise NotImplementedErrror
+
+    def rmdir(self, path=None):
+        dir_path = self.dir_path(path)
+        self.bucket.delete_blobs(self.bucket.list_blobs(prefix=dir_path))
+
+    def getsize(self, path=None):
+        dir_path = self.dir_path(path)
+        size = 0
+        for blob in self.bucket.list_blobs(prefix=dir_path):
+            size += blob.size
+        return size
+
+    def clear(self):
+        self.rmdir()

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1911,10 +1911,29 @@ def atexit_rmgcspath(bucket, path):
     client = storage.Client()
     bucket = client.get_bucket(bucket)
     bucket.delete_blobs(bucket.list_blobs(prefix=path))
-    print('deleted blobs')
 
 
 class GCSStore(MutableMapping):
+    """Storage class using a Google Cloud Storage (GCS)
+
+    Parameters
+    ----------
+    bucket_name : string
+        The name of the GCS bucket
+    prefix : string, optional
+        The prefix within the bucket (i.e. subdirectory)
+    client_kwargs : dict, optional
+        Extra options passed to ``google.cloud.storage.Client`` when connecting
+        to GCS
+
+    Notes
+    -----
+    In order to use this store, you must install the Google Cloud Storage
+    `Python Client Library <https://cloud.google.com/storage/docs/reference/libraries>`_.
+    You must also provide valid application credentials, either by setting the
+    ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable or via
+    `default credentials <https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login>`_.
+    """
 
     def __init__(self, bucket_name, prefix=None, client_kwargs={}):
 
@@ -1949,45 +1968,8 @@ class GCSStore(MutableMapping):
     def __exit__(self, *args):
         pass
 
-    def __getitem__(self, key):
-        blob_name = _append_path_to_prefix(key, self.prefix)
-        blob = self.bucket.get_blob(blob_name)
-        if blob:
-            return blob.download_as_string()
-        else:
-            raise KeyError('Blob %s not found' % blob_name)
-
-    def __setitem__(self, key, value):
-        blob_name = _append_path_to_prefix(key, self.prefix)
-        blob = self.bucket.blob(blob_name)
-        blob.upload_from_string(value)
-
-    def __delitem__(self, key):
-        blob_name = _append_path_to_prefix(key, self.prefix)
-        try:
-            self.bucket.delete_blob(blob_name)
-        except self.exceptions.NotFound as er:
-            raise KeyError(er.message)
-
-    def __contains__(self, key):
-        blob_name = _append_path_to_prefix(key, self.prefix)
-        return self.bucket.get_blob(blob_name) is not None
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, GCSMap) and
-            self.bucket_name == other.bucket_name and
-            self.prefix == other.prefix
-        )
-
-    def __iter__(self):
-        blobs = self.bucket.list_blobs(prefix=self.prefix)
-        for blob in blobs:
-            yield _strip_prefix_from_path(blob.name, self.prefix)
-
-    def __len__(self):
-        iterator = self.bucket.list_blobs(prefix=self.prefix)
-        return len(list(iterator))
+    def full_path(self, path=None):
+        return _append_path_to_prefix(path, self.prefix)
 
     def list_gcs_directory_blobs(self, path):
         """Return list of all blobs *directly* under a gcs prefix."""
@@ -1995,7 +1977,7 @@ class GCSStore(MutableMapping):
         return [blob.name for blob in
                 self.bucket.list_blobs(prefix=prefix, delimiter='/')]
 
-    # from https://github.com/GoogleCloudPlatform/google-cloud-python/issues/920#issuecomment-326125992
+    # from https://github.com/GoogleCloudPlatform/google-cloud-python/issues/920
     def list_gcs_subdirectories(self, path):
         """Return set of all "subdirectories" from a gcs prefix."""
         prefix = normalize_storage_path(path) + '/'
@@ -2016,27 +1998,69 @@ class GCSStore(MutableMapping):
             items = [_strip_prefix_from_path(path, prefix) for path in items]
         return items
 
-    def dir_path(self, path=None):
-        dir_path = _append_path_to_prefix(path, self.prefix)
-        return dir_path
-
     def listdir(self, path=None):
-        dir_path = self.dir_path(path)
+        dir_path = self.full_path(path)
         return sorted(self.list_gcs_directory(dir_path, strip_prefix=True))
 
-    def rename(self, src_path, dst_path):
-        raise NotImplementedErrror
-
     def rmdir(self, path=None):
-        dir_path = self.dir_path(path)
+        # make sure it's a directory
+        dir_path = normalize_storage_path(self.full_path(path)) + '/'
         self.bucket.delete_blobs(self.bucket.list_blobs(prefix=dir_path))
 
     def getsize(self, path=None):
-        dir_path = self.dir_path(path)
-        size = 0
-        for blob in self.bucket.list_blobs(prefix=dir_path):
-            size += blob.size
-        return size
+        # this function should *not* be recursive
+        # a lot of slash trickery is required to make this work right
+        full_path = self.full_path(path)
+        blob = self.bucket.get_blob(full_path)
+        if blob is not None:
+            return blob.size
+        else:
+            dir_path = normalize_storage_path(full_path) + '/'
+            blobs = self.bucket.list_blobs(prefix=dir_path, delimiter='/')
+            size = 0
+            for blob in blobs:
+                size += blob.size
+            return size
 
     def clear(self):
         self.rmdir()
+
+    def __getitem__(self, key):
+        blob_name = self.full_path(key)
+        blob = self.bucket.get_blob(blob_name)
+        if blob:
+            return blob.download_as_string()
+        else:
+            raise KeyError('Blob %s not found' % blob_name)
+
+    def __setitem__(self, key, value):
+        blob_name = self.full_path(key)
+        blob = self.bucket.blob(blob_name)
+        blob.upload_from_string(value)
+
+    def __delitem__(self, key):
+        blob_name = self.full_path(key)
+        try:
+            self.bucket.delete_blob(blob_name)
+        except self.exceptions.NotFound as er:
+            raise KeyError(er.message)
+
+    def __contains__(self, key):
+        blob_name = self.full_path(key)
+        return self.bucket.get_blob(blob_name) is not None
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, GCSStore) and
+            self.bucket_name == other.bucket_name and
+            self.prefix == other.prefix
+        )
+
+    def __iter__(self):
+        blobs = self.bucket.list_blobs(prefix=self.prefix)
+        for blob in blobs:
+            yield _strip_prefix_from_path(blob.name, self.prefix)
+
+    def __len__(self):
+        iterator = self.bucket.list_blobs(prefix=self.prefix)
+        return len(list(iterator))

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1699,10 +1699,9 @@ class TestArrayWithStoreCache(TestArray):
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
 
+
 try:
     from google.cloud import storage as gcstorage
-    # cleanup function
-
 except ImportError:  # pragma: no cover
     gcstorage = None
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1254,8 +1254,6 @@ class TestGCSStore(StoreTests, unittest.TestCase):
         # would need to be replaced with a dedicated test bucket
         bucket = 'zarr-test'
         prefix = uuid.uuid4()
-
-        print('registering')
         atexit.register(atexit_rmgcspath, bucket, prefix)
         store = GCSStore(bucket, prefix)
         return store

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -8,6 +8,7 @@ import json
 import array
 import shutil
 import os
+import uuid
 
 
 import numpy as np
@@ -19,7 +20,8 @@ from zarr.storage import (init_array, array_meta_key, attrs_key, DictStore,
                           DirectoryStore, ZipStore, init_group, group_meta_key,
                           getsize, migrate_1to2, TempStore, atexit_rmtree,
                           NestedDirectoryStore, default_compressor, DBMStore,
-                          LMDBStore, atexit_rmglob, LRUStoreCache)
+                          LMDBStore, atexit_rmglob, LRUStoreCache, GCSStore,
+                          atexit_rmgcspath)
 from zarr.meta import (decode_array_metadata, encode_array_metadata, ZARR_FORMAT,
                        decode_group_metadata, encode_group_metadata)
 from zarr.compat import PY2
@@ -1235,3 +1237,31 @@ def test_format_compatibility():
             else:
                 assert compressor.codec_id == z.compressor.codec_id
                 assert compressor.get_config() == z.compressor.get_config()
+
+
+try:
+    from google.cloud import storage as gcstorage
+    # cleanup function
+
+except ImportError:  # pragma: no cover
+    gcstorage = None
+
+
+@unittest.skipIf(gcstorage is None, 'google-cloud-storage is not installed')
+class TestGCSStore(StoreTests, unittest.TestCase):
+
+    def create_store(self):
+        # would need to be replaced with a dedicated test bucket
+        bucket = 'zarr-test'
+        prefix = uuid.uuid4()
+
+        print('registering')
+        atexit.register(atexit_rmgcspath, bucket, prefix)
+        store = GCSStore(bucket, prefix)
+        return store
+
+    def test_context_manager(self):
+        with self.create_store() as store:
+            store['foo'] = b'bar'
+            store['baz'] = b'qux'
+            assert 2 == len(store)


### PR DESCRIPTION
First, apologies for submitting an un-solicited pull request. I know that is against the contributor guidelines. I thought this idea would be easier to discuss with a concrete implementation to look at.

In my highly opinionated view, the killer feature of zarr is its ability to efficiently store array data in cloud storage. Currently, the recommended way to do this is via outside packages (e.g. s3fs, gcsfs), which provide a `MutableMapping` that zarr can store things in. 

In this PR, I have implemented an experimental google cloud storage class directly within zarr.

Why did I do this? Because, in the pangeo project, we are now making heavy use of the xarray -> zarr -> gcsfs -> cloud storage stack. I have come to the conclusion that a tighter coupling between zarr and gcs, via the [`google.cloud.storage`](https://googlecloudplatform.github.io/google-cloud-python/latest/storage/client.html) API, may prove advantageous.

In addition to performance benefits and easier debugging, I think there are social advantages to having cloud storage as a first-class part of zarr. Lots of people want to store arrays in the cloud, and if zarr can provide this capability more natively, it could increase adoption.

Thoughts?

These tests require GCP credentials and the google cloud storage package. It is possible add encrypted credentials to travis, but I haven't done that yet. Tests are (mostly) working locally for me.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Unit tests and doctests pass locally under Python 3.6 (e.g., run ``tox -e py36`` or 
  ``pytest -v --doctest-modules zarr``)
* [ ] Unit tests pass locally under Python 2.7 (e.g., run ``tox -e py27`` or
  ``pytest -v zarr``)
* [ ] PEP8 checks pass (e.g., run ``tox -e py36`` or ``flake8 --max-line-length=100 zarr``)
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Doctests in tutorial pass (e.g., run ``tox -e py36`` or ``python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst``)
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage to 100% (Coveralls passes)
