### PR TITLE
Fix missing backslash in docs

### DIFF
--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -253,7 +253,7 @@ keys like "foo/bar/0.0", "foo/bar/0.1", etc.
 To ensure consistent behaviour across different storage systems, logical paths
 MUST be normalized as follows:
 
-* Replace all backward slash characters ("\\") with forward slash characters
+* Replace all backward slash characters ("\\\\") with forward slash characters
   ("/")
 * Strip any leading "/" characters
 * Strip any trailing "/" characters


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr/issues/254

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
