### PR TITLE
WIP: Fix `getsize` to be recursive

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -38,6 +38,9 @@ Bug fixes
 * Ensure ``DictStore`` contains only ``bytes`` to facilitate comparisons and protect against writes.
   By :user:`John Kirkham <jakirkham>`, :issue:`350`
 
+* Fix size computation of ``DirectoryStore`` and subclasses to be recursive.
+  By :user:`John Kirkham <jakirkham>`, :issue:`253`, :issue:`362`
+
 Maintenance
 ~~~~~~~~~~~
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -843,11 +843,10 @@ class DirectoryStore(MutableMapping):
         if os.path.isfile(fs_path):
             return os.path.getsize(fs_path)
         elif os.path.isdir(fs_path):
-            children = os.listdir(fs_path)
             size = 0
-            for child in children:
-                child_fs_path = os.path.join(fs_path, child)
-                if os.path.isfile(child_fs_path):
+            for dirname, dirs, children in os.walk(fs_path):
+                for child in children:
+                    child_fs_path = os.path.join(dirname, child)
                     size += os.path.getsize(child_fs_path)
             return size
         else:

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1278,8 +1278,6 @@ class TestArrayWithDirectoryStore(TestArray):
                      cache_attrs=cache_attrs)
 
     def test_nbytes_stored(self):
-
-        # dict as store
         z = self.create_array(shape=1000, chunks=100)
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1285,6 +1285,13 @@ class TestArrayWithDirectoryStore(TestArray):
         expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored
 
+        z2 = self.create_array(shape=(1000, 1100), chunks=100)
+        expect_nbytes_stored = sum(buffer_size(v) for v in z2.store.values())
+        assert expect_nbytes_stored == z2.nbytes_stored
+        z2[:] = 42
+        expect_nbytes_stored = sum(buffer_size(v) for v in z2.store.values())
+        assert expect_nbytes_stored == z2.nbytes_stored
+
 
 class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -211,10 +211,10 @@ class StoreTests(object):
 
         # test getsize (optional)
         if hasattr(store, 'getsize'):
-            assert 6 == store.getsize()
+            assert 15 == store.getsize()
             assert 3 == store.getsize('a')
             assert 3 == store.getsize('b')
-            assert 3 == store.getsize('c')
+            assert 9 == store.getsize('c')
             assert 3 == store.getsize('c/d')
             assert 6 == store.getsize('c/e')
             assert 3 == store.getsize('c/e/f')


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr/issues/253

Make sure the `DirectoryStore`'s `getsize` method checks each directory recursively when computing the storage size of a directory.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
