### PR TITLE
RFC: Optionally support memory-mapping DirectoryStore values

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1035,6 +1035,10 @@ class NestedDirectoryStore(DirectoryStore):
             self.path == other.path
         )
 
+    def pop(self, key, *args, **kwargs):
+        key = _nested_map_ckey(key)
+        return super(NestedDirectoryStore, self).pop(key, *args, **kwargs)
+
     def listdir(self, path=None):
         children = super(NestedDirectoryStore, self).listdir(path=path)
         if array_meta_key in children:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -901,10 +901,10 @@ class TempStore(DirectoryStore):
     """
 
     # noinspection PyShadowingBuiltins
-    def __init__(self, suffix='', prefix='zarr', dir=None):
+    def __init__(self, suffix='', prefix='zarr', dir=None, memmap=False):
         path = tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
         atexit.register(atexit_rmtree, path)
-        super(TempStore, self).__init__(path)
+        super(TempStore, self).__init__(path, memmap=memmap)
 
 
 _prog_ckey = re.compile(r'^(\d+)(\.\d+)+$')
@@ -987,8 +987,8 @@ class NestedDirectoryStore(DirectoryStore):
 
     """
 
-    def __init__(self, path):
-        super(NestedDirectoryStore, self).__init__(path)
+    def __init__(self, path, memmap=False):
+        super(NestedDirectoryStore, self).__init__(path, memmap=memmap)
 
     def __getitem__(self, key):
         key = _nested_map_ckey(key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -810,6 +810,30 @@ class DirectoryStore(MutableMapping):
     def __len__(self):
         return sum(1 for _ in self.keys())
 
+    __marker = object()
+
+    def pop(self, key, default=__marker):
+        try:
+            value = ensure_bytes(self[key])
+        except KeyError:
+            if default is self.__marker:
+                raise
+            else:
+                return default
+        else:
+            del self[key]
+            return value
+
+    def popitem(self):
+        try:
+            key = next(self.keys())
+        except StopIteration:
+            raise KeyError("Store empty")
+        else:
+            value = ensure_bytes(self[key])
+            del self[key]
+            return (key, value)
+
     def dir_path(self, path=None):
         store_path = normalize_storage_path(path)
         dir_path = self.path

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -724,7 +724,7 @@ class DirectoryStore(MutableMapping):
         filepath = os.path.join(self.path, key)
         if os.path.isfile(filepath):
             if self.memmap:
-                return np.memmap(filepath, mode='r')
+                return memoryview(np.memmap(filepath, mode='r'))
             else:
                 with open(filepath, 'rb') as f:
                     return f.read()

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -830,8 +830,7 @@ class DirectoryStore(MutableMapping):
         except StopIteration:
             raise KeyError("Store empty")
         else:
-            value = ensure_bytes(self[key])
-            del self[key]
+            value = self.pop(key)
             return (key, value)
 
     def dir_path(self, path=None):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -813,16 +813,16 @@ class DirectoryStore(MutableMapping):
     __marker = object()
 
     def pop(self, key, default=__marker):
-        try:
-            value = ensure_bytes(self[key])
-        except KeyError:
-            if default is self.__marker:
-                raise
-            else:
-                return default
-        else:
-            del self[key]
+        filepath = os.path.join(self.path, key)
+        if os.path.isfile(filepath):
+            with open(filepath, 'rb') as f:
+                value = f.read()
+            os.remove(filepath)
             return value
+        elif default is self.__marker:
+            raise KeyError(key)
+        else:
+            return default
 
     def popitem(self):
         try:

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -744,6 +744,15 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
         setdel_hierarchy_checks(store)
 
 
+class TestDirectoryStoreMemmap(TestDirectoryStore, unittest.TestCase):
+
+    def create_store(self):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = DirectoryStore(path, memmap=True)
+        return store
+
+
 class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
 
     def create_store(self):


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr/issues/265
Depends on ~~https://github.com/zarr-developers/zarr/pull/378~~ & ~~https://github.com/zarr-developers/zarr/pull/379~~ & ~~https://github.com/zarr-developers/zarr/pull/380~~

Adds the `memmap` option to `DirectoryStore`, which defaults to `False` (current behavior). If set to `True`, this will memory-map each value returned instead of loading it all into memory. This behavior is extended to `NestedDirectoryStore` and `TempStore`.

Given the recent work in PR ( https://github.com/zarr-developers/numcodecs/pull/128 ) and PR ( https://github.com/zarr-developers/zarr/pull/352 ), this just works out-of-the-box. The tests needed some adjustment to be a bit more flexible as they were strictly requiring `bytes` before. Also had to implement `pop` and `popitem` to ensure data was copied into memory before files were removed.

xref: https://github.com/zarr-developers/zarr/issues/320
xref: https://github.com/zarr-developers/zarr/issues/321
xref: https://github.com/zarr-developers/zarr/issues/334

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
