### PR TITLE
Fixtureize and parametrize h5py copy tests.

### DIFF
--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -1,5 +1,4 @@
 import atexit
-import os
 import tempfile
 import unittest
 from numbers import Integral
@@ -683,17 +682,16 @@ class TestCopy:
         assert 0 == n_bytes_copied
         assert_array_equal(baz, dest['foo/bar/baz'])
 
-    def test_logging(self, source, dest):
+    def test_logging(self, source, dest, tmpdir):
         # callable log
         copy(source['foo'], dest, dry_run=True, log=print)
 
         # file name
-        fn = tempfile.mktemp()
-        atexit.register(os.remove, fn)
+        fn = str(tmpdir.join('log_name'))
         copy(source['foo'], dest, dry_run=True, log=fn)
 
         # file
-        with tempfile.TemporaryFile(mode='w') as f:
+        with tmpdir.join('log_file').open(mode='w') as f:
             copy(source['foo'], dest, dry_run=True, log=f)
 
         # bad option


### PR DESCRIPTION
The main reason for this is that closing h5py files using `atexit` seems to be a bit buggy. If I run with `pytest`, it's fine, but if I use `python setup.py test`, it will crash on exit.

Using pytest fixtures, we can avoid `atexit` entirely and files will be closed at the end of the test. Unfortunately, this means `unittest.TestCase` cannot be used, so switch to a plain class works. With the fixture, we can parametrize zarr vs. h5py and drop the extra classes.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [N/A] Add docstrings and API docs for any new/modified user-facing classes and functions
* [N/A] New/modified features documented in docs/tutorial.rst
* [N/A] Changes documented in docs/release.rst
* [N/A] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
