### PR TITLE
Explicitly close stores during tests.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -10,6 +10,8 @@ Next release
 * Improve error message in Jupyter when trying to use the ``ipytree`` widget
   without ``ipytree`` installed.
   By :user:`Zain Patel <mzjp2>; :issue:`537`
+* Explicitly close stores during testing.
+  By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`442`
 
 
 .. _release_2.4.0:

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -89,6 +89,9 @@ class TestArray(unittest.TestCase):
             if not isinstance(k, expected_type):  # pragma: no cover
                 pytest.fail("Non-text key: %s" % repr(k))
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_store_has_binary_values(self):
         # Initialize array
         np.random.seed(42)
@@ -100,6 +103,9 @@ class TestArray(unittest.TestCase):
                 ensure_ndarray(v)
             except TypeError:  # pragma: no cover
                 pytest.fail("Non-bytes-like value: %s" % repr(v))
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_store_has_bytes_values(self):
         # Test that many stores do hold bytes values.
@@ -113,6 +119,9 @@ class TestArray(unittest.TestCase):
 
         # Check in-memory array only contains `bytes`
         assert all([isinstance(v, bytes) for v in z.chunk_store.values()])
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_nbytes_stored(self):
 
@@ -130,6 +139,9 @@ class TestArray(unittest.TestCase):
             assert -1 == z.nbytes_stored
         except TypeError:
             pass
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_1d(self):
@@ -212,6 +224,9 @@ class TestArray(unittest.TestCase):
         assert_array_equal(b[190:310], z[190:310])
         assert_array_equal(a[310:], z[310:])
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_array_1d_fill_value(self):
         for fill_value in -1, 0, 1, 10:
 
@@ -225,6 +240,9 @@ class TestArray(unittest.TestCase):
             assert_array_equal(f[:190], z[:190])
             assert_array_equal(a[190:310], z[190:310])
             assert_array_equal(f[310:], z[310:])
+
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
     def test_array_1d_set_scalar(self):
         # test setting the contents of an array with a scalar value
@@ -242,6 +260,9 @@ class TestArray(unittest.TestCase):
             a[:] = value
             z[:] = value
             assert_array_equal(a, z[:])
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_array_1d_selections(self):
         # light test here, full tests in test_indexing
@@ -284,6 +305,9 @@ class TestArray(unittest.TestCase):
         assert_array_equal(8, z.vindex[bix])
         z.oindex[bix] = 9
         assert_array_equal(9, z.oindex[bix])
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_2d(self):
@@ -393,6 +417,9 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[310:], z[310:])
         assert_array_equal(a[:, 7:], z[:, 7:])
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_array_2d_edge_case(self):
         # this fails with filters - chunks extend beyond edge of array, messes with delta
         # filter if no fill value?
@@ -404,6 +431,9 @@ class TestArray(unittest.TestCase):
         expect = np.zeros(shape, dtype=dtype)
         actual = z[:]
         assert_array_equal(expect, actual)
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_array_2d_partial(self):
         z = self.create_array(shape=(1000, 10), chunks=(100, 2), dtype='i4',
@@ -445,6 +475,9 @@ class TestArray(unittest.TestCase):
         assert -1 == z[2, 2]
         assert -1 == z[-1, -1]
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_array_order(self):
 
         # 1D
@@ -460,6 +493,9 @@ class TestArray(unittest.TestCase):
             z[:] = a
             assert_array_equal(a, z[:])
 
+            if hasattr(z.store, 'close'):
+                z.store.close()
+
         # 2D
         a = np.arange(10000).reshape((100, 100))
         for order in 'C', 'F':
@@ -474,6 +510,9 @@ class TestArray(unittest.TestCase):
             actual = z[:]
             assert_array_equal(a, actual)
 
+            if hasattr(z.store, 'close'):
+                z.store.close()
+
     def test_setitem_data_not_shared(self):
         # check that data don't end up being shared with another array
         # https://github.com/alimanfoo/zarr/issues/79
@@ -483,29 +522,41 @@ class TestArray(unittest.TestCase):
         assert_array_equal(z[:], np.arange(20, dtype='i4'))
         a[:] = 0
         assert_array_equal(z[:], np.arange(20, dtype='i4'))
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         assert '063b02ff8d9d3bab6da932ad5828b506ef0a6578' == z.hexdigest()
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
         assert 'f97b84dc9ffac807415f750100108764e837bb82' == z.hexdigest()
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
         assert 'c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261' == z.hexdigest()
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
         assert '14470724dca6c1837edddedc490571b6a7f270bc' == z.hexdigest()
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
         assert '2a1046dd99b914459b3e86be9dde05027a07d209' == z.hexdigest()
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_resize_1d(self):
 
@@ -541,6 +592,9 @@ class TestArray(unittest.TestCase):
         z.shape = (105,)
         assert (105,) == z.shape
         assert (105,) == z[:].shape
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_resize_2d(self):
 
@@ -586,6 +640,9 @@ class TestArray(unittest.TestCase):
         assert (105, 105) == z.shape
         assert (105, 105) == z[:].shape
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_append_1d(self):
 
         a = np.arange(105)
@@ -613,6 +670,9 @@ class TestArray(unittest.TestCase):
         assert (10,) == z.chunks
         assert_array_equal(f, z[:])
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_append_2d(self):
 
         a = np.arange(105*105, dtype='i4').reshape((105, 105))
@@ -633,6 +693,9 @@ class TestArray(unittest.TestCase):
         actual = z[:]
         assert_array_equal(e, actual)
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_append_2d_axis(self):
 
         a = np.arange(105*105, dtype='i4').reshape((105, 105))
@@ -651,6 +714,9 @@ class TestArray(unittest.TestCase):
         assert (10, 10) == z.chunks
         assert_array_equal(e, z[:])
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_append_bad_shape(self):
         a = np.arange(100)
         z = self.create_array(shape=a.shape, chunks=10, dtype=a.dtype)
@@ -658,11 +724,15 @@ class TestArray(unittest.TestCase):
         b = a.reshape(10, 10)
         with pytest.raises(ValueError):
             z.append(b)
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_read_only(self):
 
         z = self.create_array(shape=1000, chunks=100)
         assert not z.read_only
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=1000, chunks=100, read_only=True)
         assert z.read_only
@@ -684,6 +754,9 @@ class TestArray(unittest.TestCase):
             z.vindex[[0, 1, 2]] = 42
         with pytest.raises(PermissionError):
             z.set_mask_selection(np.ones(z.shape, dtype=bool), 42)
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_pickle(self):
 
@@ -721,6 +794,9 @@ class TestArray(unittest.TestCase):
         assert attrs_cache == z2.attrs.cache
         assert_array_equal(a, z2[:])
 
+        if hasattr(z2.store, 'close'):
+            z2.store.close()
+
     def test_np_ufuncs(self):
         z = self.create_array(shape=(100, 100), chunks=(10, 10))
         a = np.arange(10000).reshape(100, 100)
@@ -737,18 +813,26 @@ class TestArray(unittest.TestCase):
         assert_array_equal(np.take(a, indices, axis=1),
                            np.take(z, indices, axis=1))
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
         # use zarr array as indices or condition
         zc = self.create_array(shape=condition.shape, dtype=condition.dtype,
                                chunks=10, filters=None)
         zc[:] = condition
         assert_array_equal(np.compress(condition, a, axis=0),
                            np.compress(zc, a, axis=0))
+        if hasattr(zc.store, 'close'):
+            zc.store.close()
+
         zi = self.create_array(shape=indices.shape, dtype=indices.dtype,
                                chunks=10, filters=None)
         zi[:] = indices
         # this triggers __array__() call with dtype argument
         assert_array_equal(np.take(a, indices, axis=1),
                            np.take(a, zi, axis=1))
+        if hasattr(zi.store, 'close'):
+            zi.store.close()
 
     # noinspection PyStatementEffect
     def test_0len_dim_1d(self):
@@ -782,6 +866,9 @@ class TestArray(unittest.TestCase):
         # this should error
         with pytest.raises(IndexError):
             z[0] = 42
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     # noinspection PyStatementEffect
     def test_0len_dim_2d(self):
@@ -819,6 +906,9 @@ class TestArray(unittest.TestCase):
         # this should error
         with pytest.raises(IndexError):
             z[:, 0] = 42
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_0d(self):
@@ -867,6 +957,9 @@ class TestArray(unittest.TestCase):
         with pytest.raises(ValueError):
             z[...] = np.array([1, 2, 3])
 
+        if hasattr(z.store, 'close'):
+            z.store.close()
+
     def test_nchunks_initialized(self):
 
         z = self.create_array(shape=100, chunks=10)
@@ -876,6 +969,9 @@ class TestArray(unittest.TestCase):
         assert 0 == z.nchunks_initialized
         z[:] = 42
         assert 10 == z.nchunks_initialized
+
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_array_dtype_shape(self):
 
@@ -897,6 +993,8 @@ class TestArray(unittest.TestCase):
                     assert fill_value == z.fill_value
                 z[...] = a
                 assert_array_equal(a, z[...])
+                if hasattr(z.store, 'close'):
+                    z.store.close()
 
     def check_structured_array(self, d, fill_values):
         for a in (d, d[:0]):
@@ -937,6 +1035,9 @@ class TestArray(unittest.TestCase):
                     for f in a.dtype.names:
                         assert_array_equal(a[f], z[f])
 
+                if hasattr(z.store, 'close'):
+                    z.store.close()
+
     def test_structured_array(self):
         d = np.array([(b'aaa', 1, 4.2),
                       (b'bbb', 2, 8.4),
@@ -971,6 +1072,8 @@ class TestArray(unittest.TestCase):
             a = np.arange(z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_equal(a, z[:])
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
         # floats
         for dtype in 'f2', 'f4', 'f8':
@@ -979,6 +1082,8 @@ class TestArray(unittest.TestCase):
             a = np.linspace(0, 1, z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_almost_equal(a, z[:])
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
         # complex
         for dtype in 'c8', 'c16':
@@ -988,6 +1093,8 @@ class TestArray(unittest.TestCase):
             a -= 1j * a
             z[:] = a
             assert_array_almost_equal(a, z[:])
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
         # datetime, timedelta
         for base_type in 'Mm':
@@ -1000,6 +1107,8 @@ class TestArray(unittest.TestCase):
                                       dtype='i8').view(dtype)
                 z[:] = a
                 assert_array_equal(a, z[:])
+                if hasattr(z.store, 'close'):
+                    z.store.close()
 
         # check that datetime generic units are not allowed
         with pytest.raises(ValueError):
@@ -1016,7 +1125,9 @@ class TestArray(unittest.TestCase):
         # an object_codec is required for object arrays, but allow to be provided via
         # filters to maintain API backwards compatibility
         with pytest.warns(FutureWarning):
-            self.create_array(shape=10, chunks=3, dtype=object, filters=[MsgPack()])
+            z = self.create_array(shape=10, chunks=3, dtype=object, filters=[MsgPack()])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # create an object array using msgpack
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=MsgPack())
@@ -1032,6 +1143,8 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # create an object array using pickle
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=Pickle())
@@ -1047,6 +1160,8 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # create an object array using JSON
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=JSON())
@@ -1062,6 +1177,8 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_object_arrays_vlen_text(self):
 
@@ -1078,6 +1195,8 @@ class TestArray(unittest.TestCase):
         a = z[:]
         assert a.dtype == object
         assert_array_equal(data, a)
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=str)
@@ -1085,23 +1204,33 @@ class TestArray(unittest.TestCase):
         assert isinstance(z.filters[0], VLenUTF8)
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=MsgPack())
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=JSON())
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=Pickle())
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object,
                               object_codec=Categorize(greetings, dtype=object))
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_object_arrays_vlen_bytes(self):
 
@@ -1119,6 +1248,8 @@ class TestArray(unittest.TestCase):
         a = z[:]
         assert a.dtype == object
         assert_array_equal(data, a)
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=bytes)
@@ -1126,10 +1257,14 @@ class TestArray(unittest.TestCase):
         assert isinstance(z.filters[0], VLenBytes)
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=Pickle())
         z[:] = data
         assert_array_equal(data, z[:])
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_object_arrays_vlen_array(self):
 
@@ -1155,6 +1290,8 @@ class TestArray(unittest.TestCase):
             a = z[:]
             assert a.dtype == object
             compare_arrays(data, a, codec.dtype)
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
         # convenience API
         for item_type in 'int', '<u4':
@@ -1164,6 +1301,8 @@ class TestArray(unittest.TestCase):
             assert z.filters[0].dtype == np.dtype(item_type)
             z[:] = data
             compare_arrays(data, z[:], np.dtype(item_type))
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
     def test_object_arrays_danger(self):
 
@@ -1175,6 +1314,8 @@ class TestArray(unittest.TestCase):
             z[0] = 'foo'
         with pytest.raises(RuntimeError):
             z[:] = 42
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
         # do something else dangerous
         data = greetings * 10
@@ -1188,12 +1329,16 @@ class TestArray(unittest.TestCase):
             with pytest.raises(RuntimeError):
                 # noinspection PyStatementEffect
                 v[:]
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
     def test_object_codec_warnings(self):
 
         with pytest.warns(UserWarning):
             # provide object_codec, but not object dtype
-            self.create_array(shape=10, chunks=5, dtype='i4', object_codec=JSON())
+            z = self.create_array(shape=10, chunks=5, dtype='i4', object_codec=JSON())
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_zero_d_iter(self):
         a = np.array(1, dtype=int)
@@ -1205,6 +1350,8 @@ class TestArray(unittest.TestCase):
         with pytest.raises(TypeError):
             # noinspection PyStatementEffect
             list(z)
+        if hasattr(z.store, 'close'):
+            z.store.close()
 
     def test_iter(self):
         params = (
@@ -1228,6 +1375,8 @@ class TestArray(unittest.TestCase):
             z[:] = a
             for expect, actual in zip_longest(a, z):
                 assert_array_equal(expect, actual)
+            if hasattr(z.store, 'close'):
+                z.store.close()
 
     def test_compressors(self):
         compressors = [
@@ -1241,6 +1390,8 @@ class TestArray(unittest.TestCase):
             assert np.all(a[0:100] == 1)
             a[:] = 1
             assert np.all(a[:] == 1)
+            if hasattr(a.store, 'close'):
+                a.store.close()
 
     def test_endian(self):
         dtype = np.dtype('float32')
@@ -1251,6 +1402,10 @@ class TestArray(unittest.TestCase):
         a2[:] = 1
         x2 = a2[:]
         assert_array_equal(x1, x2)
+        if hasattr(a1.store, 'close'):
+            a1.store.close()
+        if hasattr(a2.store, 'close'):
+            a2.store.close()
 
     def test_attributes(self):
         a = self.create_array(shape=10, chunks=10, dtype='i8')
@@ -1264,6 +1419,8 @@ class TestArray(unittest.TestCase):
         attrs = json_loads(a.store[a.attrs.key])
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         assert 'bar' in attrs and attrs['bar'] == 'foo'
+        if hasattr(a.store, 'close'):
+            a.store.close()
 
 
 class TestArrayWithPath(TestArray):

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -68,6 +68,8 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g.info, InfoReporter)
         assert isinstance(repr(g.info), str)
         assert isinstance(g.info._repr_html_(), str)
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_group_init_2(self):
         store, chunk_store = self.create_store()
@@ -79,12 +81,16 @@ class TestGroup(unittest.TestCase):
         assert '/foo/bar' == g.name
         assert 'bar' == g.basename
         assert isinstance(g.attrs, Attributes)
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_group_init_errors_1(self):
         store, chunk_store = self.create_store()
         # group metadata not initialized
         with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_group_init_errors_2(self):
         store, chunk_store = self.create_store()
@@ -92,6 +98,8 @@ class TestGroup(unittest.TestCase):
         # array blocks group
         with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_create_group(self):
         g1 = self.create_group()
@@ -162,6 +170,9 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g7, Group)
         assert g7.path == 'z'
 
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
+
     def test_require_group(self):
         g1 = self.create_group()
 
@@ -202,6 +213,9 @@ class TestGroup(unittest.TestCase):
         assert g6.path == 'y'
         assert isinstance(g7, Group)
         assert g7.path == 'z'
+
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
 
     def test_create_dataset(self):
         g = self.create_group()
@@ -277,6 +291,9 @@ class TestGroup(unittest.TestCase):
         assert d.compressor.codec_id == 'zlib'
         assert 1 == d.compressor.level
 
+        if hasattr(g.store, 'close'):
+            g.store.close()
+
     def test_require_dataset(self):
         g = self.create_group()
 
@@ -320,6 +337,9 @@ class TestGroup(unittest.TestCase):
             # can cast but not exact match
             g.require_dataset('foo', shape=1000, chunks=100, dtype='i2',
                               exact=True)
+
+        if hasattr(g.store, 'close'):
+            g.store.close()
 
     def test_create_errors(self):
         g = self.create_group()
@@ -374,6 +394,9 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(PermissionError):
             g.require_dataset('zzz', shape=100, chunks=10)
 
+        if hasattr(g.store, 'close'):
+            g.store.close()
+
     def test_create_overwrite(self):
         try:
             for method_name in 'create_dataset', 'create', 'empty', 'zeros', \
@@ -397,6 +420,9 @@ class TestGroup(unittest.TestCase):
                                             overwrite=True)
                 assert (400,) == d.shape
                 assert isinstance(g['foo'], Group)
+
+                if hasattr(g.store, 'close'):
+                    g.store.close()
         except NotImplementedError:
             pass
 
@@ -624,6 +650,9 @@ class TestGroup(unittest.TestCase):
         assert g1.visitvalues(visitor1) is True
         assert g1.visititems(visitor1) is True
 
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
+
     def test_empty_getitem_contains_iterators(self):
         # setup
         g = self.create_group()
@@ -633,6 +662,9 @@ class TestGroup(unittest.TestCase):
         assert [] == list(g.keys())
         assert 0 == len(g)
         assert 'foo' not in g
+
+        if hasattr(g.store, 'close'):
+            g.store.close()
 
     def test_iterators_recurse(self):
         # setup
@@ -658,6 +690,9 @@ class TestGroup(unittest.TestCase):
         assert 'zab' == arrays_recurse[0][0]
         assert g1['foo']['bar']['zab'] == arrays_recurse[0][1]
 
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
+
     def test_getattr(self):
         # setup
         g1 = self.create_group()
@@ -669,6 +704,9 @@ class TestGroup(unittest.TestCase):
         assert g2['bar'] == g2.bar
         # test that hasattr returns False instead of an exception (issue #88)
         assert not hasattr(g1, 'unexistingattribute')
+
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
 
     def test_setitem(self):
         g = self.create_group()
@@ -685,6 +723,8 @@ class TestGroup(unittest.TestCase):
             assert 42 == g['foo'][()]
         except NotImplementedError:
             pass
+        if hasattr(g.store, 'close'):
+            g.store.close()
 
     def test_delitem(self):
         g = self.create_group()
@@ -703,6 +743,8 @@ class TestGroup(unittest.TestCase):
             assert 'foo' in g
             assert 'bar' not in g
             assert 'bar/baz' not in g
+        if hasattr(g.store, 'close'):
+            g.store.close()
 
     def test_move(self):
         g = self.create_group()
@@ -750,6 +792,9 @@ class TestGroup(unittest.TestCase):
         except NotImplementedError:
             pass
 
+        if hasattr(g.store, 'close'):
+            g.store.close()
+
     def test_array_creation(self):
         grp = self.create_group()
 
@@ -785,6 +830,9 @@ class TestGroup(unittest.TestCase):
         assert isinstance(j, Array)
         assert_array_equal(np.arange(100), j[:])
 
+        if hasattr(grp.store, 'close'):
+            grp.store.close()
+
         grp = self.create_group(read_only=True)
         with pytest.raises(PermissionError):
             grp.create('aa', shape=100, chunks=10)
@@ -808,6 +856,9 @@ class TestGroup(unittest.TestCase):
             grp.ones_like('aa', a)
         with pytest.raises(PermissionError):
             grp.full_like('aa', a)
+
+        if hasattr(grp.store, 'close'):
+            grp.store.close()
 
     def test_paths(self):
         g1 = self.create_group()
@@ -840,6 +891,9 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(ValueError):
             g1['foo/../bar']
 
+        if hasattr(g1.store, 'close'):
+            g1.store.close()
+
     def test_pickle(self):
 
         # setup group
@@ -866,6 +920,9 @@ class TestGroup(unittest.TestCase):
         assert keys == list(g2)
         assert isinstance(g2['foo'], Group)
         assert isinstance(g2['foo/bar'], Array)
+
+        if hasattr(g2.store, 'close'):
+            g2.store.close()
 
     def test_context_manager(self):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -70,11 +70,17 @@ class StoreTests(object):
                 # noinspection PyStatementEffect
                 del store['foo']
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_set_invalid_content(self):
         store = self.create_store()
 
         with pytest.raises(TypeError):
             store['baz'] = list(range(5))
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_clear(self):
         store = self.create_store()
@@ -85,6 +91,9 @@ class StoreTests(object):
         assert len(store) == 0
         assert 'foo' not in store
         assert 'baz' not in store
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_pop(self):
         store = self.create_store()
@@ -106,6 +115,9 @@ class StoreTests(object):
         v = store.pop('xxx', None)
         assert v is None
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_popitem(self):
         store = self.create_store()
         store['foo'] = b'bar'
@@ -116,6 +128,9 @@ class StoreTests(object):
         with pytest.raises(KeyError):
             store.popitem()
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_writeable_values(self):
         store = self.create_store()
 
@@ -125,6 +140,9 @@ class StoreTests(object):
         store['foo3'] = array.array('B', b'bar')
         store['foo4'] = np.frombuffer(b'bar', dtype='u1')
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_update(self):
         store = self.create_store()
         assert 'foo' not in store
@@ -132,6 +150,9 @@ class StoreTests(object):
         store.update(foo=b'bar', baz=b'quux')
         assert b'bar' == store['foo']
         assert b'quux' == store['baz']
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_iterators(self):
         store = self.create_store()
@@ -156,6 +177,9 @@ class StoreTests(object):
         assert {b'aaa', b'bbb', b'ddd', b'fff'} == set(store.values())
         assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
                 set(store.items()))
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_pickle(self):
 
@@ -182,6 +206,9 @@ class StoreTests(object):
         assert b'bar' == store2['foo']
         assert b'quux' == store2['baz']
 
+        if hasattr(store2, 'close'):
+            store2.close()
+
     def test_getsize(self):
         store = self.create_store()
         if isinstance(store, dict) or hasattr(store, 'getsize'):
@@ -201,6 +228,9 @@ class StoreTests(object):
             store['spong'] = np.frombuffer(b'zzzzz', dtype='u1')
             assert 15 == getsize(store)
             assert 5 == getsize(store, 'spong')
+
+        if hasattr(store, 'close'):
+            store.close()
 
     # noinspection PyStatementEffect
     def test_hierarchy(self):
@@ -336,6 +366,9 @@ class StoreTests(object):
             assert 'c/d' in store
             assert 'c/e/f' in store
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_init_array(self):
         store = self.create_store()
         init_array(store, shape=1000, chunks=100)
@@ -349,6 +382,9 @@ class StoreTests(object):
         assert np.dtype(None) == meta['dtype']
         assert default_compressor.get_config() == meta['compressor']
         assert meta['fill_value'] is None
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_init_array_overwrite(self):
         self._test_init_array_overwrite('F')
@@ -399,6 +435,9 @@ class StoreTests(object):
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_init_array_path(self):
         path = 'foo/bar'
         store = self.create_store()
@@ -414,6 +453,9 @@ class StoreTests(object):
         assert np.dtype(None) == meta['dtype']
         assert default_compressor.get_config() == meta['compressor']
         assert meta['fill_value'] is None
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def _test_init_array_overwrite_path(self, order):
         # setup
@@ -450,6 +492,9 @@ class StoreTests(object):
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def test_init_array_overwrite_group(self):
         # setup
         path = 'foo/bar'
@@ -474,6 +519,9 @@ class StoreTests(object):
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def _test_init_array_overwrite_chunk_store(self, order):
         # setup
@@ -511,11 +559,19 @@ class StoreTests(object):
             assert '0' not in chunk_store
             assert '1' not in chunk_store
 
+        if hasattr(store, 'close'):
+            store.close()
+        if hasattr(chunk_store, 'close'):
+            chunk_store.close()
+
     def test_init_array_compat(self):
         store = self.create_store()
         init_array(store, shape=1000, chunks=100, compressor='none')
         meta = decode_array_metadata(store[array_meta_key])
         assert meta['compressor'] is None
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def test_init_group(self):
         store = self.create_store()
@@ -525,6 +581,9 @@ class StoreTests(object):
         assert group_meta_key in store
         meta = decode_group_metadata(store[group_meta_key])
         assert ZARR_FORMAT == meta['zarr_format']
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def _test_init_group_overwrite(self, order):
         # setup
@@ -558,6 +617,9 @@ class StoreTests(object):
         with pytest.raises(ValueError):
             init_group(store)
 
+        if hasattr(store, 'close'):
+            store.close()
+
     def _test_init_group_overwrite_path(self, order):
         # setup
         path = 'foo/bar'
@@ -589,6 +651,9 @@ class StoreTests(object):
             # should have been overwritten
             meta = decode_group_metadata(store[path + '/' + group_meta_key])
             assert ZARR_FORMAT == meta['zarr_format']
+
+        if hasattr(store, 'close'):
+            store.close()
 
     def _test_init_group_overwrite_chunk_store(self, order):
         # setup
@@ -626,6 +691,11 @@ class StoreTests(object):
         # don't overwrite group
         with pytest.raises(ValueError):
             init_group(store)
+
+        if hasattr(store, 'close'):
+            store.close()
+        if hasattr(chunk_store, 'close'):
+            chunk_store.close()
 
 
 class TestMappingStore(StoreTests, unittest.TestCase):


### PR DESCRIPTION
This is especially troublesome on 32-bit systems with LMDB, as opening
an LMDB store maps 2\**28 blocks, and letting the gc clean them up can
cause excess memory pressure. Eventually, this results in LMDB tests
failing to open a store because it can't find a 2**28 block to mmap.

* [x] Add unit tests and/or doctests in docstrings
* [N/A] Add docstrings and API docs for any new/modified user-facing classes and functions
* [N/A] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [N/A] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
