### PR TITLE
Set file permissions in DirectoryStorage according to umask

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -721,6 +721,13 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
         store['foo'] = b'bar'
         assert os.path.isdir(path)
 
+        # check correct permissions
+        stat = os.stat(path)
+        mode = stat.st_mode & 0o666
+        umask = os.umask(0)
+        os.umask(umask)
+        assert mode == (0o666 & ~umask)
+
         # test behaviour with file path
         with tempfile.NamedTemporaryFile() as f:
             with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #325

This is my take on having DirectoryStorage play nice with the local defined umask.
