### PR TITLE
optmizaton for LRUStoreCache.__contains__

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1772,7 +1772,7 @@ class LRUStoreCache(MutableMapping):
                 # the below 2 if statements are not done together
                 # as an 'and' because we can possibly avoid one expensive
                 # __contains__ call to the underlying store
-                if not key in self._contains_cache:
+                if key not in self._contains_cache:
                     if key in self._store:
                         self._contains_cache.add(key)
             else:

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1337,13 +1337,13 @@ class TestLRUStoreCache(StoreTests, unittest.TestCase):
         assert 0 == store.counter['__iter__']
         cache.invalidate_keys()
         assert 'foo' in cache
-        assert 5 == store.counter['keys']
-        assert 0 == store.counter['__contains__', 'foo']
+        assert 4 == store.counter['keys']
+        assert 1 == store.counter['__contains__', 'foo']
         assert 0 == store.counter['__iter__']
 
         # check these would get counted if called directly
         assert 'foo' in store
-        assert 1 == store.counter['__contains__', 'foo']
+        assert 2 == store.counter['__contains__', 'foo']
         assert keys == sorted(store)
         assert 1 == store.counter['__iter__']
 


### PR DESCRIPTION
Closes https://github.com/zarr-developers/zarr/issues/295.

As mentioned in https://github.com/zarr-developers/zarr/issues/295, `LRUStoreCache.__contains__` made a call to `self._keys`, which can take long, if for example we have an array with terabytes of data and millions of keys stored on cloud, the call to `self._keys` will first list all those keys and cache them. This PR removes the `self._keys` call from `__contains__`. The call to `self._store.keys()` still exists in the `self.keys` method and keys will still be cached, but just not when the `__contains__` method is called.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
