### PR TITLE
Drop `decode` from `ConsolidatedMetadataStore`

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2451,11 +2451,7 @@ class ConsolidatedMetadataStore(MutableMapping):
         self.store = store
 
         # retrieve consolidated metadata
-        if sys.version_info.major == 3 and sys.version_info.minor < 6:
-            d = store[metadata_key].decode()  # pragma: no cover
-        else:  # pragma: no cover
-            d = store[metadata_key]
-        meta = json_loads(d)
+        meta = json_loads(store[metadata_key])
 
         # check format of consolidated metadata
         consolidated_format = meta.get('zarr_consolidated_format', None)


### PR DESCRIPTION
Fixes the issue described in [this SO question]( https://stackoverflow.com/q/56904331/3877089 ).

This call to `decode` has been made unnecessary thanks to the `json_loads` utility function used here. Unfortunately this code was left over when that was added in. Drop this now unneeded code so as to better handle `bytes`-like data.

cc @martindurant

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)