### PR TITLE
Fix URLs to point to zarr-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,11 @@ more information.
 .. image:: https://readthedocs.org/projects/zarr/badge/?version=latest
     :target: http://zarr.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://travis-ci.org/zarr-developers/zarr.svg?branch=master
-    :target: https://travis-ci.org/zarr-developers/zarr
+.. image:: https://travis-ci.org/zarr-developers/zarr-python.svg?branch=master
+    :target: https://travis-ci.org/zarr-developers/zarr-python
 
 .. image:: https://ci.appveyor.com/api/projects/status/7d4iko59k8hpbbik?svg=true
-    :target: https://ci.appveyor.com/project/zarr-developers/zarr
+    :target: https://ci.appveyor.com/project/zarr-developers/zarr-python
 
-.. image:: https://coveralls.io/repos/github/zarr-developers/zarr/badge.svg?branch=master
-    :target: https://coveralls.io/github/zarr-developers/zarr?branch=master
+.. image:: https://coveralls.io/repos/github/zarr-developers/zarr-python/badge.svg?branch=master
+    :target: https://coveralls.io/github/zarr-developers/zarr-python?branch=master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ extensions = [
 
 numpydoc_show_class_members = False
 numpydoc_class_members_toctree = False
-issues_github_path = 'zarr-developers/zarr'
+issues_github_path = 'zarr-developers/zarr-python'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,7 +11,7 @@ Asking for help
 If you have a question about how to use Zarr, please post your question on
 StackOverflow using the `"zarr" tag <https://stackoverflow.com/questions/tagged/zarr>`_.
 If you don't get a response within a day or two, feel free to raise a `GitHub issue
-<https://github.com/zarr-developers/zarr/issues/new>`_ including a link to your StackOverflow
+<https://github.com/zarr-developers/zarr-python/issues/new>`_ including a link to your StackOverflow
 question. We will try to respond to questions as quickly as possible, but please bear
 in mind that there may be periods where we have limited time to answer questions
 due to other commitments.
@@ -20,7 +20,7 @@ Bug reports
 -----------
 
 If you find a bug, please raise a `GitHub issue
-<https://github.com/zarr-developers/zarr/issues/new>`_. Please include the following items in
+<https://github.com/zarr-developers/zarr-python/issues/new>`_. Please include the following items in
 a bug report:
 
 1. A minimal, self-contained snippet of Python code reproducing the problem. You can
@@ -53,7 +53,7 @@ Enhancement proposals
 ---------------------
 
 If you have an idea about a new feature or some other improvement to Zarr, please raise a
-`GitHub issue <https://github.com/zarr-developers/zarr/issues/new>`_ first to discuss.
+`GitHub issue <https://github.com/zarr-developers/zarr-python/issues/new>`_ first to discuss.
 
 We very much welcome ideas and suggestions for how to improve Zarr, but please bear in
 mind that we are likely to be conservative in accepting proposals for new features. The
@@ -70,14 +70,14 @@ Forking the repository
 
 The Zarr source code is hosted on GitHub at the following location:
 
-* `https://github.com/zarr-developers/zarr <https://github.com/zarr-developers/zarr>`_
+* `https://github.com/zarr-developers/zarr-python <https://github.com/zarr-developers/zarr-python>`_
 
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
     $ git clone git@github.com:your-user-name/zarr.git
     $ cd zarr
-    $ git remote add upstream git@github.com:zarr-developers/zarr.git
+    $ git remote add upstream git@github.com:zarr-developers/zarr-python.git
 
 Creating a development environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Status
 ------
 
 Zarr is still a young project. Feedback and bug reports are very welcome, please get in touch via
-the `GitHub issue tracker <https://github.com/zarr-developers/zarr/issues>`_. See
+the `GitHub issue tracker <https://github.com/zarr-developers/zarr-python/issues>`_. See
 :doc:`contributing` for further information about contributing to Zarr.
 
 Installation
@@ -44,11 +44,11 @@ Alternatively, install Zarr via conda::
 To install the latest development version of Zarr, you can use pip with the 
 latest GitHub master::
 
-    $ pip install git+https://github.com/zarr-developers/zarr.git
+    $ pip install git+https://github.com/zarr-developers/zarr-python.git
 
 To work with Zarr source code in development, install from GitHub::
 
-    $ git clone --recursive https://github.com/zarr-developers/zarr.git
+    $ git clone --recursive https://github.com/zarr-developers/zarr-python.git
     $ cd zarr
     $ python setup.py install
 
@@ -73,7 +73,7 @@ Projects using Zarr
 -------------------
 
 If you are using Zarr, we would `love to hear about it
-<https://github.com/zarr-developers/zarr/issues/228>`_.
+<https://github.com/zarr-developers/zarr-python/issues/228>`_.
 
 Acknowledgments
 ---------------

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -161,7 +161,7 @@ Enhancements
   properties that enable a selection of items in an array to be retrieved or
   updated. See the :ref:`tutorial_indexing` tutorial section for more
   information. There is also a `notebook
-  <https://github.com/zarr-developers/zarr/blob/master/notebooks/advanced_indexing.ipynb>`_
+  <https://github.com/zarr-developers/zarr-python/blob/master/notebooks/advanced_indexing.ipynb>`_
   with extended examples and performance benchmarks. :issue:`78`, :issue:`89`,
   :issue:`112`, :issue:`172`.
 
@@ -574,7 +574,7 @@ Thanks to :user:`Matthew Rocklin <mrocklin>`, :user:`Stephan Hoyer <shoyer>`,
 -----
 
 See `v0.4.0 release notes on GitHub
-<https://github.com/zarr-developers/zarr/releases/tag/v0.4.0>`_.
+<https://github.com/zarr-developers/zarr-python/releases/tag/v0.4.0>`_.
 
 .. _release_0.3.0:
 
@@ -582,6 +582,6 @@ See `v0.4.0 release notes on GitHub
 -----
 
 See `v0.3.0 release notes on GitHub
-<https://github.com/zarr-developers/zarr/releases/tag/v0.3.0>`_.
+<https://github.com/zarr-developers/zarr-python/releases/tag/v0.3.0>`_.
 
 .. _NumCodecs: http://numcodecs.readthedocs.io/

--- a/docs/talks/scipy2019/submission.rst
+++ b/docs/talks/scipy2019/submission.rst
@@ -93,7 +93,7 @@ References
 ~~~~~~~~~~
 
 .. _1: https://zarr.readthedocs.io/en/stable/spec/v2.html
-.. _2: https://github.com/zarr-developers/zarr
+.. _2: https://github.com/zarr-developers/zarr-python
 .. _3: https://github.com/zarr-developers/numcodecs
 .. _4: https://www.hdfgroup.org/solutions/hdf5/
 .. _5: https://pangeo.io/

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -423,7 +423,7 @@ Groups also have the :func:`zarr.hierarchy.Group.tree` method, e.g.::
 
 If you're using Zarr within a Jupyter notebook, calling ``tree()`` will generate an
 interactive tree representation, see the `repr_tree.ipynb notebook
-<http://nbviewer.jupyter.org/github/zarr-developers/zarr/blob/master/notebooks/repr_tree.ipynb>`_
+<http://nbviewer.jupyter.org/github/zarr-developers/zarr-python/blob/master/notebooks/repr_tree.ipynb>`_
 for more examples.
 
 .. _tutorial_attrs:

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     ],
     maintainer='Alistair Miles',
     maintainer_email='alimanfoo@googlemail.com',
-    url='https://github.com/zarr-developers/zarr',
+    url='https://github.com/zarr-developers/zarr-python',
     license='MIT',
 )


### PR DESCRIPTION


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
