### PR TITLE
DOC: fix typo in code snippet

### DIFF
--- a/docs/api/codecs.rst
+++ b/docs/api/codecs.rst
@@ -10,7 +10,7 @@ class can be used as a compressor for a Zarr array::
 
     >>> import zarr
     >>> from numcodecs import Blosc
-    >>> z = zarr.zeros(1000000, compressor=Blosc(cname='zstd', clevel=1, shuffle=Blosc.SHUFFLE)
+    >>> z = zarr.zeros(1000000, compressor=Blosc(cname='zstd', clevel=1, shuffle=Blosc.SHUFFLE))
 
 Codec classes can also be used as filters. See the tutorial section on :ref:`tutorial_filters`
 for more information.


### PR DESCRIPTION
Add missing closing parenthesis in code snippet.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
