### PR TITLE
Add require_parent and check_exists as options 

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -359,7 +359,8 @@ def array(data, **kwargs):
 def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
                compressor='default', fill_value=0, order='C', synchronizer=None,
                filters=None, cache_metadata=True, cache_attrs=True, path=None,
-               object_codec=None, chunk_store=None, require_parent=True, check_exists=True, **kwargs):
+               object_codec=None, chunk_store=None, require_parent=True,
+               check_exists=True, **kwargs):
     """Open an array using file-mode-like semantics.
 
     Parameters

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -18,7 +18,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            fill_value=0, order='C', store=None, synchronizer=None,
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
-           object_codec=None, **kwargs):
+           object_codec=None, require_parent=True, check_exists=True, **kwargs):
     """Create an array.
 
     Parameters
@@ -65,6 +65,10 @@ def create(shape, chunks=True, dtype=None, compressor='default',
         True if array should be protected against modification.
     object_codec : Codec, optional
         A codec to encode object arrays, only needed if dtype=object.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     Returns
     -------
@@ -119,7 +123,8 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     # initialize array metadata
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
                fill_value=fill_value, order=order, overwrite=overwrite, path=path,
-               chunk_store=chunk_store, filters=filters, object_codec=object_codec)
+               chunk_store=chunk_store, filters=filters, object_codec=object_codec,
+               require_parent=require_parent, check_exists=check_exists)
 
     # instantiate array
     z = Array(store, path=path, chunk_store=chunk_store, synchronizer=synchronizer,
@@ -354,7 +359,7 @@ def array(data, **kwargs):
 def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
                compressor='default', fill_value=0, order='C', synchronizer=None,
                filters=None, cache_metadata=True, cache_attrs=True, path=None,
-               object_codec=None, chunk_store=None, **kwargs):
+               object_codec=None, chunk_store=None, require_parent=True, check_exists=True, **kwargs):
     """Open an array using file-mode-like semantics.
 
     Parameters
@@ -400,6 +405,10 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
         A codec to encode object arrays, only needed if dtype=object.
     chunk_store : MutableMapping or string, optional
         Store or path to directory in file system or name of zip file.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     Returns
     -------
@@ -460,7 +469,8 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
         init_array(store, shape=shape, chunks=chunks, dtype=dtype,
                    compressor=compressor, fill_value=fill_value,
                    order=order, filters=filters, overwrite=True, path=path,
-                   object_codec=object_codec, chunk_store=chunk_store)
+                   object_codec=object_codec, chunk_store=chunk_store,
+                   require_parent=require_parent, check_exists=check_exists)
 
     elif mode == 'a':
         if contains_group(store, path=path):

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -627,7 +627,7 @@ class Group(MutableMapping):
         with lock:
             return f(*args, **kwargs)
 
-    def create_group(self, name, overwrite=False):
+    def create_group(self, name, overwrite=False, require_parent=True, check_exists=True):
         """Create a sub-group.
 
         Parameters
@@ -636,6 +636,10 @@ class Group(MutableMapping):
             Group name.
         overwrite : bool, optional
             If True, overwrite any existing array with the given name.
+        require_parent : bool, optional
+            If False, no check is done to ensure that the parent group exists.
+        check_exists : bool, optional
+            If False, no check is done to see if the array or group already exists.
 
         Returns
         -------
@@ -651,14 +655,15 @@ class Group(MutableMapping):
 
         """
 
-        return self._write_op(self._create_group_nosync, name, overwrite=overwrite)
+        return self._write_op(self._create_group_nosync, name, overwrite=overwrite,
+                              require_parent=require_parent, check_exists=check_exists)
 
-    def _create_group_nosync(self, name, overwrite=False):
+    def _create_group_nosync(self, name, overwrite=False, require_parent=True, check_exists=True):
         path = self._item_path(name)
 
         # create terminal group
         init_group(self._store, path=path, chunk_store=self._chunk_store,
-                   overwrite=overwrite)
+                   overwrite=overwrite, require_parent=require_parent, check_exists=check_exists)
 
         return Group(self._store, path=path, read_only=self._read_only,
                      chunk_store=self._chunk_store, cache_attrs=self.attrs.cache,
@@ -747,6 +752,10 @@ class Group(MutableMapping):
             lifetime of the object. If False, array metadata will be reloaded
             prior to all data access and modification operations (may incur
             overhead depending on storage and data access pattern).
+        require_parent : bool, optional
+            If False, no check is done to ensure that the parent group exists.
+        check_exists : bool, optional
+            If False, no check is done to see if the array or group already exists.
 
         Returns
         -------
@@ -1000,7 +1009,8 @@ def _normalize_store_arg(store, clobber=False):
 
 
 def group(store=None, overwrite=False, chunk_store=None,
-          cache_attrs=True, synchronizer=None, path=None):
+          cache_attrs=True, synchronizer=None, path=None,
+          require_parent=True, check_exists=True):
     """Create a group.
 
     Parameters
@@ -1021,6 +1031,10 @@ def group(store=None, overwrite=False, chunk_store=None,
         Array synchronizer.
     path : string, optional
         Group path within store.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     Returns
     -------
@@ -1051,14 +1065,14 @@ def group(store=None, overwrite=False, chunk_store=None,
     # require group
     if overwrite or not contains_group(store):
         init_group(store, overwrite=overwrite, chunk_store=chunk_store,
-                   path=path)
+                   path=path, require_parent=require_parent, check_exists=check_exists)
 
     return Group(store, read_only=False, chunk_store=chunk_store,
                  cache_attrs=cache_attrs, synchronizer=synchronizer, path=path)
 
 
 def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=None,
-               chunk_store=None):
+               chunk_store=None, require_parent=True, check_exists=True):
     """Open a group using file-mode-like semantics.
 
     Parameters
@@ -1080,6 +1094,10 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
         Group path within store.
     chunk_store : MutableMapping or string, optional
         Store or path to directory in file system or name of zip file.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     Returns
     -------
@@ -1116,7 +1134,8 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
             err_group_not_found(path)
 
     elif mode == 'w':
-        init_group(store, overwrite=True, path=path, chunk_store=chunk_store)
+        init_group(store, overwrite=True, path=path, chunk_store=chunk_store,
+                   require_parent=require_parent, check_exists=check_exists)
 
     elif mode == 'a':
         if contains_array(store, path=path):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -206,7 +206,8 @@ def _require_parent_group(path, store, chunk_store, overwrite):
 
 def init_array(store, shape, chunks=True, dtype=None, compressor='default',
                fill_value=None, order='C', overwrite=False, path=None,
-               chunk_store=None, filters=None, object_codec=None, require_parent=True, check_exists=True):
+               chunk_store=None, filters=None, object_codec=None,
+               require_parent=True, check_exists=True):
     """Initialize an array store with the given configuration. Note that this is a low-level
     function and there should be no need to call this directly from user code.
 
@@ -408,7 +409,8 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
 init_store = init_array
 
 
-def init_group(store, overwrite=False, path=None, chunk_store=None, require_parent=True, check_exists=True):
+def init_group(store, overwrite=False, path=None, chunk_store=None, 
+               require_parent=True, check_exists=True):
     """Initialize a group store. Note that this is a low-level function and there should be no
     need to call this directly from user code.
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -409,7 +409,7 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
 init_store = init_array
 
 
-def init_group(store, overwrite=False, path=None, chunk_store=None, 
+def init_group(store, overwrite=False, path=None, chunk_store=None,
                require_parent=True, check_exists=True):
     """Initialize a group store. Note that this is a low-level function and there should be no
     need to call this directly from user code.

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -206,7 +206,7 @@ def _require_parent_group(path, store, chunk_store, overwrite):
 
 def init_array(store, shape, chunks=True, dtype=None, compressor='default',
                fill_value=None, order='C', overwrite=False, path=None,
-               chunk_store=None, filters=None, object_codec=None):
+               chunk_store=None, filters=None, object_codec=None, require_parent=True, check_exists=True):
     """Initialize an array store with the given configuration. Note that this is a low-level
     function and there should be no need to call this directly from user code.
 
@@ -238,6 +238,10 @@ def init_array(store, shape, chunks=True, dtype=None, compressor='default',
         Sequence of filters to use to encode chunk data prior to compression.
     object_codec : Codec, optional
         A codec to encode object arrays, only needed if dtype=object.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     Examples
     --------
@@ -314,18 +318,19 @@ def init_array(store, shape, chunks=True, dtype=None, compressor='default',
     path = normalize_storage_path(path)
 
     # ensure parent group initialized
-    _require_parent_group(path, store=store, chunk_store=chunk_store, overwrite=overwrite)
+    if require_parent:
+        _require_parent_group(path, store=store, chunk_store=chunk_store, overwrite=overwrite)
 
     _init_array_metadata(store, shape=shape, chunks=chunks, dtype=dtype,
                          compressor=compressor, fill_value=fill_value,
                          order=order, overwrite=overwrite, path=path,
                          chunk_store=chunk_store, filters=filters,
-                         object_codec=object_codec)
+                         object_codec=object_codec, check_exists=check_exists)
 
 
 def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='default',
                          fill_value=None, order='C', overwrite=False, path=None,
-                         chunk_store=None, filters=None, object_codec=None):
+                         chunk_store=None, filters=None, object_codec=None, check_exists=True):
 
     # guard conditions
     if overwrite:
@@ -333,10 +338,11 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
         rmdir(store, path)
         if chunk_store is not None:
             rmdir(chunk_store, path)
-    elif contains_array(store, path):
-        err_contains_array(path)
-    elif contains_group(store, path):
-        err_contains_group(path)
+    elif check_exists:
+        if contains_array(store, path):
+            err_contains_array(path)
+        elif contains_group(store, path):
+            err_contains_group(path)
 
     # normalize metadata
     dtype, object_codec = normalize_dtype(dtype, object_codec)
@@ -402,7 +408,7 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
 init_store = init_array
 
 
-def init_group(store, overwrite=False, path=None, chunk_store=None):
+def init_group(store, overwrite=False, path=None, chunk_store=None, require_parent=True, check_exists=True):
     """Initialize a group store. Note that this is a low-level function and there should be no
     need to call this directly from user code.
 
@@ -417,6 +423,10 @@ def init_group(store, overwrite=False, path=None, chunk_store=None):
     chunk_store : MutableMapping, optional
         Separate storage for chunks. If not provided, `store` will be used
         for storage of both chunks and metadata.
+    require_parent : bool, optional
+        If False, no check is done to ensure that the parent group exists.
+    check_exists : bool, optional
+        If False, no check is done to see if the array or group already exists.
 
     """
 
@@ -424,15 +434,16 @@ def init_group(store, overwrite=False, path=None, chunk_store=None):
     path = normalize_storage_path(path)
 
     # ensure parent group initialized
-    _require_parent_group(path, store=store, chunk_store=chunk_store,
-                          overwrite=overwrite)
+    if require_parent:
+        _require_parent_group(path, store=store, chunk_store=chunk_store,
+                              overwrite=overwrite)
 
     # initialise metadata
     _init_group_metadata(store=store, overwrite=overwrite, path=path,
-                         chunk_store=chunk_store)
+                         chunk_store=chunk_store, check_exists=check_exists)
 
 
-def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
+def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None, check_exists=True):
 
     # guard conditions
     if overwrite:
@@ -440,10 +451,11 @@ def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
         rmdir(store, path)
         if chunk_store is not None:
             rmdir(chunk_store, path)
-    elif contains_array(store, path):
-        err_contains_array(path)
-    elif contains_group(store, path):
-        err_contains_group(path)
+    elif check_exists:
+        if contains_array(store, path):
+            err_contains_array(path)
+        elif contains_group(store, path):
+            err_contains_group(path)
 
     # initialize metadata
     # N.B., currently no metadata properties are needed, however there may


### PR DESCRIPTION
Add require_parent and check_exists as options when creating an array

This option allows the user to skip the test that check whether the parent group of an array already exists and whether the array or group itself already exist. Based on Issue #460 #

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
