### PR TITLE
undo parameter renaming for compatibility with n5-blosc

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,9 @@ Upcoming Release
 * Upgrade dependencies in the test matrices and resolve a
   compatibility issue with testing against the Azure Storage
   Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
+  
+* Do not rename Blosc parameters in n5 backend and add `blocksize` parameter,
+  compatible with n5-blosc.
 
 .. _release_2.3.2:
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -416,11 +416,10 @@ def compressor_config_to_n5(compressor_config):
             RuntimeWarning
         )
 
-        n5_config['codec'] = compressor_config['cname']
-        n5_config['level'] = compressor_config['clevel']
+        n5_config['cname'] = compressor_config['cname']
+        n5_config['clevel'] = compressor_config['clevel']
         n5_config['shuffle'] = compressor_config['shuffle']
-        assert compressor_config['blocksize'] == 0, \
-            "blosc block size needs to be 0 for N5 containers."
+        n5_config['blocksize'] = compressor_config['blocksize']
 
     elif codec_id == 'lzma':
 
@@ -475,10 +474,10 @@ def compressor_config_to_zarr(compressor_config):
 
     elif codec_id == 'blosc':
 
-        zarr_config['cname'] = compressor_config['codec']
-        zarr_config['clevel'] = compressor_config['level']
+        zarr_config['cname'] = compressor_config['cname']
+        zarr_config['clevel'] = compressor_config['clevel']
         zarr_config['shuffle'] = compressor_config['shuffle']
-        zarr_config['blocksize'] = 0
+        zarr_config['blocksize'] = compressor_config['blocksize']
 
     elif codec_id == 'lzma':
 


### PR DESCRIPTION
n5-blosc expects the original blosc parameters including 'blocksize'

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
