### PR TITLE
Import blosc from numcodecs in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1416,7 +1416,7 @@ compression and decompression. By default, Blosc uses up to 8
 internal threads. The number of Blosc threads can be changed to increase or
 decrease this number, e.g.::
 
-    >>> from zarr import blosc
+    >>> from numcodecs import blosc
     >>> blosc.set_nthreads(2)  # doctest: +SKIP
     8
 


### PR DESCRIPTION
This PR updates the "Configuring Blosc" section of the tutorial to import `blosc` from `numcodecs` instead of `zarr`. Closes #292

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
