### PR TITLE
Use pytest.importorskip in tests

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,9 @@ Upcoming Release
 * Removed support for Python 2.
   By :user:`jhamman`; :issue:`393`, :issue:`470`.
 
+* Updates tests to use ``pytest.importorskip``.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`492`
+
 .. _release_2.3.2:
 
 2.3.2

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -654,6 +654,7 @@ except ImportError:  # pragma: no cover
 
 
 def temp_h5f():
+    h5py = pytest.importorskip("h5py")
     fn = tempfile.mktemp()
     atexit.register(os.remove, fn)
     h5f = h5py.File(fn, mode='w')
@@ -661,7 +662,6 @@ def temp_h5f():
     return h5f
 
 
-@unittest.skipIf(h5py is None, 'h5py is not installed')
 class TestCopyHDF5ToZarr(TestCopy):
 
     def __init__(self, *args, **kwargs):
@@ -672,7 +672,6 @@ class TestCopyHDF5ToZarr(TestCopy):
         self.new_dest = group
 
 
-@unittest.skipIf(h5py is None, 'h5py is not installed')
 class TestCopyZarrToHDF5(TestCopy):
 
     def __init__(self, *args, **kwargs):
@@ -683,7 +682,6 @@ class TestCopyZarrToHDF5(TestCopy):
         self.new_dest = temp_h5f
 
 
-@unittest.skipIf(h5py is None, 'h5py is not installed')
 class TestCopyHDF5ToHDF5(TestCopy):
 
     def __init__(self, *args, **kwargs):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -23,16 +23,7 @@ from zarr.storage import (ABSStore, DBMStore, DirectoryStore, LMDBStore,
                           LRUStoreCache, NestedDirectoryStore, SQLiteStore,
                           atexit_rmglob, atexit_rmtree, init_array, init_group)
 from zarr.util import buffer_size
-
-try:
-    import azure.storage.blob as asb
-except ImportError:  # pragma: no cover
-    asb = None
-
-
-# also check for environment variables indicating whether tests requiring
-# services should be run
-ZARR_TEST_ABS = os.environ.get('ZARR_TEST_ABS', '0')
+from zarr.tests.util import skip_test_env_var
 
 
 # noinspection PyMethodMayBeStatic
@@ -1404,13 +1395,12 @@ class TestArrayWithDirectoryStore(TestArray):
         assert expect_nbytes_stored == z.nbytes_stored
 
 
-@pytest.mark.skipif(asb is None or ZARR_TEST_ABS == '0',
-                    reason="azure-blob-storage could not be imported or tests not"
-                           "enabled via environment variable")
+@skip_test_env_var("ZARR_TEST_ABS")
 class TestArrayWithABSStore(TestArray):
 
     @staticmethod
     def absstore():
+        asb = pytest.importorskip("azure.storage.blob")
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
@@ -1737,17 +1727,11 @@ class TestArrayWithDBMStore(TestArray):
         pass  # not implemented
 
 
-try:
-    import bsddb3
-except ImportError:  # pragma: no cover
-    bsddb3 = None
-
-
-@unittest.skipIf(bsddb3 is None, 'bsddb3 is not installed')
 class TestArrayWithDBMStoreBerkeleyDB(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
+        bsddb3 = pytest.importorskip("bsddb3")
         path = mktemp(suffix='.dbm')
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n', open=bsddb3.btopen)
@@ -1762,17 +1746,11 @@ class TestArrayWithDBMStoreBerkeleyDB(TestArray):
         pass  # not implemented
 
 
-try:
-    import lmdb
-except ImportError:  # pragma: no cover
-    lmdb = None
-
-
-@unittest.skipIf(lmdb is None, 'lmdb is not installed')
 class TestArrayWithLMDBStore(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
+        pytest.importorskip("lmdb")
         path = mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
         store = LMDBStore(path, buffers=True)
@@ -1790,11 +1768,11 @@ class TestArrayWithLMDBStore(TestArray):
         pass  # not implemented
 
 
-@unittest.skipIf(lmdb is None, 'lmdb is not installed')
 class TestArrayWithLMDBStoreNoBuffers(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
+        pytest.importorskip("lmdb")
         path = mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
         store = LMDBStore(path, buffers=False)
@@ -1809,17 +1787,11 @@ class TestArrayWithLMDBStoreNoBuffers(TestArray):
         pass  # not implemented
 
 
-try:
-    import sqlite3
-except ImportError:  # pragma: no cover
-    sqlite3 = None
-
-
-@unittest.skipIf(sqlite3 is None, 'python built without sqlite')
 class TestArrayWithSQLiteStore(TestArray):
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
+        pytest.importorskip("sqlite3")
         path = mktemp(suffix='.db')
         atexit.register(atexit_rmtree, path)
         store = SQLiteStore(path)

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -22,16 +22,7 @@ from zarr.storage import (ABSStore, DBMStore, DirectoryStore, LMDBStore,
                           atexit_rmtree, group_meta_key, init_array,
                           init_group)
 from zarr.util import InfoReporter
-
-try:
-    import azure.storage.blob as asb
-except ImportError:  # pragma: no cover
-    asb = None
-
-
-# also check for environment variables indicating whether tests requiring
-# services should be run
-ZARR_TEST_ABS = os.environ.get('ZARR_TEST_ABS', '0')
+from zarr.tests.util import skip_test_env_var
 
 
 # noinspection PyStatementEffect
@@ -887,13 +878,12 @@ class TestGroupWithDirectoryStore(TestGroup):
         return store, None
 
 
-@pytest.mark.skipif(asb is None or ZARR_TEST_ABS == '0',
-                    reason="azure-blob-storage could not be imported or tests not enabled"
-                           "via environment variable")
+@skip_test_env_var("ZARR_TEST_ABS")
 class TestGroupWithABSStore(TestGroup):
 
     @staticmethod
     def create_store():
+        asb = pytest.importorskip("azure.storage.blob")
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
@@ -933,50 +923,32 @@ class TestGroupWithDBMStore(TestGroup):
         return store, None
 
 
-try:
-    import bsddb3
-except ImportError:  # pragma: no cover
-    bsddb3 = None
-
-
-@unittest.skipIf(bsddb3 is None, 'bsddb3 is not installed')
 class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
 
     @staticmethod
     def create_store():
+        bsddb3 = pytest.importorskip("bsddb3")
         path = tempfile.mktemp(suffix='.dbm')
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n', open=bsddb3.btopen)
         return store, None
 
 
-try:
-    import lmdb
-except ImportError:  # pragma: no cover
-    lmdb = None
-
-
-@unittest.skipIf(lmdb is None, 'lmdb is not installed')
 class TestGroupWithLMDBStore(TestGroup):
 
     @staticmethod
     def create_store():
+        pytest.importorskip("lmdb")
         path = tempfile.mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
         store = LMDBStore(path)
         return store, None
 
 
-try:
-    import sqlite3
-except ImportError:  # pragma: no cover
-    sqlite3 = None
-
-
-@unittest.skipIf(sqlite3 is None, 'python built without sqlite')
 class TestGroupWithSQLiteStore(TestGroup):
 
     def create_store(self):
+        pytest.importorskip("sqlite3")
         path = tempfile.mktemp(suffix='.db')
         atexit.register(atexit_rmtree, path)
         store = SQLiteStore(path)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -28,40 +28,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
-from zarr.tests.util import CountingDict
-
-try:
-    import sqlite3
-except ImportError:  # pragma: no cover
-    sqlite3 = None
-
-try:
-    import azure.storage.blob as asb
-except ImportError:  # pragma: no cover
-    asb = None
-
-try:
-    import pymongo
-except ImportError:  # pragma: no cover
-    pymongo = None
-
-try:
-    import redis
-except ImportError:  # pragma: no cover
-    redis = None
-
-
-try:
-    from zarr.codecs import LZMA
-except ImportError:  # pragma: no cover
-    LZMA = None
-
-
-# also check for environment variables indicating whether tests requiring
-# services should be run
-ZARR_TEST_ABS = os.environ.get('ZARR_TEST_ABS', '0')
-ZARR_TEST_MONGO = os.environ.get('ZARR_TEST_MONGO', '0')
-ZARR_TEST_REDIS = os.environ.get('ZARR_TEST_REDIS', '0')
+from zarr.tests.util import CountingDict, skip_test_env_var
 
 
 @contextmanager
@@ -994,64 +961,40 @@ class TestDBMStoreDumb(TestDBMStore):
         return store
 
 
-try:
-    import dbm.gnu as gdbm
-except ImportError:  # pragma: no cover
-    gdbm = None
-
-
-@unittest.skipIf(gdbm is None, reason='gdbm is not installed')
 class TestDBMStoreGnu(TestDBMStore):
 
     def create_store(self):
+        gdbm = pytest.importorskip("dbm.gnu")
         path = tempfile.mktemp(suffix='.gdbm')
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n', open=gdbm.open, write_lock=False)
         return store
 
 
-try:
-    import dbm.ndbm as ndbm
-except ImportError:  # pragma: no cover
-    ndbm = None
-
-
-@unittest.skipIf(ndbm is None, reason='ndbm is not installed')
 class TestDBMStoreNDBM(TestDBMStore):
 
     def create_store(self):
+        ndbm = pytest.importorskip("dbm.ndbm")
         path = tempfile.mktemp(suffix='.ndbm')
         atexit.register(atexit_rmglob, path + '*')
         store = DBMStore(path, flag='n', open=ndbm.open)
         return store
 
 
-try:
-    import bsddb3
-except ImportError:  # pragma: no cover
-    bsddb3 = None
-
-
-@unittest.skipIf(bsddb3 is None, reason='bsddb3 is not installed')
 class TestDBMStoreBerkeleyDB(TestDBMStore):
 
     def create_store(self):
+        bsddb3 = pytest.importorskip("bsddb3")
         path = tempfile.mktemp(suffix='.dbm')
         atexit.register(os.remove, path)
         store = DBMStore(path, flag='n', open=bsddb3.btopen, write_lock=False)
         return store
 
 
-try:
-    import lmdb
-except ImportError:  # pragma: no cover
-    lmdb = None
-
-
-@unittest.skipIf(lmdb is None, reason='lmdb is not installed')
 class TestLMDBStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
+        pytest.importorskip("lmdb")
         path = tempfile.mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
         buffers = True
@@ -1065,20 +1008,20 @@ class TestLMDBStore(StoreTests, unittest.TestCase):
             assert 2 == len(store)
 
 
-@unittest.skipIf(sqlite3 is None, reason='python built without sqlite')
 class TestSQLiteStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
+        pytest.importorskip("sqlite3")
         path = tempfile.mktemp(suffix='.db')
         atexit.register(atexit_rmtree, path)
         store = SQLiteStore(path)
         return store
 
 
-@unittest.skipIf(sqlite3 is None, reason='python built without sqlite')
 class TestSQLiteStoreInMemory(TestSQLiteStore, unittest.TestCase):
 
     def create_store(self):
+        pytest.importorskip("sqlite3")
         store = SQLiteStore(':memory:')
         return store
 
@@ -1094,12 +1037,11 @@ class TestSQLiteStoreInMemory(TestSQLiteStore, unittest.TestCase):
             pickle.dumps(store)
 
 
-@unittest.skipIf(pymongo is None or ZARR_TEST_MONGO == '0',
-                 reason='pymongo client library not installed or tests not enabled'
-                        'via environment variable')
+@skip_test_env_var("ZARR_TEST_MONGO")
 class TestMongoDBStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
+        pytest.importorskip("pymongo")
         store = MongoDBStore(host='127.0.0.1', database='zarr_tests',
                              collection='zarr_tests')
         # start with an empty store
@@ -1107,14 +1049,13 @@ class TestMongoDBStore(StoreTests, unittest.TestCase):
         return store
 
 
-@unittest.skipIf(redis is None or ZARR_TEST_REDIS == '0',
-                 reason='redis client library not installed or tests not enabled'
-                        'via environment variable')
+@skip_test_env_var("ZARR_TEST_REDIS")
 class TestRedisStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
         # TODO: this is the default host for Redis on Travis,
         # we probably want to generalize this though
+        pytest.importorskip("redis")
         store = RedisStore(host='localhost', port=6379)
         # start with an empty store
         store.clear()
@@ -1515,12 +1456,11 @@ def test_format_compatibility():
                 assert compressor.get_config() == z.compressor.get_config()
 
 
-@pytest.mark.skipif(asb is None or ZARR_TEST_ABS == '0',
-                    reason='azure blob storage client library not available or tests '
-                           'not enabled via environment variable')
+@skip_test_env_var("ZARR_TEST_ABS")
 class TestABSStore(StoreTests, unittest.TestCase):
 
     def create_store(self):
+        asb = pytest.importorskip("azure.storage.blob")
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import collections
 from collections.abc import MutableMapping
+import os
+
+import pytest
 
 
 class CountingDict(MutableMapping):
@@ -36,3 +39,10 @@ class CountingDict(MutableMapping):
     def __delitem__(self, key):
         self.counter['__delitem__', key] += 1
         del self.wrapped[key]
+
+
+def skip_test_env_var(name):
+    """ Checks for environment variables indicating whether tests requiring services should be run
+    """
+    value = os.environ.get(name, '0')
+    return pytest.mark.skipif(value == '0', reason='Tests not enabled via environment variable')


### PR DESCRIPTION
This PR replaces (almost all) occurrences of `try`/`except` blocks to determine if a library is available with [`pytest.importorskip`](http://doc.pytest.org/en/latest/skipping.html#skipping-on-a-missing-import-dependency). I wasn't able to replace this `LZMA` import

https://github.com/zarr-developers/zarr-python/blob/55ae9eb95d2c7c59582fed02f1dba88298f10fda/zarr/tests/test_core.py#L1944-L1947

because it's used in other conditional statements in `test_core.py`. 

Also added a `skip_test_env_var` utility function to `zarr/tests/util.py` to replace some of the boilerplate code related to skipping tests based on environment variables (e.g. `ZARR_TEST_ABS`)

Closes #229 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
