### PR TITLE
WIP: Use NumPy's `fromfile` and `tofile`

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -34,6 +34,8 @@ from pickle import PicklingError
 from threading import Lock, RLock
 import uuid
 
+import numpy
+
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from numcodecs.registry import codec_registry
 
@@ -741,7 +743,7 @@ class DirectoryStore(MutableMapping):
         filepath = os.path.join(self.path, key)
         if os.path.isfile(filepath):
             with open(filepath, 'rb') as f:
-                return f.read()
+                return numpy.fromfile(f, dtype='u1')
         else:
             raise KeyError(key)
 
@@ -774,7 +776,7 @@ class DirectoryStore(MutableMapping):
         temp_path = os.path.join(dir_path, temp_name)
         try:
             with open(temp_path, mode='wb') as f:
-                f.write(value)
+                value.tofile(f)
 
             # move temporary file into place
             replace(temp_path, file_path)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -742,8 +742,7 @@ class DirectoryStore(MutableMapping):
     def __getitem__(self, key):
         filepath = os.path.join(self.path, key)
         if os.path.isfile(filepath):
-            with open(filepath, 'rb') as f:
-                return numpy.fromfile(f, dtype='u1')
+            return numpy.fromfile(filepath, dtype='u1')
         else:
             raise KeyError(key)
 
@@ -775,8 +774,7 @@ class DirectoryStore(MutableMapping):
         temp_name = file_name + '.' + uuid.uuid4().hex + '.partial'
         temp_path = os.path.join(dir_path, temp_name)
         try:
-            with open(temp_path, mode='wb') as f:
-                value.tofile(f)
+            value.tofile(temp_path)
 
             # move temporary file into place
             replace(temp_path, file_path)


### PR DESCRIPTION
For reading and writing data on disk, start using NumPy's `fromfile` and `tofile`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
