### PR TITLE
Also include required `nthreads` in compression metadata

### DIFF
--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 from numcodecs.abc import Codec
+from numcodecs.blosc import get_nthreads
 from numcodecs.compat import ndarray_copy
 from numcodecs.registry import get_codec, register_codec
 
@@ -418,6 +419,7 @@ def compressor_config_to_n5(compressor_config):
         n5_config['clevel'] = compressor_config['clevel']
         n5_config['shuffle'] = compressor_config['shuffle']
         n5_config['blocksize'] = compressor_config['blocksize']
+        n5_config['nthreads'] = get_nthreads()
 
     elif codec_id == 'lzma':
 


### PR DESCRIPTION
Feed on from #485. The N5 reference library blosc compression adapter `saalfeldlab/n5-blosc` expects `nthreads` to be present in the metadata:

 * https://github.com/saalfeldlab/n5-blosc/blob/master/src/main/java/org/janelia/saalfeldlab/n5/blosc/BloscCompression.java#L68

Without `nthreads` reading a blosc compressed N5 dataset, which is the default if you do not specify a specific compression strategy, using the N5 reference library causes exceptions to be thrown of the form:

```
java.lang.IllegalArgumentException: Can not set int field org.janelia.saalfeldlab.n5.blosc.BloscCompression.nthreads to null value
        at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167)
        at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171)
        at sun.reflect.UnsafeIntegerFieldAccessorImpl.set(UnsafeIntegerFieldAccessorImpl.java:80)
        at java.lang.reflect.Field.set(Field.java:764)
        at org.janelia.saalfeldlab.n5.CompressionAdapter.deserialize(CompressionAdapter.java:160)
        at org.janelia.saalfeldlab.n5.CompressionAdapter.deserialize(CompressionAdapter.java:57)
        at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
        at com.google.gson.Gson.fromJson(Gson.java:927)
        at com.google.gson.Gson.fromJson(Gson.java:994)
        at com.google.gson.Gson.fromJson(Gson.java:967)
        at org.janelia.saalfeldlab.n5.GsonAttributesParser.parseAttribute(GsonAttributesParser.java:78)
        at org.janelia.saalfeldlab.n5.AbstractGsonReader.getDatasetAttributes(AbstractGsonReader.java:95)
...
```

This change does feel a little hacky but I'm throwing it out there for discussion. I'm not 100% on why N5 expects the `nthreads` value in the first place as this seems to be a consumer concern rather than a file format one. It is not present in the equivalent Zarr metadata.

There also seems to be a bit of a disconnect between the default blosc threading configuration here in Zarr vs. N5 but this is probably not the place for that discussion.

/cc @axtimwalde, @joshmoore 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
