### PR TITLE
Use `ensure_text` from Numcodecs

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -27,6 +27,9 @@ Upcoming Release
 * Update ``DirectoryStore`` to create files with more permissive permissions.
   By :user:`Eduardo Gonzalez <eddienko>` and :user:`James Bourbeau <jrbourbeau>`; :issue:`493`
 
+* Bump Numcodecs requirement to 0.6.4 use text handling functionality from it.
+  By :user:`John Kirkham <jakirkham>`; :issue:`497`.
+
 .. _release_2.3.2:
 
 2.3.2

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -270,8 +270,8 @@ Here is an example using a delta filter with the Blosc compressor::
     Compressor         : Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0)
     Store type         : builtins.dict
     No. bytes          : 400000000 (381.5M)
-    No. bytes stored   : 648605 (633.4K)
-    Storage ratio      : 616.7
+    No. bytes stored   : 1290562 (1.2M)
+    Storage ratio      : 309.9
     Chunks initialized : 100/100
 
 For more information about available filter codecs, see the `Numcodecs

--- a/requirements_dev_minimal.txt
+++ b/requirements_dev_minimal.txt
@@ -1,7 +1,7 @@
 # library requirements
 asciitree==0.3.3
 fasteners==0.15
-numcodecs==0.6.3
+numcodecs==0.6.4
 msgpack-python==0.5.6
 setuptools-scm==3.3.3
 # test requirements

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ dependencies = [
     'asciitree',
     'numpy>=1.7',
     'fasteners',
-    'numcodecs>=0.6.2',
+    'numcodecs>=0.6.4',
 ]
 
 setup(

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -9,7 +9,7 @@ from textwrap import TextWrapper, dedent
 import numpy as np
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
-from numcodecs.compat import ensure_contiguous_ndarray, ensure_ndarray
+from numcodecs.compat import ensure_contiguous_ndarray, ensure_ndarray, ensure_text
 from numcodecs.registry import codec_registry
 
 # codecs to use for object dtype convenience API
@@ -35,7 +35,7 @@ def json_dumps(o):
 
 def json_loads(s):
     """Read JSON in a consistent way."""
-    return json.loads(ensure_str(s))
+    return json.loads(ensure_text(s, 'ascii'))
 
 
 def normalize_shape(shape):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import codecs
 import inspect
 import json
 import numbers
@@ -9,7 +8,7 @@ from textwrap import TextWrapper, dedent
 import numpy as np
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
-from numcodecs.compat import ensure_contiguous_ndarray, ensure_ndarray, ensure_text
+from numcodecs.compat import ensure_ndarray, ensure_text
 from numcodecs.registry import codec_registry
 
 # codecs to use for object dtype convenience API

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -20,13 +20,6 @@ object_codecs = {
 }
 
 
-def ensure_str(s):
-    if not isinstance(s, str):
-        s = ensure_contiguous_ndarray(s)
-        s = codecs.decode(s, 'ascii')
-    return s
-
-
 def json_dumps(o):
     """Write JSON in a consistent, human-readable way."""
     return json.dumps(o, indent=4, sort_keys=True, ensure_ascii=True,


### PR DESCRIPTION
As Numcodecs is able to convert `bytes`-like data to text, use its functionality in Zarr and drop equivalent functions in Zarr.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
