### PR TITLE
Use `math.ceil` for scalars

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -30,6 +30,9 @@ Upcoming Release
 * Require Numcodecs 0.6.4+ to use text handling functionality from it.
   By :user:`John Kirkham <jakirkham>`; :issue:`497`.
 
+* Use ``math.ceil`` for scalars.
+  By :user:`John Kirkham <jakirkham>`; :issue:`500`.
+
 .. _release_2.3.2:
 
 2.3.2

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -356,7 +356,7 @@ class Array(object):
         if self._shape == ():
             return 1,
         else:
-            return tuple(int(math.ceil(s / c))
+            return tuple(math.ceil(s / c)
                          for s, c in zip(self._shape, self._chunks))
 
     @property

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2008,7 +2008,7 @@ class Array(object):
 
         # determine the new number and arrangement of chunks
         chunks = self._chunks
-        new_cdata_shape = tuple(int(math.ceil(s / c))
+        new_cdata_shape = tuple(math.ceil(s / c)
                                 for s, c in zip(new_shape, chunks))
 
         # remove any chunks not within range

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2,6 +2,7 @@
 import binascii
 import hashlib
 import itertools
+import math
 import operator
 import re
 from functools import reduce
@@ -355,7 +356,7 @@ class Array(object):
         if self._shape == ():
             return 1,
         else:
-            return tuple(int(np.ceil(s / c))
+            return tuple(int(math.ceil(s / c))
                          for s, c in zip(self._shape, self._chunks))
 
     @property
@@ -2007,7 +2008,7 @@ class Array(object):
 
         # determine the new number and arrangement of chunks
         chunks = self._chunks
-        new_cdata_shape = tuple(int(np.ceil(s / c))
+        new_cdata_shape = tuple(int(math.ceil(s / c))
                                 for s, c in zip(new_shape, chunks))
 
         # remove any chunks not within range

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -92,7 +92,7 @@ class IntDimIndexer(object):
 
 
 def ceildiv(a, b):
-    return int(math.ceil(a / b))
+    return math.ceil(a / b)
 
 
 class SliceDimIndexer(object):

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
 import itertools
+import math
 import numbers
 
 import numpy as np
@@ -91,7 +92,7 @@ class IntDimIndexer(object):
 
 
 def ceildiv(a, b):
-    return int(np.ceil(a / b))
+    return int(math.ceil(a / b))
 
 
 class SliceDimIndexer(object):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import inspect
 import json
+import math
 import numbers
 import uuid
 from textwrap import TextWrapper, dedent
@@ -92,7 +93,7 @@ def guess_chunks(shape, typesize):
         if np.product(chunks) == 1:
             break  # Element size larger than CHUNK_MAX
 
-        chunks[idx % ndims] = np.ceil(chunks[idx % ndims] / 2.0)
+        chunks[idx % ndims] = math.ceil(chunks[idx % ndims] / 2.0)
         idx += 1
 
     return tuple(int(x) for x in chunks)


### PR DESCRIPTION
Instead of using `numpy.ceil`, use `math.ceil` on scalars. After all this is `math.ceil`'s primary use case (unlike `numpy.ceil`).

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
