### PR TITLE
Refactor out `_tofile`/`_fromfile` from `DirectoryStore`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -40,6 +40,9 @@ Upcoming Release
 * Use ``math.ceil`` for scalars.
   By :user:`John Kirkham <jakirkham>`; :issue:`500`.
 
+* Refactor out ``_tofile``/``_fromfile`` from ``DirectoryStore``.
+  By :user:`John Kirkham <jakirkham>`; :issue:`503`.
+
 .. _release_2.3.2:
 
 2.3.2

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -779,7 +779,7 @@ class DirectoryStore(MutableMapping):
         file writing logic.
         """
         with open(fn, mode='wb') as f:
-            return f.write(a)
+            f.write(a)
 
     def __getitem__(self, key):
         key = self._normalize_key(key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -747,10 +747,37 @@ class DirectoryStore(MutableMapping):
         return key.lower() if self.normalize_keys else key
 
     def _fromfile(self, fn):
+        """ Read data from a file
+
+        Parameters
+        ----------
+        fn: str
+            Filepath to open and read from.
+
+        Notes
+        -----
+        Subclasses should overload this method to specify any custom
+        file reading logic.
+        """
         with open(fn, 'rb') as f:
             return f.read()
 
     def _tofile(self, a, fn):
+        """ Write data to a file
+
+        Parameters
+        ----------
+        a: array-like
+            Data to write into the file.
+
+        fn: str
+            Filepath to open and write to.
+
+        Notes
+        -----
+        Subclasses should overload this method to specify any custom
+        file writing logic.
+        """
         with open(fn, mode='wb') as f:
             return f.write(a)
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -747,7 +747,7 @@ class DirectoryStore(MutableMapping):
         return key.lower() if self.normalize_keys else key
 
     def _fromfile(self, fn):
-        with open(filepath, 'rb') as f:
+        with open(fn, 'rb') as f:
             return f.read()
 
     def _tofile(self, a, fn):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -746,6 +746,14 @@ class DirectoryStore(MutableMapping):
     def _normalize_key(self, key):
         return key.lower() if self.normalize_keys else key
 
+    def _fromfile(self, fn):
+        with open(filepath, 'rb') as f:
+            return f.read()
+
+    def _tofile(self, a, fn):
+        with open(fn, mode='wb') as f:
+            return f.write(a)
+
     def __getitem__(self, key):
         key = self._normalize_key(key)
         filepath = os.path.join(self.path, key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -758,8 +758,7 @@ class DirectoryStore(MutableMapping):
         key = self._normalize_key(key)
         filepath = os.path.join(self.path, key)
         if os.path.isfile(filepath):
-            with open(filepath, 'rb') as f:
-                return f.read()
+            return self._fromfile(filepath)
         else:
             raise KeyError(key)
 
@@ -792,8 +791,7 @@ class DirectoryStore(MutableMapping):
         temp_name = file_name + '.' + uuid.uuid4().hex + '.partial'
         temp_path = os.path.join(dir_path, temp_name)
         try:
-            with open(temp_path, mode='wb') as f:
-                f.write(value)
+            self._tofile(value, temp_path)
 
             # move temporary file into place
             replace(temp_path, file_path)


### PR DESCRIPTION
To make it easier for users to implement their own methods for reading and writing from disk ( like memory-mapping https://github.com/zarr-developers/zarr-python/pull/377 ), refactor out `_tofile` and `_fromfile` methods that are called to handle the reading and writing of the value. Should avoid duplicating a lot of other logic when trying to extend `DirectoryStore`s for these cases.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
