### PR TITLE
Use `ensure_ndarray` in a few more places

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -40,6 +40,9 @@ Upcoming Release
 * Use ``math.ceil`` for scalars.
   By :user:`John Kirkham <jakirkham>`; :issue:`500`.
 
+* Use ``ensure_ndarray`` in a few more places.
+  By :user:`John Kirkham <jakirkham>`; :issue:`506`.
+
 .. _release_2.3.2:
 
 2.3.2

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1769,7 +1769,7 @@ class Array(object):
                 chunk = f.encode(chunk)
 
         # check object encoding
-        if isinstance(chunk, np.ndarray) and chunk.dtype == object:
+        if ensure_ndarray(chunk).dtype == object:
             raise RuntimeError('cannot write object array without object codec')
 
         # compress

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1570,8 +1570,13 @@ class Array(object):
 
         """
 
-        out = ensure_ndarray(out)
         assert len(chunk_coords) == len(self._cdata_shape)
+
+        out_is_ndarray = True
+        try:
+            out = ensure_ndarray(out)
+        except TypeError:
+            out_is_ndarray = False
 
         # obtain key for chunk
         ckey = self._chunk_key(chunk_coords)
@@ -1591,7 +1596,8 @@ class Array(object):
 
         else:
 
-            if (not fields and
+            if (out_is_ndarray and
+                    not fields and
                     is_contiguous_selection(out_selection) and
                     is_total_slice(chunk_selection, self._chunks) and
                     not self._filters and

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1570,6 +1570,7 @@ class Array(object):
 
         """
 
+        out = ensure_ndarray(out)
         assert len(chunk_coords) == len(self._cdata_shape)
 
         # obtain key for chunk
@@ -1590,8 +1591,7 @@ class Array(object):
 
         else:
 
-            if (isinstance(out, np.ndarray) and
-                    not fields and
+            if (not fields and
                     is_contiguous_selection(out_selection) and
                     is_total_slice(chunk_selection, self._chunks) and
                     not self._filters and


### PR DESCRIPTION
As we can coerce any object that is array-like to an `ndarray`, there should be no need for these explicit `ndarray` checks. So eliminate them by using `ensure_ndarray` to get an `ndarray` object instead.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
