### PR TITLE
Fix azure link rendering in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -803,7 +803,7 @@ Here is an example using S3Map to read an array created previously::
 
 Zarr now also has a builtin storage backend for Azure Blob Storage.
 The class is :class:`zarr.storage.ABSStore` (requires
- `azure-storage-blob <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python>`_
+`azure-storage-blob <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python>`_
 to be installed)::
 
     >>> store = zarr.ABSStore(container='test', prefix='zarr-testing', blob_service_kwargs={'is_emulated': True})  # doctest: +SKIP


### PR DESCRIPTION
Small update to fix the azure-storage-blob link being rendered as a block quote in the tutorial.

On `master`:

<img width="1092" alt="Screen Shot 2019-11-11 at 8 49 03 PM" src="https://user-images.githubusercontent.com/11656932/68637635-d6ad3c80-04c4-11ea-83b2-3a880559d369.png">


With changes in this PR:

<img width="1069" alt="Screen Shot 2019-11-11 at 8 49 25 PM" src="https://user-images.githubusercontent.com/11656932/68637626-d01ec500-04c4-11ea-8d39-1e1f1c506e0b.png">


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
