### PR TITLE
Group as context manager

### DIFF
--- a/docs/api/hierarchy.rst
+++ b/docs/api/hierarchy.rst
@@ -11,6 +11,8 @@ Groups (``zarr.hierarchy``)
     .. automethod:: __iter__
     .. automethod:: __contains__
     .. automethod:: __getitem__
+    .. automethod:: __enter__
+    .. automethod:: __exit__
     .. automethod:: group_keys
     .. automethod:: groups
     .. automethod:: array_keys

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,7 +21,7 @@ Upcoming Release
 * Upgrade dependencies in the test matrices and resolve a
   compatibility issue with testing against the Azure Storage
   Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
-  
+
 * Do not rename Blosc parameters in n5 backend and add `blocksize` parameter,
   compatible with n5-blosc. By :user:`axtimwalde`, :issue:`485`.
 
@@ -45,6 +45,9 @@ Upcoming Release
 
 * Refactor out ``_tofile``/``_fromfile`` from ``DirectoryStore``.
   By :user:`John Kirkham <jakirkham>`; :issue:`503`.
+
+* Add ``__enter__``/``__exit__`` methods to ``Group`` for ``h5py.File`` compatibility.
+  By :user:`Chris Barnes <clbarnes>`; :issue:`509`.
 
 .. _release_2.3.2:
 
@@ -91,7 +94,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 * New storage backend, backed by Azure Blob Storage, class :class:`zarr.storage.ABSStore`.
-  All data is stored as block blobs. By :user:`Shikhar Goenka <shikarsg>`, 
+  All data is stored as block blobs. By :user:`Shikhar Goenka <shikarsg>`,
   :user:`Tim Crone <tjcrone>` and :user:`Zain Patel <mzjp2>`; :issue:`345`.
 
 * Add "consolidated" metadata as an experimental feature: use

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -346,6 +346,9 @@ sub-directories, e.g.::
     >>> z
     <zarr.core.Array '/foo/bar/baz' (10000, 10000) int32>
 
+Groups can be used as context managers (in a ``with`` statement).
+If the underlying store has a ``close`` method, it will be called on exit.
+
 For more information on groups see the :mod:`zarr.hierarchy` and
 :mod:`zarr.convenience` API docs.
 
@@ -744,7 +747,7 @@ databases. The :class:`zarr.storage.RedisStore` class interfaces `Redis <https:/
 (an in memory data structure store), and the :class:`zarr.storage.MongoDB` class interfaces
 with `MongoDB <https://www.mongodb.com/>`_ (an oject oriented NoSQL database). These stores
 respectively require the `redis <https://redis-py.readthedocs.io>`_ and
-`pymongo <https://api.mongodb.com/python/current/>`_ packages to be installed. 
+`pymongo <https://api.mongodb.com/python/current/>`_ packages to be installed.
 
 For compatibility with the `N5 <https://github.com/saalfeldlab/n5>`_ data format, Zarr also provides
 an N5 backend (this is currently an experimental feature). Similar to the zip storage class, an

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -26,6 +26,8 @@ class Group(MutableMapping):
     ----------
     store : MutableMapping
         Group store, already initialized.
+        If the Group is used in a context manager, and the store has a ``close`` method,
+        it will be called on exit.
     path : string, optional
         Group path.
     read_only : bool, optional
@@ -224,6 +226,15 @@ class Group(MutableMapping):
             r += ' read-only'
         r += '>'
         return r
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            self.store.close()
+        except AttributeError:
+            pass
 
     def info_items(self):
 

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -59,6 +59,8 @@ class Group(MutableMapping):
     __iter__
     __contains__
     __getitem__
+    __enter__
+    __exit__
     group_keys
     groups
     array_keys
@@ -228,9 +230,11 @@ class Group(MutableMapping):
         return r
 
     def __enter__(self):
+        """Return the Group for use as a context manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """If the underlying Store has a ``close`` method, call it."""
         try:
             self.store.close()
         except AttributeError:


### PR DESCRIPTION
For compatibility with other group-like things (e.g. `h5py.File`),
`Groups` now have enter/exit methods for use as a context manager.
If the underlying store has a `close` method, that will be called on
exit; otherwise this does nothing.

See issue #509.

It would have been nice to extend the context manager stuff to a Store superclass (an ABC which also inherits from MutableMapping), but as described in the issue, that makes guarantees that existing code may already break (e.g. using a raw `dict` as a store).

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)