### PR TITLE
Ensure contiguous data using `astype`

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -43,6 +43,9 @@ Upcoming Release
 * Use ``ensure_ndarray`` in a few more places.
   By :user:`John Kirkham <jakirkham>`; :issue:`506`.
 
+* Ensure contiguous data using ``astype``.
+  By :user:`John Kirkham <jakirkham>`; :issue:`513`.
+
 * Refactor out ``_tofile``/``_fromfile`` from ``DirectoryStore``.
   By :user:`John Kirkham <jakirkham>`; :issue:`503`.
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1684,10 +1684,7 @@ class Array(object):
             else:
 
                 # ensure array is contiguous
-                if self._order == 'F':
-                    chunk = np.asfortranarray(value, dtype=self._dtype)
-                else:
-                    chunk = np.ascontiguousarray(value, dtype=self._dtype)
+                chunk = value.astype(self._dtype, order=self._order, copy=False)
 
         else:
             # partially replace the contents of this chunk


### PR DESCRIPTION
Previously we were calling `ascontiguousarray` and `asfortranarray` based on whether we wanted a C or Fortran ordered array. However we can simplify this by using `astype` to capture both cases. Additionally those functions ensure the array is at least 1-D, but that doesn't seem to matter for this use case since the scalar case is handled in a different branch. So we leave that part out.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
