### PR TITLE
Add documentation build to CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,5 @@ TODO:
 * [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
 * [ ] New/modified features documented in docs/tutorial.rst
 * [ ] Changes documented in docs/release.rst
-* [ ] Docs build locally (e.g., run ``tox -e docs``)
 * [ ] AppVeyor and Travis CI passes
 * [ ] Test coverage is 100% (Coveralls passes)

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   include:
     - python: 3.5
     - python: 3.6
+      env: BUILD_DOCS='true'
     - python: 3.7
       dist: xenial
       sudo: true
@@ -42,6 +43,7 @@ install:
 
 script:
   - tox
+  - if [[ $BUILD_DOCS == 'true' ]]; then tox -e docs; fi
 
 after_success:
   - coveralls

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'talks']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -49,6 +49,9 @@ Upcoming Release
 * Refactor out ``_tofile``/``_fromfile`` from ``DirectoryStore``.
   By :user:`John Kirkham <jakirkham>`; :issue:`503`.
 
+* Add documentation build to CI.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`516`.
+
 .. _release_2.3.2:
 
 2.3.2

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -141,7 +141,7 @@ Bug fixes
 * Avoid raising in :class:`zarr.storage.DirectoryStore`'s ``__setitem__`` when file already exists.
   By :user:`Justin Swaney <jmswaney>`, :issue:`272`, :issue:`318`.
 
-* The required version of the `numcodecs <http://numcodecs.rtfd.io>`_ package has been upgraded
+* The required version of the `Numcodecs`_ package has been upgraded
   to 0.6.2, which has enabled some code simplification and fixes a failing test involving
   msgpack encoding. By :user:`John Kirkham <jakirkham>`, :issue:`361`, :issue:`360`, :issue:`352`,
   :issue:`355`, :issue:`324`.
@@ -215,10 +215,10 @@ Enhancements
 
 * **New package for compressor and filter codecs**. The classes previously
   defined in the :mod:`zarr.codecs` module have been factored out into a
-  separate package called NumCodecs_. The NumCodecs_ package also includes
+  separate package called `Numcodecs`_. The `Numcodecs`_ package also includes
   several new codec classes not previously available in Zarr, including
   compressor codecs for Zstd and LZ4. This change is backwards-compatible with
-  existing code, as all codec classes defined by NumCodecs are imported into the
+  existing code, as all codec classes defined by Numcodecs are imported into the
   :mod:`zarr.codecs` namespace. However, it is recommended to import codecs from
   the new package, see the tutorial sections on :ref:`tutorial_compress` and
   :ref:`tutorial_filters` for examples. With contributions by
@@ -632,4 +632,4 @@ See `v0.4.0 release notes on GitHub
 See `v0.3.0 release notes on GitHub
 <https://github.com/zarr-developers/zarr-python/releases/tag/v0.3.0>`_.
 
-.. _NumCodecs: http://numcodecs.readthedocs.io/
+.. _Numcodecs: http://numcodecs.readthedocs.io/

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -743,7 +743,7 @@ Also added in Zarr version 2.3 are two storage classes for interfacing with serv
 databases. The :class:`zarr.storage.RedisStore` class interfaces `Redis <https://redis.io/>`_
 (an in memory data structure store), and the :class:`zarr.storage.MongoDB` class interfaces
 with `MongoDB <https://www.mongodb.com/>`_ (an oject oriented NoSQL database). These stores
-respectively require the `redis <https://redis-py.readthedocs.io>`_ and
+respectively require the `redis-py <https://redis-py.readthedocs.io>`_ and
 `pymongo <https://api.mongodb.com/python/current/>`_ packages to be installed. 
 
 For compatibility with the `N5 <https://github.com/saalfeldlab/n5>`_ data format, Zarr also provides


### PR DESCRIPTION
Closes #369

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] Docs build locally (e.g., run ``tox -e docs``)
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
