### PR TITLE
Fixing permissions for files inside a ZipStore

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,10 @@ Release notes
 Upcoming Release
 ----------------
 
+* Add intermediate step (using ``zipfile.ZipInfo`` object) to write
+  inside ``ZipStore`` to solve too restrictive permission issue.
+  By :user:`Raphael Dussin <raphaeldussin`; :issue:`505`.
+
 * Add key normalization option for ``DirectoryStore``, ``NestedDirectoryStore``,
   ``TempStore``, and ``N5Store``.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`459`.
@@ -21,7 +25,7 @@ Upcoming Release
 * Upgrade dependencies in the test matrices and resolve a
   compatibility issue with testing against the Azure Storage
   Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
-  
+
 * Do not rename Blosc parameters in n5 backend and add `blocksize` parameter,
   compatible with n5-blosc. By :user:`axtimwalde`, :issue:`485`.
 
@@ -94,7 +98,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 * New storage backend, backed by Azure Blob Storage, class :class:`zarr.storage.ABSStore`.
-  All data is stored as block blobs. By :user:`Shikhar Goenka <shikarsg>`, 
+  All data is stored as block blobs. By :user:`Shikhar Goenka <shikarsg>`,
   :user:`Tim Crone <tjcrone>` and :user:`Zain Patel <mzjp2>`; :issue:`345`.
 
 * Add "consolidated" metadata as an experimental feature: use

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,7 +6,7 @@ Upcoming Release
 
 * Add intermediate step (using ``zipfile.ZipInfo`` object) to write
   inside ``ZipStore`` to solve too restrictive permission issue.
-  By :user:`Raphael Dussin <raphaeldussin`; :issue:`505`.
+  By :user:`Raphael Dussin <raphaeldussin>`; :issue:`505`.
 
 * Add key normalization option for ``DirectoryStore``, ``NestedDirectoryStore``,
   ``TempStore``, and ``N5Store``.

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -132,7 +132,7 @@ def normalize_store_arg(store, clobber=False, default=dict):
         return default()
     elif isinstance(store, str):
         if store.endswith('.zip'):
-            mode = 'w' if clobber else 'a'
+            mode = 'w' if clobber else 'r'
             return ZipStore(store, mode=mode)
         elif store.endswith('.n5'):
             return N5Store(store)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -33,6 +33,7 @@ from os import scandir
 from pickle import PicklingError
 from threading import Lock, RLock
 import uuid
+import time
 
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from numcodecs.registry import codec_registry
@@ -1254,7 +1255,22 @@ class ZipStore(MutableMapping):
             err_read_only()
         value = ensure_contiguous_ndarray(value)
         with self.mutex:
-            self.zf.writestr(key, value)
+            # writestr(key, value) writes with default permissions from
+            # zipfile (600) that are too restrictive, build ZipInfo for
+            # the key to work around limitation
+            keyinfo = zipfile.ZipInfo(filename=key,
+                                      date_time=time.localtime(time.time())[:6])
+            keyinfo.compress_type = self.compression
+            if keyinfo.filename[-1] == os.sep:
+                keyinfo.external_attr = 0o40775 << 16   # drwxrwxr-x
+                keyinfo.external_attr |= 0x10           # MS-DOS directory flag
+            else:
+                keyinfo.external_attr = 0o644 << 16     # ?rw-r--r--
+
+            if isinstance(value, str):
+                value = value.encode("utf-8")
+
+            self.zf.writestr(keyinfo, value)
 
     def __delitem__(self, key):
         raise NotImplementedError

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -960,7 +960,11 @@ class TestZipStore(StoreTests, unittest.TestCase):
         assert perm == '0o644'
         info = z.getinfo('baz/')
         perm = oct(info.external_attr >> 16)
-        assert perm == '0o40775'
+        # windows/unix os dependent
+        if os.name == 'posix':
+            assert perm == '0o40775'
+        else:
+            assert perm == '0o644'
         z.close()
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -960,11 +960,9 @@ class TestZipStore(StoreTests, unittest.TestCase):
         assert perm == '0o644'
         info = z.getinfo('baz/')
         perm = oct(info.external_attr >> 16)
-        # windows/unix os dependent
+        # only for posix platforms
         if os.name == 'posix':
             assert perm == '0o40775'
-        else:
-            assert perm == '0o644'
         z.close()
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -956,10 +956,10 @@ class TestZipStore(StoreTests, unittest.TestCase):
         store.close()
         z = ZipFile('data/store.zip', 'r')
         info = z.getinfo('foo')
-        perm = oct( info.external_attr >> 16 )
+        perm = oct(info.external_attr >> 16)
         assert perm == '0o644'
         info = z.getinfo('baz/')
-        perm = oct( info.external_attr >> 16 )
+        perm = oct(info.external_attr >> 16)
         assert perm == '0o40775'
         z.close()
 


### PR DESCRIPTION
By default zipfile.writestr write files with permissions 600 when called with a filename.
These permissions are too restrictive for ZipStore to be shared with other users. In order to
fix the problem, I pass zipfile.writestr a zipfile.ZipInfo object in which I have set more open
permissions. Fixes #505 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] Docs build locally (e.g., run ``tox -e docs``)
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
