### PR TITLE
Fixed '/' prepend bug in ABSStore

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -55,6 +55,13 @@ Upcoming Release
 * Add documentation build to CI.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`516`.
 
+Bug fixes
+~~~~~~~~~
+
+* Fix '/' prepend bug in ``ABSStore``.
+  By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
+
+
 .. _release_2.3.2:
 
 2.3.2

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1964,7 +1964,7 @@ class ABSStore(MutableMapping):
     In order to use this store, you must install the Microsoft Azure Storage SDK for Python.
     """
 
-    def __init__(self, container, prefix=None, account_name=None, account_key=None,
+    def __init__(self, container, prefix='', account_name=None, account_key=None,
                  blob_service_kwargs=None):
         from azure.storage.blob import BlockBlobService
         self.container = container
@@ -1994,8 +1994,7 @@ class ABSStore(MutableMapping):
         if self.prefix == '':
             return normalize_storage_path(path)
         else:
-            return '/'.join([normalize_storage_path(self.prefix),
-                             normalize_storage_path(path)])
+            return '/'.join([self.prefix, normalize_storage_path(path)])
 
     @staticmethod
     def _strip_prefix_from_path(path, prefix):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2057,16 +2057,17 @@ class ABSStore(MutableMapping):
             return False
 
     def listdir(self, path=None):
+        from azure.storage.blob import Blob
         dir_path = normalize_storage_path(self._append_path_to_prefix(path))
         if dir_path:
             dir_path += '/'
         items = list()
         for blob in self.client.list_blobs(self.container, prefix=dir_path, delimiter='/'):
-            if '/' in blob.name[len(dir_path):]:
+            if type(blob) == Blob:
+                items.append(self._strip_prefix_from_path(blob.name, dir_path))
+            else:
                 items.append(self._strip_prefix_from_path(
                     blob.name[:blob.name.find('/', len(dir_path))], dir_path))
-            else:
-                items.append(self._strip_prefix_from_path(blob.name, dir_path))
         return items
 
     def rmdir(self, path=None):
@@ -2077,7 +2078,7 @@ class ABSStore(MutableMapping):
             self.client.delete_blob(self.container, blob.name)
 
     def getsize(self, path=None):
-        from azure.storage.blob.models import Blob
+        from azure.storage.blob import Blob
         store_path = normalize_storage_path(path)
         fs_path = self.prefix
         if store_path:

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1404,8 +1404,8 @@ class TestArrayWithABSStore(TestArray):
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
-        store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',
-                         account_key='bar', blob_service_kwargs={'is_emulated': True})
+        store = ABSStore(container='test', account_name='foo', account_key='bar',
+                         blob_service_kwargs={'is_emulated': True})
         store.rmdir()
         return store
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -894,8 +894,8 @@ class TestGroupWithABSStore(TestGroup):
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
-        store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',
-                         account_key='bar', blob_service_kwargs={'is_emulated': True})
+        store = ABSStore(container='test', account_name='foo', account_key='bar',
+                         blob_service_kwargs={'is_emulated': True})
         store.rmdir()
         return store, None
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1484,28 +1484,29 @@ class TestABSStore(StoreTests, unittest.TestCase):
         return store
 
     def test_iterators_with_prefix(self):
-        store = self.create_store(prefix='test_prefix')
+        for prefix in ['test_prefix', '/test_prefix', 'test_prefix/', 'test/prefix', '', None]:
+            store = self.create_store(prefix=prefix)
 
-        # test iterator methods on empty store
-        assert 0 == len(store)
-        assert set() == set(store)
-        assert set() == set(store.keys())
-        assert set() == set(store.values())
-        assert set() == set(store.items())
+            # test iterator methods on empty store
+            assert 0 == len(store)
+            assert set() == set(store)
+            assert set() == set(store.keys())
+            assert set() == set(store.values())
+            assert set() == set(store.items())
 
-        # setup some values
-        store['a'] = b'aaa'
-        store['b'] = b'bbb'
-        store['c/d'] = b'ddd'
-        store['c/e/f'] = b'fff'
+            # setup some values
+            store['a'] = b'aaa'
+            store['b'] = b'bbb'
+            store['c/d'] = b'ddd'
+            store['c/e/f'] = b'fff'
 
-        # test iterators on store with data
-        assert 4 == len(store)
-        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store)
-        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store.keys())
-        assert {b'aaa', b'bbb', b'ddd', b'fff'} == set(store.values())
-        assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
-                set(store.items()))
+            # test iterators on store with data
+            assert 4 == len(store)
+            assert {'a', 'b', 'c/d', 'c/e/f'} == set(store)
+            assert {'a', 'b', 'c/d', 'c/e/f'} == set(store.keys())
+            assert {b'aaa', b'bbb', b'ddd', b'fff'} == set(store.values())
+            assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
+                    set(store.items()))
 
 
 class TestConsolidatedMetadataStore(unittest.TestCase):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1478,8 +1478,8 @@ class TestABSStore(StoreTests, unittest.TestCase):
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
-        store = ABSStore(container='test', prefix='zarrtesting/', account_name='foo',
-                         account_key='bar', blob_service_kwargs={'is_emulated': True})
+        store = ABSStore(container='test', account_name='foo', account_key='bar',
+                         blob_service_kwargs={'is_emulated': True})
         store.rmdir()
         return store
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1473,15 +1473,39 @@ def test_format_compatibility():
 @skip_test_env_var("ZARR_TEST_ABS")
 class TestABSStore(StoreTests, unittest.TestCase):
 
-    def create_store(self):
+    def create_store(self, prefix=None):
         asb = pytest.importorskip("azure.storage.blob")
         blob_client = asb.BlockBlobService(is_emulated=True)
         blob_client.delete_container('test')
         blob_client.create_container('test')
-        store = ABSStore(container='test', account_name='foo', account_key='bar',
-                         blob_service_kwargs={'is_emulated': True})
+        store = ABSStore(container='test', prefix=prefix, account_name='foo',
+                         account_key='bar', blob_service_kwargs={'is_emulated': True})
         store.rmdir()
         return store
+
+    def test_iterators_with_prefix(self):
+        store = self.create_store(prefix='test_prefix')
+
+        # test iterator methods on empty store
+        assert 0 == len(store)
+        assert set() == set(store)
+        assert set() == set(store.keys())
+        assert set() == set(store.values())
+        assert set() == set(store.items())
+
+        # setup some values
+        store['a'] = b'aaa'
+        store['b'] = b'bbb'
+        store['c/d'] = b'ddd'
+        store['c/e/f'] = b'fff'
+
+        # test iterators on store with data
+        assert 4 == len(store)
+        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store)
+        assert {'a', 'b', 'c/d', 'c/e/f'} == set(store.keys())
+        assert {b'aaa', b'bbb', b'ddd', b'fff'} == set(store.values())
+        assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
+                set(store.items()))
 
 
 class TestConsolidatedMetadataStore(unittest.TestCase):


### PR DESCRIPTION
Fixes '/' prepend bug in `ABSStore`, issue: https://github.com/zarr-developers/zarr-python/issues/525

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
