### PR TITLE
Add 2.4 Changelog

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,6 +4,9 @@ Release notes
 Upcoming Release
 ----------------
 
+Enhancements
+~~~~~~~~~~~~
+
 * Add key normalization option for ``DirectoryStore``, ``NestedDirectoryStore``,
   ``TempStore``, and ``N5Store``.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`459`.
@@ -18,37 +21,18 @@ Upcoming Release
 * Rename ``DictStore`` to ``MemoryStore``.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`455`.
 
-* Rewrite ``.tree()`` pretty representation to use ipytree.
+* Rewrite ``.tree()`` pretty representation to use ``ipytree``.
   Allows it to work in both the Jupyter Notebook and JupyterLab.
   By :user:`John Kirkham <jakirkham>`; :issue:`450`.
-
-* Upgrade dependencies in the test matrices and resolve a
-  compatibility issue with testing against the Azure Storage
-  Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
 
 * Do not rename Blosc parameters in n5 backend and add `blocksize` parameter,
   compatible with n5-blosc. By :user:`axtimwalde`, :issue:`485`.
 
-* Removed support for Python 2.
-  By :user:`jhamman`; :issue:`393`, :issue:`470`.
-
-* Updates tests to use ``pytest.importorskip``.
-  By :user:`James Bourbeau <jrbourbeau>`; :issue:`492`
-
 * Update ``DirectoryStore`` to create files with more permissive permissions.
   By :user:`Eduardo Gonzalez <eddienko>` and :user:`James Bourbeau <jrbourbeau>`; :issue:`493`
 
-* Require Numcodecs 0.6.4+ to use text handling functionality from it.
-  By :user:`John Kirkham <jakirkham>`; :issue:`497`.
-
-* Support Python 3.8.
-  By :user:`John Kirkham <jakirkham>`; :issue:`499`.
-
 * Use ``math.ceil`` for scalars.
   By :user:`John Kirkham <jakirkham>`; :issue:`500`.
-
-* Use ``ensure_ndarray`` in a few more places.
-  By :user:`John Kirkham <jakirkham>`; :issue:`506`.
 
 * Ensure contiguous data using ``astype``.
   By :user:`John Kirkham <jakirkham>`; :issue:`513`.
@@ -58,9 +42,6 @@ Upcoming Release
 
 * Add ``__enter__``/``__exit__`` methods to ``Group`` for ``h5py.File`` compatibility.
   By :user:`Chris Barnes <clbarnes>`; :issue:`509`.
-
-* Add documentation build to CI.
-  By :user:`James Bourbeau <jrbourbeau>`; :issue:`516`.
 
 Bug fixes
 ~~~~~~~~~
@@ -74,6 +55,31 @@ Bug fixes
 
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
+
+Maintenance
+~~~~~~~~~~~
+
+* Add documentation build to CI.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`516`.
+
+* Use ``ensure_ndarray`` in a few more places.
+  By :user:`John Kirkham <jakirkham>`; :issue:`506`.
+
+* Support Python 3.8.
+  By :user:`John Kirkham <jakirkham>`; :issue:`499`.
+
+* Require Numcodecs 0.6.4+ to use text handling functionality from it.
+  By :user:`John Kirkham <jakirkham>`; :issue:`497`.
+
+* Updates tests to use ``pytest.importorskip``.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`492`
+
+* Removed support for Python 2.
+  By :user:`jhamman`; :issue:`393`, :issue:`470`.
+
+* Upgrade dependencies in the test matrices and resolve a
+  compatibility issue with testing against the Azure Storage
+  Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
 
 
 .. _release_2.3.2:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -4,10 +4,6 @@ Release notes
 Upcoming Release
 ----------------
 
-* Add intermediate step (using ``zipfile.ZipInfo`` object) to write
-  inside ``ZipStore`` to solve too restrictive permission issue.
-  By :user:`Raphael Dussin <raphaeldussin>`; :issue:`505`.
-
 * Add key normalization option for ``DirectoryStore``, ``NestedDirectoryStore``,
   ``TempStore``, and ``N5Store``.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`459`.
@@ -67,6 +63,10 @@ Bug fixes
 
 * Fix Sqlite Store Wrong Modification.
   By :user:`potter420 <potter420>`; :issue:`440`.
+
+* Add intermediate step (using ``zipfile.ZipInfo`` object) to write
+  inside ``ZipStore`` to solve too restrictive permission issue.
+  By :user:`Raphael Dussin <raphaeldussin>`; :issue:`505`.
 
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -56,6 +56,35 @@ Bug fixes
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
 
+Documentation
+~~~~~~~~~~~~~
+* Fix hyperlink in ``README.md``.
+  By :user:`Anderson Banihirwe <andersy005>`; :issue:`531`.
+
+* Replace "nuimber" with "number".
+  By :user:`John Kirkham <jakirkham>`; :issue:`512`.
+
+* Fix azure link rendering in tutorial.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`507`.
+
+* Update ``README`` file to be more detailed.
+  By :user:`Zain Patel <mzjp2>`; :issue:`495`.
+
+* Import blosc from numcodecs in tutorial.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`491`.
+
+* Adds logo to docs.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`462`.
+
+* Fix N5 link in tutorial.
+  By :user:`James Bourbeau <jrbourbeau>`; :issue:`480`.
+
+* Fix typo in code snippet.
+  By :user:`Joe Jevnik <llllllllll>`; :issue:`461`.
+
+* Fix URLs to point to zarr-python
+  By :user:`John Kirkham <jakirkham>`; :issue:`453`.
+
 Maintenance
 ~~~~~~~~~~~
 
@@ -80,6 +109,12 @@ Maintenance
 * Upgrade dependencies in the test matrices and resolve a
   compatibility issue with testing against the Azure Storage
   Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.
+
+* Use ``unittest.mock`` on Python 3.
+  By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`426`.
+
+* Drop ``decode`` from ``ConsolidatedMetadataStore``.
+  By :user:`John Kirkham <jakirkham>`; :issue:`452`.
 
 
 .. _release_2.3.2:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -66,7 +66,7 @@ Bug fixes
 ~~~~~~~~~
 
 * Fix Sqlite Store Wrong Modification.
-  By :user:`potter420 <potter420>`; :issue:`440`.
+  By :user:`Tommy Tran <potter420>`; :issue:`440`.
 
 * Add intermediate step (using ``zipfile.ZipInfo`` object) to write
   inside ``ZipStore`` to solve too restrictive permission issue.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,8 +1,10 @@
 Release notes
 =============
 
-Upcoming Release
-----------------
+.. _release_2.4.0:
+
+2.4.0
+-----
 
 Enhancements
 ~~~~~~~~~~~~

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -68,6 +68,9 @@ Bug fixes
 * Fix Sqlite Store Wrong Modification.
   By :user:`potter420 <potter420>`; :issue:`440`.
 
+* Fixing permissions for files inside a ZipStore.
+  By :user:`Raphael Dussin <raphaeldussin>`; :issue:`517`.
+
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,10 @@ Upcoming Release
 * Rename ``DictStore`` to ``MemoryStore``.
   By :user:`James Bourbeau <jrbourbeau>`; :issue:`455`.
 
+* Rewrite ``.tree()`` pretty representation to use ipytree.
+  Allows it to work in both the Jupyter Notebook and JupyterLab.
+  By :user:`John Kirkham <jakirkham>`; :issue:`450`.
+
 * Upgrade dependencies in the test matrices and resolve a
   compatibility issue with testing against the Azure Storage
   Emulator. By :user:`alimanfoo`; :issue:`468`, :issue:`467`.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -68,9 +68,6 @@ Bug fixes
 * Fix Sqlite Store Wrong Modification.
   By :user:`potter420 <potter420>`; :issue:`440`.
 
-* Fixing permissions for files inside a ZipStore.
-  By :user:`Raphael Dussin <raphaeldussin>`; :issue:`517`.
-
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -65,6 +65,9 @@ Upcoming Release
 Bug fixes
 ~~~~~~~~~
 
+* Fix Sqlite Store Wrong Modification.
+  By :user:`potter420 <potter420>`; :issue:`440`.
+
 * Fix '/' prepend bug in ``ABSStore``.
   By :user:`Shikhar Goenka <shikharsg>`; :issue:`525`.
 


### PR DESCRIPTION
Includes some other Changelog entries for 2.4.

xref: https://github.com/zarr-developers/zarr-python/issues/529

cc @jrbourbeau

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
