### PR TITLE
WIP: Add custom json encoder and decoder

### DIFF
--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -166,6 +166,9 @@ def encode_fill_value(v, dtype):
     if v is None:
         return v
     if dtype.kind == 'f':
+        # these cases are handled in the ZarrJsonEncoder now,
+        # but there may be cases where the metadata was not parsed
+        # with this encoder (?), so better to leave it here
         if np.isnan(v):
             return 'NaN'
         elif np.isposinf(v):

--- a/zarr/tests/test_attrs.py
+++ b/zarr/tests/test_attrs.py
@@ -4,6 +4,7 @@ import unittest
 
 import pytest
 
+import numpy as np
 from zarr.attrs import Attributes
 from zarr.tests.util import CountingDict
 
@@ -218,3 +219,15 @@ class TestAttributes(unittest.TestCase):
         assert 'spam' not in a
         assert 10 == store.counter['__getitem__', 'attrs']
         assert 3 == store.counter['__setitem__', 'attrs']
+
+    def test_special_values(self):
+        a = self.init_attributes(dict())
+
+        a['nan'] = np.nan
+        assert np.isnan(a['nan'])
+
+        a['pinf'] = np.PINF
+        assert np.isposinf(a['pinf'])
+
+        a['ninf'] = np.NINF
+        assert np.isneginf(a['ninf'])


### PR DESCRIPTION
Add custom `JsonEncoder` / `JsonDecoder` to properly handle nan and inf attributes, see #412.
Also adds a test to ensure these values are properly encoded / decoded.
This is still WIP because:
- I haven't tested the solution myself yet.
- Potentially one could simplify the code [here](https://github.com/zarr-developers/zarr-python/blob/master/zarr/meta.py#L130-L135) and [here](https://github.com/zarr-developers/zarr-python/blob/master/zarr/meta.py#L169-L174) with this solution, but I am not sure this is a good idea, because I don't know if we can always assume that the metadata passes through `zarr.util.json_dumps/json_loads`
- Potentially one could also add json encoding for numpy dtypes; this is an error that always annoys me a lot, but it's unrelated to #412.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
