### PR TITLE
WIP: Concurrent block reads and writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ zarr/version.py
 #doesnotexist
 #test_sync*
 data/*
+
+venv/*

--- a/docs/api/concurrency.rst
+++ b/docs/api/concurrency.rst
@@ -1,0 +1,15 @@
+Concurrency
+===========
+
+Zarr supports concurrent reads and writes to distinct blocks through the use of an `Executor <https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor>`__ object.
+The read and write routines of a :class:`zarr.core.Array` accept an optional ``executor`` keyword argument which controls how or if concurrent execution should be performed.
+By default, or if ``executor=None``, all blocks will be read and written serially.
+
+.. warning::
+
+   Not all executors can be used with all stores safely.
+   For example, a ``ThreadPoolExecutor`` may only be used if the underlying store is in fact thread safe.
+
+For stores where the data is already in memory or can be read very quickly, serial execution will likely be the fastest type of execution.
+A concurrent executor is particularly useful when there is a high IO cost to retrieving a block, for example, with a store that reads data from some cloud object storage like Amazon S3.
+In the case of some cloud object storage, a concurrent executor allows the Zarr to submit all of the web requests at once, instead of executing many web requests serially.


### PR DESCRIPTION
This commit adds support for optional concurrent executors to allow concurrently
reading or writing blocks to the underlying store. For stores where the IO is
expensive, for example an S3Map, allowing concurrent reads can be a massive
performance improvement.

The API is designed around Executor objects to allow safe composition. An
executor may be threaded to all of the places where concurrency is desired, both
inside of Zarr itself and in the user's code, to ensure that a shared thread
pool is used and no more than the desired number of threads are launched at the
same time. Executors would allow users to safely read or write blocks
concurrently from different Zarr Array objects at the same time, without
worrying about accidentally spawning too many threads.

I am opening this PR early before adding tests or more documentation to get feedback this proposed API, and discuss the implications of allowing concurrent access to blocks in a zarr array. I didn't want to invest too much time before getting your feedback to make sure this is something that the zarr developers are interested in.

This API doesn't necessarily allow users to do something new, because they could add concurrency on top of the existing interfaces, but adding this interface makes it much easier to align your reads and writes on chunk boundaries without needing to know as much about the implementation of Zarr. This is especially true for integer indexers and boolean mask indexers.

One major downside of this API is that it makes it easier for a user to attempt to access a non thread safe store in a multithreaded context. A user may naively use a `ThreadPoolExecutor` when it is not safe to do so and then get unexpected crashes. This could cause hard to debug (or even notice) data corruption depending on the given store. Another issue is that users may open many duplicate issues about this which adds a maintenance burden for the zarr developers. 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
