### PR TITLE
Add better ipytree error handling in jupyter notebooks

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,17 @@
 Release notes
 =============
 
+
+Next release
+------------
+
+* Fix minor bug in `N5Store`. 
+  By :user:`gsakkis`, :issue:`550`.
+* Improve error message in Jupyter when trying to use the ``ipytree`` widget
+  without ``ipytree`` installed.
+  By :user:`Zain Patel <mzjp2>; :issue:`537`
+
+
 .. _release_2.4.0:
 
 2.4.0

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,15 @@ setup(
     use_scm_version={
         'version_scheme': 'guess-next-dev',
         'local_scheme': 'dirty-tag',
-        'write_to': 'zarr/version.py'
+        'write_to': 'zarr/version.py',
     },
     setup_requires=[
         'setuptools>=38.6.0',
-        'setuptools-scm>1.5.4'
+        'setuptools-scm>1.5.4',
     ],
     extras_require={
         'jupyter': [
+            'jupyter',
             'ipytree',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     extras_require={
         'jupyter': [
-            'jupyter',
+            'notebook',
             'ipytree',
         ],
     },

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import re
+from unittest import mock
+
 import numpy as np
 import pytest
 
@@ -6,7 +9,8 @@ from zarr.util import (guess_chunks, human_readable_size, info_html_report,
                        info_text_report, is_total_slice, normalize_chunks,
                        normalize_fill_value, normalize_order,
                        normalize_resize_args, normalize_shape,
-                       tree_array_icon, tree_group_icon, tree_get_icon)
+                       tree_array_icon, tree_group_icon, tree_get_icon,
+                       tree_widget)
 
 
 def test_normalize_shape():
@@ -160,3 +164,12 @@ def test_tree_get_icon():
     assert tree_get_icon("Group") == tree_group_icon
     with pytest.raises(ValueError):
         tree_get_icon("Baz")
+
+@mock.patch.dict("sys.modules", {"ipytree": None})
+def test_tree_widget_missing_ipytree():
+    pattern = (
+        "Run `pip install zarr[jupyter]` to get the required ipytree "
+        "dependency for displaying the tree widget."
+        )
+    with pytest.raises(ImportError, match=re.escape(pattern)):
+        tree_widget(None, None, None)

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -169,9 +169,10 @@ def test_tree_get_icon():
 @mock.patch.dict("sys.modules", {"ipytree": None})
 def test_tree_widget_missing_ipytree():
     pattern = (
-        "Run `pip install zarr[jupyter]` to get the required ipytree "
-        "dependency for displaying the tree widget. If using jupyterlab, "
-        "you also need to run `jupyter labextension install ipytree`"
+        "Run `pip install zarr[jupyter]` or `conda install ipytree`"
+        "to get the required ipytree dependency for displaying the tree "
+        "widget. If using jupyterlab, you also need to run "
+        "`jupyter labextension install ipytree`"
         )
     with pytest.raises(ImportError, match=re.escape(pattern)):
         tree_widget(None, None, None)

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -170,7 +170,8 @@ def test_tree_get_icon():
 def test_tree_widget_missing_ipytree():
     pattern = (
         "Run `pip install zarr[jupyter]` to get the required ipytree "
-        "dependency for displaying the tree widget."
+        "dependency for displaying the tree widget. If using jupyterlab, "
+        "you also need to run `jupyter labextension install ipytree`"
         )
     with pytest.raises(ImportError, match=re.escape(pattern)):
         tree_widget(None, None, None)

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -165,6 +165,7 @@ def test_tree_get_icon():
     with pytest.raises(ValueError):
         tree_get_icon("Baz")
 
+
 @mock.patch.dict("sys.modules", {"ipytree": None})
 def test_tree_widget_missing_ipytree():
     pattern = (

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -433,7 +433,8 @@ def tree_widget(group, expand, level):
     except ImportError as error:
         raise ImportError(
             "{}: Run `pip install zarr[jupyter]` to get the required ipytree "
-            "dependency for displaying the tree widget.".format(error)
+            "dependency for displaying the tree widget. If using jupyterlab, "
+            "you also need to run `jupyter labextension install ipytree`".format(error)
         )
 
     result = ipytree.Tree()

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -428,7 +428,13 @@ def tree_widget_sublist(node, root=False, expand=False):
 
 
 def tree_widget(group, expand, level):
-    import ipytree
+    try:
+        import ipytree
+    except ImportError as error:
+        raise ImportError(
+            "{}: Run `pip install zarr[jupyter]` to get the required ipytree "
+            "dependency for displaying the tree widget.".format(error)
+        )
 
     result = ipytree.Tree()
     root = TreeNode(group, level=level)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -432,9 +432,10 @@ def tree_widget(group, expand, level):
         import ipytree
     except ImportError as error:
         raise ImportError(
-            "{}: Run `pip install zarr[jupyter]` to get the required ipytree "
-            "dependency for displaying the tree widget. If using jupyterlab, "
-            "you also need to run `jupyter labextension install ipytree`".format(error)
+            "{}: Run `pip install zarr[jupyter]` or `conda install ipytree`"
+            "to get the required ipytree dependency for displaying the tree "
+            "widget. If using jupyterlab, you also need to run "
+            "`jupyter labextension install ipytree`".format(error)
         )
 
     result = ipytree.Tree()


### PR DESCRIPTION
Resolves https://github.com/zarr-developers/zarr-python/issues/537

Adds a custom error message when failing to import `ipytree` in jupyter notebooks along with instructions on how to get it (`pip install zarr[jupyter]`). Also added `jupyter` itself to `extras_require["jupyter"]` seeing as `jupyter` isn't a requirement in-and-of-itself of `zarr`. Let me know if anything doesn't make sense, happy to change.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
