### PR TITLE
Maximize coverage

### DIFF
--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -691,11 +691,7 @@ class CoordinateIndexer(object):
         self.chunk_rixs = np.nonzero(self.chunk_nitems)[0]
 
         # unravel chunk indices
-        if tuple(map(int, np.__version__.split('.')[:2])) < (1, 16):
-            self.chunk_mixs = np.unravel_index(self.chunk_rixs, dims=array._cdata_shape)
-        else:
-            # deal with change dims->shape in arguments as of numpy 1.16
-            self.chunk_mixs = np.unravel_index(self.chunk_rixs, shape=array._cdata_shape)
+        self.chunk_mixs = np.unravel_index(self.chunk_rixs, array._cdata_shape)
 
     def __iter__(self):
 

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -13,8 +13,6 @@ from zarr.meta import (ZARR_FORMAT, decode_array_metadata, decode_dtype,
 
 
 def assert_json_equal(expect, actual):
-    if isinstance(expect, bytes):  # pragma: py3 no cover
-        expect = str(expect, 'ascii')
     if isinstance(actual, bytes):
         actual = str(actual, 'ascii')
     ej = json.loads(expect)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -510,15 +510,6 @@ def is_valid_python_name(name):
     return name.isidentifier() and not iskeyword(name)
 
 
-def class_dir(klass):  # pragma: py3 no cover
-    d = dict()
-    d.update(klass.__dict__)
-    bases = klass.__bases__
-    for base in bases:
-        d.update(class_dir(base))
-    return d
-
-
 class NoLock(object):
     """A lock that doesn't lock."""
 


### PR DESCRIPTION
These were uncovered lines in [this Coveralls report]( https://coveralls.io/builds/29088639 ). As we already dropped Python 2 in PR ( https://github.com/zarr-developers/zarr-python/pull/470 ), go ahead and drop this no longer need Python 2 code.

Also smooth over differences in `unravel_index`'s signature across NumPy versions.