### PR TITLE
Add FSStore

### DIFF
--- a/docs/api/storage.rst
+++ b/docs/api/storage.rst
@@ -35,6 +35,8 @@ Storage (``zarr.storage``)
 
 .. autoclass:: ABSStore
 
+.. autoclass:: FSStore
+
 .. autoclass:: ConsolidatedMetadataStore
 
 .. autofunction:: init_array

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -18,4 +18,5 @@ pytest-cov==2.7.1
 pytest-doctestplus==0.4.0
 pytest-remotedata==0.3.2
 h5py==2.10.0
-s3fs==0.3.4; python_version > '3.0'
+s3fs==0.5.0; python_version > '3.6'
+moto>=1.3.14; python_version > '3.6'

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -20,3 +20,4 @@ pytest-remotedata==0.3.2
 h5py==2.10.0
 s3fs==0.5.0; python_version > '3.6'
 moto>=1.3.14; python_version > '3.6'
+flask

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -357,7 +357,8 @@ def array(data, **kwargs):
 def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
                compressor='default', fill_value=0, order='C', synchronizer=None,
                filters=None, cache_metadata=True, cache_attrs=True, path=None,
-               object_codec=None, chunk_store=None, **kwargs):
+               object_codec=None, chunk_store=None, storage_options=None,
+               **kwargs):
     """Open an array using file-mode-like semantics.
 
     Parameters
@@ -403,6 +404,9 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
         A codec to encode object arrays, only needed if dtype=object.
     chunk_store : MutableMapping or string, optional
         Store or path to directory in file system or name of zip file.
+    storage_options : dict
+        If using an fsspec URL to create the store, these will be passed to
+        the backend implementation. Ignored otherwise.
 
     Returns
     -------
@@ -439,7 +443,6 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
 
     # handle polymorphic store arg
     clobber = mode == 'w'
-    storage_options = kwargs.pop("storage_options", None)
     store = normalize_store_arg(store, clobber=clobber, storage_options=storage_options)
     if chunk_store is not None:
         chunk_store = normalize_store_arg(chunk_store, clobber=clobber,

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -133,7 +133,7 @@ def normalize_store_arg(store, clobber=False, default=dict, storage_options=None
     elif isinstance(store, str):
         mode = 'w' if clobber else 'r'
         if "://" in store or "::" in store:
-            return FSStore(store, **(storage_options or {}))
+            return FSStore(store, mode=mode, **(storage_options or {}))
         elif storage_options:
             raise ValueError("storage_options passed with non-fsspec path")
         if store.endswith('.zip'):

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -10,7 +10,7 @@ from zarr.errors import (err_array_not_found, err_contains_array,
 from zarr.n5 import N5Store
 from zarr.storage import (DirectoryStore, ZipStore, contains_array,
                           contains_group, default_compressor, init_array,
-                          normalize_storage_path)
+                          normalize_storage_path, FSStore)
 
 
 def create(shape, chunks=True, dtype=None, compressor='default',
@@ -131,8 +131,10 @@ def normalize_store_arg(store, clobber=False, default=dict):
     if store is None:
         return default()
     elif isinstance(store, str):
+        mode = 'w' if clobber else 'r'
+        if "://" in store:
+            return FSStore(store)
         if store.endswith('.zip'):
-            mode = 'w' if clobber else 'r'
             return ZipStore(store, mode=mode)
         elif store.endswith('.n5'):
             return N5Store(store)

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1032,8 +1032,9 @@ class Group(MutableMapping):
         self._write_op(self._move_nosync, source, dest)
 
 
-def _normalize_store_arg(store, clobber=False):
-    return normalize_store_arg(store, clobber=clobber, default=MemoryStore)
+def _normalize_store_arg(store, clobber=False, storage_options=None):
+    return normalize_store_arg(store, clobber=clobber, default=MemoryStore,
+                               storage_options=storage_options)
 
 
 def group(store=None, overwrite=False, chunk_store=None,

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1118,6 +1118,9 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
         Group path within store.
     chunk_store : MutableMapping or string, optional
         Store or path to directory in file system or name of zip file.
+    storage_options : dict
+        If using an fsspec URL to create the store, these will be passed to
+        the backend implementation. Ignored otherwise.
 
     Returns
     -------
@@ -1140,9 +1143,10 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     """
 
     # handle polymorphic store arg
-    store = _normalize_store_arg(store, storage_options=storage_options)
+    clobber = mode != 'r'
+    store = _normalize_store_arg(store, clobber=clobber, storage_options=storage_options)
     if chunk_store is not None:
-        chunk_store = _normalize_store_arg(chunk_store, storage_options=storage_options)
+        chunk_store = _normalize_store_arg(chunk_store, clobber=clobber, storage_options=storage_options)
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1146,7 +1146,8 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     clobber = mode != 'r'
     store = _normalize_store_arg(store, clobber=clobber, storage_options=storage_options)
     if chunk_store is not None:
-        chunk_store = _normalize_store_arg(chunk_store, clobber=clobber, storage_options=storage_options)
+        chunk_store = _normalize_store_arg(chunk_store, clobber=clobber,
+                                           storage_options=storage_options)
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1096,7 +1096,7 @@ def group(store=None, overwrite=False, chunk_store=None,
 
 
 def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=None,
-               chunk_store=None):
+               chunk_store=None, storage_options=None):
     """Open a group using file-mode-like semantics.
 
     Parameters
@@ -1140,9 +1140,9 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     """
 
     # handle polymorphic store arg
-    store = _normalize_store_arg(store)
+    store = _normalize_store_arg(store, storage_options=storage_options)
     if chunk_store is not None:
-        chunk_store = _normalize_store_arg(chunk_store)
+        chunk_store = _normalize_store_arg(chunk_store, storage_options=storage_options)
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -949,7 +949,7 @@ def atexit_rmglob(path,
 class FSStore(MutableMapping):
 
     def __init__(self, url, normalize_keys=True, key_separator='.',
-                 mode='r', **storage_options):
+                 mode='w', **storage_options):
         import fsspec
         self.path = url
         self.normalize_keys = normalize_keys

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -21,7 +21,6 @@ import glob
 import multiprocessing
 import operator
 import os
-import json
 import re
 import shutil
 import sys

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -959,7 +959,7 @@ class FSStore(MutableMapping):
         self.mode = mode
 
     def _normalize_key(self, key):
-        key = normalize_storage_path(key)
+        key = normalize_storage_path(key).lstrip('/')
         if key:
             *bits, end = key.split('/')
             key = '/'.join(bits + [end.replace('.', self.key_separator)])
@@ -1015,8 +1015,9 @@ class FSStore(MutableMapping):
     def listdir(self, path=None):
         dir_path = self.dir_path(path)
         try:
-            return sorted(p.rsplit('/', 1)[-1]
+            out = sorted(p.rstrip('/').rsplit('/', 1)[-1]
                           for p in self.fs.ls(dir_path, detail=False))
+            return out
         except IOError:
             return []
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -970,7 +970,7 @@ class FSStore(MutableMapping):
             self.meta = json.loads(self.map.get(metadata_key, b"{}").decode())
             if mode == 'r' or 'zarr_consolidated_format' in self.meta:
                 consolidated_format = self.meta.get('zarr_consolidated_format', None)
-                if consolidated_format != 1:
+                if consolidated_format != 1:  # pragma: no cover
                     raise MetadataError('unsupported zarr consolidated metadata format: %s' %
                                         consolidated_format)
             else:
@@ -989,11 +989,11 @@ class FSStore(MutableMapping):
 
     def __getitem__(self, key):
         if self.consolidated and self._is_meta(key):
-            return self.meta[key]
+            return self.meta[key].encode()  # expect bytes out
         key = self._normalize_key(key)
         try:
             return self.map[key]
-        except self.exceptions  as e:
+        except self.exceptions as e:
             raise KeyError(key) from e
 
     def __setitem__(self, key, value):
@@ -1032,7 +1032,8 @@ class FSStore(MutableMapping):
         return key in self.map
 
     def __eq__(self, other):
-        return type(self) == type(other) and self.map == other.map
+        return (type(self) == type(other) and self.map == other.map
+                and self.mode == other.mode)
 
     def keys(self):
         return iter(self.map)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -949,13 +949,14 @@ def atexit_rmglob(path,
 class FSStore(MutableMapping):
 
     def __init__(self, url, normalize_keys=True, key_separator='.',
-                 **storage_options):
+                 mode='r', **storage_options):
         import fsspec
         self.path = url
         self.normalize_keys = normalize_keys
         self.key_separator = key_separator
         self.map = fsspec.get_mapper(url, **storage_options)
         self.fs = self.map.fs  # for direct operations
+        self.mode = mode
 
     def _normalize_key(self, key):
         key = normalize_storage_path(key)
@@ -969,6 +970,8 @@ class FSStore(MutableMapping):
         return self.map[key]
 
     def __setitem__(self, key, value):
+        if self.mode == 'r':
+            raise PermissionError
         key = self._normalize_key(key)
         path = self.dir_path(key)
         value = ensure_contiguous_ndarray(value)
@@ -980,6 +983,8 @@ class FSStore(MutableMapping):
             raise KeyError(key)
 
     def __delitem__(self, key):
+        if self.mode == 'r':
+            raise PermissionError
         key = self._normalize_key(key)
         path = self.dir_path(key)
         if self.fs.isdir(path):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1010,7 +1010,8 @@ class FSStore(MutableMapping):
     def listdir(self, path=None):
         dir_path = self.dir_path(path)
         try:
-            return sorted(p.rsplit('/', 1)[-1] for p in self.fs.ls(dir_path))
+            return sorted(p.rsplit('/', 1)[-1]
+                          for p in self.fs.ls(dir_path, detail=False))
         except IOError:
             return []
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1045,7 +1045,7 @@ class FSStore(MutableMapping):
         dir_path = self.dir_path(path)
         try:
             out = sorted(p.rstrip('/').rsplit('/', 1)[-1]
-                          for p in self.fs.ls(dir_path, detail=False))
+                         for p in self.fs.ls(dir_path, detail=False))
             return out
         except IOError:
             return []

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -30,6 +30,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore as NestedDirectoryStore
+from zarr.storage import FSStore as DirectoryStore
 from zarr.tests.util import CountingDict, skip_test_env_var
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -871,6 +871,12 @@ class TestFSStore(StoreTests, unittest.TestCase):
             store2[".zarray"] = b"{{}}"
         with pytest.raises(PermissionError):
             del store2[".zarray"]
+        with pytest.raises(PermissionError):
+            store2.clear()
+        with pytest.raises(PermissionError):
+            store2.rmdir("any")
+        with pytest.raises(ValueError):
+            FSStore(os.path.join(path, ".zmetadata"))
 
         store.clear()
         assert ".zmetadata" not in store
@@ -882,6 +888,7 @@ class TestFSStore(StoreTests, unittest.TestCase):
             zarr.open_array(path, mode='w', storage_options={"some": "kwargs"})
         with pytest.raises(ValueError, match="storage_options"):
             zarr.open_group(path, mode='w', storage_options={"some": "kwargs"})
+        zarr.open_array("file://" + path, mode='w', shape=(1,), dtype="f8")
 
 
 class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -879,6 +879,37 @@ class TestFSStore(StoreTests, unittest.TestCase):
         with pytest.raises(PermissionError):
             g.data[:] = 1
 
+    def test_read_only(self):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = FSStore(path)
+        store['foo'] = b"bar"
+
+        store = FSStore(path, mode='r')
+
+        with pytest.raises(PermissionError):
+            store['foo'] = b"hex"
+
+        with pytest.raises(PermissionError):
+            del store['foo']
+
+        with pytest.raises(PermissionError):
+            store.clear()
+
+        with pytest.raises(PermissionError):
+            store.rmdir("anydir")
+
+        assert store['foo'] == b"bar"
+
+        filepath = os.path.join(path, "foo")
+        with pytest.raises(ValueError):
+            FSStore(filepath, mode='r')
+
+    def test_eq(self):
+        store1 = FSStore("anypath")
+        store2 = FSStore("anypath")
+        assert store1 == store2
+
 
 class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -30,7 +30,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore
-from zarr.tests.util import CountingDict, skip_test_env_var
+from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var
 
 
 @contextmanager
@@ -828,6 +828,7 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
         assert 'foo' in store
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStore(StoreTests, unittest.TestCase):
 
     def create_store(self, normalize_keys=False):
@@ -857,8 +858,7 @@ class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
     def create_store(self, normalize_keys=False):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
-        store = NestedDirectoryStore(path, normalize_keys=normalize_keys,
-                                     key_separator='/', auto_mkdir=True)
+        store = NestedDirectoryStore(path, normalize_keys=normalize_keys)
         return store
 
     def test_chunk_nesting(self):
@@ -987,6 +987,7 @@ class TestN5Store(TestNestedDirectoryStore, unittest.TestCase):
                 init_array(store, shape=1000, chunks=100, filters=filters)
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestNestedFSStore(TestNestedDirectoryStore):
 
     def create_store(self, normalize_keys=False):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -29,6 +29,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
+from zarr.storage import FSStore as NestedDirectoryStore
 from zarr.tests.util import CountingDict, skip_test_env_var
 
 
@@ -762,7 +763,8 @@ class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
     def create_store(self, normalize_keys=False):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
-        store = NestedDirectoryStore(path, normalize_keys=normalize_keys)
+        store = NestedDirectoryStore(path, normalize_keys=normalize_keys,
+                                     key_separator='/', auto_mkdir=True)
         return store
 
     def test_chunk_nesting(self):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -852,6 +852,18 @@ class TestFSStore(StoreTests, unittest.TestCase):
         assert store["foo"] == b"hello"
         assert 'foo' in os.listdir(path2)
 
+    def test_consolidated(self):
+        path = tempfile.mkdtemp()
+        store = FSStore(path, consolidated=True)
+        store[".zarray"] = b"{}"
+        assert ".zmetadata" in os.listdir(path)
+
+    def test_not_fsspec(self):
+        import zarr
+        path = tempfile.mkdtemp()
+        with pytest.raises(ValueError, match="storage_options"):
+            zarr.open_array(path, mode='w', storage_options={"some": "kwargs"})
+
 
 class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
 

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -46,3 +46,10 @@ def skip_test_env_var(name):
     """
     value = os.environ.get(name, '0')
     return pytest.mark.skipif(value == '0', reason='Tests not enabled via environment variable')
+
+
+try:
+    import fsspec  # noqa: F401
+    have_fsspec = True
+except ImportError:
+    have_fsspec = False

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import collections
+from distutils.version import LooseVersion
 from collections.abc import MutableMapping
 import os
+import sys
 
 import pytest
 
@@ -50,6 +52,6 @@ def skip_test_env_var(name):
 
 try:
     import fsspec  # noqa: F401
-    have_fsspec = True
+    have_fsspec = LooseVersion(sys.version) >= LooseVersion("3.6")
 except ImportError:
     have_fsspec = False

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -51,7 +51,10 @@ def skip_test_env_var(name):
 
 
 try:
-    import fsspec  # noqa: F401
-    have_fsspec = LooseVersion(sys.version) >= LooseVersion("3.6")
+    if LooseVersion(sys.version) >= LooseVersion("3.6"):
+        import fsspec  # noqa: F401
+        have_fsspec = True
+    else:
+        have_fsspec = False
 except ImportError:
     have_fsspec = False

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -54,7 +54,7 @@ try:
     if LooseVersion(sys.version) >= LooseVersion("3.6"):
         import fsspec  # noqa: F401
         have_fsspec = True
-    else:
+    else:  # pragma: no cover
         have_fsspec = False
-except ImportError:
+except ImportError:  # pragma: no cover
     have_fsspec = False


### PR DESCRIPTION
Fixes #540 
Ref https://github.com/zarr-developers/zarr-python/pull/373#issuecomment-592722584 (@rabernat )

Introduces a short Store implementation for generic fsspec url+options. Allows both lowercasing of keys and choice between '.' and '/'-based ("nested") keys.

For testing, have hijacked the TestNestedDirectoryStore tests just as an example - this is not how things will remain.