### PR TITLE
Update Deprecating Warning with version number.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
 filterwarnings =
-    error::DeprecationWarning
+    error::DeprecationWarning:zarr.*
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
+filterwarnings =
+    error::DeprecationWarning
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -660,8 +660,8 @@ class MemoryStore(MutableMapping):
 class DictStore(MemoryStore):
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("DictStore has been renamed to MemoryStore and will be "
-                      "removed in the future. Please use MemoryStore.",
+        warnings.warn("DictStore has been renamed to MemoryStore in 2.4.0 and "
+                      "will be removed in the future. Please use MemoryStore.",
                       DeprecationWarning,
                       stacklevel=2)
         super(DictStore, self).__init__(*args, **kwargs)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -762,14 +762,19 @@ class TestMemoryStore(StoreTests, unittest.TestCase):
 
 
 class TestDictStore(StoreTests, unittest.TestCase):
-
+ 
     def create_store(self):
-        return DictStore()
+        with pytest.warns(DeprecationWarning):
+            return DictStore()
 
     def test_deprecated(self):
-        with pytest.warns(DeprecationWarning):
-            store = self.create_store()
+        store = self.create_store()
         assert isinstance(store, MemoryStore)
+
+    def test_pickle(self):
+        with pytest.warns(DeprecationWarning):
+            # pickle.load() will also trigger deprecation warning
+            super().test_pickle()
 
 
 class TestDirectoryStore(StoreTests, unittest.TestCase):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -762,7 +762,7 @@ class TestMemoryStore(StoreTests, unittest.TestCase):
 
 
 class TestDictStore(StoreTests, unittest.TestCase):
- 
+
     def create_store(self):
         with pytest.warns(DeprecationWarning):
             return DictStore()


### PR DESCRIPTION
Adding the versing number make it slightly easier on consumers to update
to the new naming as they will get a sens of compatibility.

Also update pytest to fail is any deprecation warning are not marked in
the test suite, and catch them in more places.

In particular we realise that many more places trigger the warnings in
create_store so we catch the warning there, but also that
`pickle.load()` can trigger it.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
