### PR TITLE
modify top level description of zarr

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Zarr
 ====
 
-Zarr is format for the storage of chunked, compressed, N-dimensional arrays.
+Zarr is a format for the storage of chunked, compressed, N-dimensional arrays.
 These documents describe the Zarr format and its Python implementation.
 
 Highlights

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,8 @@
 Zarr
 ====
 
-Zarr is a Python package providing an implementation of chunked,
-compressed, N-dimensional arrays.
+Zarr is format for the storage of chunked, compressed, N-dimensional arrays.
+These documents describe the Zarr format and its Python implementation.
 
 Highlights
 ----------
@@ -40,8 +40,8 @@ Install Zarr from PyPI::
 Alternatively, install Zarr via conda::
 
     $ conda install -c conda-forge zarr
-    
-To install the latest development version of Zarr, you can use pip with the 
+
+To install the latest development version of Zarr, you can use pip with the
 latest GitHub master::
 
     $ pip install git+https://github.com/zarr-developers/zarr-python.git


### PR DESCRIPTION
This PR changes the very first sentence of our documentation from

> Zarr is a Python package providing an implementation of chunked, compressed, N-dimensional arrays.

to

> Zarr is format for the storage of chunked, compressed, N-dimensional arrays. These documents describe the Zarr format and its Python implementation.

I think it's important at this stage to make this clarification.

Should we also consider linking to the implementations in other languages?