### PR TITLE
Attempt to use os.walk to speedup reading from Directory Store

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -5,6 +5,8 @@ Release notes
 Next release
 ------------
 
+* `DirectoryStore` now uses `os.scandir`, which should make listing large store
+  faster, :issue:`563`
 * Fix minor bug in `N5Store`. 
   By :user:`gsakkis`, :issue:`550`.
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -827,6 +827,34 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
         assert 'FOO' in store
         assert 'foo' in store
 
+    def test_listing_keys_slash(self):
+
+        def mock_walker_slash(_path):
+            yield from [
+                # trailing slash in first key
+                ('root_with_slash/', ['d1', 'g1'], ['.zgroup']),
+                ('root_with_slash/d1', [], ['.zarray']),
+                ('root_with_slash/g1', [], ['.zgroup'])
+            ]
+
+        res = set(DirectoryStore._keys_fast('root_with_slash/', walker=mock_walker_slash))
+        assert res == {'.zgroup', 'g1/.zgroup', 'd1/.zarray'}
+
+    def test_listing_keys_no_slash(self):
+
+        def mock_walker_no_slash(_path):
+            yield from [
+                # no trainling slash in first key
+                ('root_with_no_slash', ['d1', 'g1'], ['.zgroup']),
+                ('root_with_no_slash/d1', [], ['.zarray']),
+                ('root_with_no_slash/g1', [], ['.zgroup'])
+            ]
+
+        res = set(
+            DirectoryStore._keys_fast('root_with_no_slash', mock_walker_no_slash)
+                )
+        assert res == {'.zgroup', 'g1/.zgroup', 'd1/.zarray'}
+
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStore(StoreTests, unittest.TestCase):


### PR DESCRIPTION
usage of os.walk for tree (os.scandir for folders) is faster than
listdir as it avoids many stats call.

This Should make the DirectoryStore faster.

See #562 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
