### PR TITLE
Always display the 10 slowest test when running pytest.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
+addopts = --durations=10
 


### PR DESCRIPTION
This is useful when inspecting CI builds to have an idea of what takes
the longest time – especially since CI may have some slow resources
(disk, network). And may help to speedup test suite, which is always
good for fast development.