### PR TITLE
Spec v2 update link to stable numpy docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
     'numpydoc',
     'sphinx_issues',
 ]
@@ -306,4 +307,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+# use in refs e.g:
+# :ref:`comparison manual <python:comparisons>`
+intersphinx_mapping = { 'python':('https://docs.python.org/', None), 
+                        'numpy': ('https://numpy.org/doc/stable/', None)}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Installation
 ------------
 
 Zarr depends on NumPy. It is generally best to `install NumPy
-<http://docs.scipy.org/doc/numpy/user/install.html>`_ first using whatever method is most
+<https://numpy.org/doc/stable/user/install.html>`_ first using whatever method is most
 appropriate for you operating system and Python distribution. Other dependencies should be
 installed automatically if using one of the installation methods below.
 

--- a/docs/spec/v1.rst
+++ b/docs/spec/v1.rst
@@ -108,7 +108,7 @@ Data type encoding
 Simple data types are encoded within the array metadata resource as a
 string, following the `NumPy array protocol type string (typestr)
 format
-<http://docs.scipy.org/doc/numpy/reference/arrays.interface.html>`_. The
+<numpy:arrays.interface>`_. The
 format consists of 3 parts: a character describing the byteorder of
 the data (``<``: little-endian, ``>``: big-endian, ``|``:
 not-relevant), a character code giving the basic type of the array,
@@ -119,7 +119,7 @@ order MUST be specified. E.g., ``"<f8"``, ``">i4"``, ``"|b1"`` and
 Structure data types (i.e., with multiple named fields) are encoded as
 a list of two-element lists, following `NumPy array protocol type
 descriptions (descr)
-<http://docs.scipy.org/doc/numpy/reference/arrays.interface.html#>`_.
+<numpy:arrays.interface>`_.
 For example, the JSON list ``[["r", "|u1"], ["g", "|u1"], ["b",
 "|u1"]]`` defines a data type composed of three single-byte unsigned
 integers labelled 'r', 'g' and 'b'.

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -117,8 +117,8 @@ Data type encoding
 ~~~~~~~~~~~~~~~~~~
 
 Simple data types are encoded within the array metadata as a string,
-following the `NumPy array protocol type string (typestr) format
-<http://docs.scipy.org/doc/numpy/reference/arrays.interface.html>`_. The format
+following the :ref:`NumPy array protocol type string (typestr) format
+<numpy:arrays.interface>`. The format
 consists of 3 parts:
 
 * One character describing the byteorder of the data (``"<"``: little-endian;
@@ -136,14 +136,14 @@ The byte order MUST be specified. E.g., ``"<f8"``, ``">i4"``, ``"|b1"`` and
 
 For datetime64 ("M") and timedelta64 ("m") data types, these MUST also include the
 units within square brackets. A list of valid units and their definitions are given in
-the `NumPy documentation on Datetimes and Timedeltas
-<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html#datetime-units>`_.
+the :ref:`NumPy documentation on Datetimes and Timedeltas
+<numpy:arrays.dtypes.dateunits>`.
 For example, ``"<M8[ns]"`` specifies a datetime64 data type with nanosecond time units.
 
 Structured data types (i.e., with multiple named fields) are encoded
-as a list of lists, following `NumPy array protocol type descriptions
+as a list of lists, following :ref:`NumPy array protocol type descriptions
 (descr)
-<http://docs.scipy.org/doc/numpy/reference/arrays.interface.html#>`_. Each
+<numpy:arrays.interface>`. Each
 sub-list has the form ``[fieldname, datatype, shape]`` where ``shape``
 is optional. ``fieldname`` is a string, ``datatype`` is a string
 specifying a simple data type (see above), and ``shape`` is a list of


### PR DESCRIPTION
Numpy docs have move, update links to newer version. 
