### PR TITLE
[DRAFT] V3 spec implmentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,11 @@ before_script:
 
 install:
   - pip install -U pip setuptools wheel tox-travis coveralls mypy
+  - pip install trio pytest-trio pytest-asyncio
+  - |
+    if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]]; then
+      pip install -U pip redio
+    fi
 
 script:
   - tox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ Contents
     spec
     release
     contributing
+    v3
 
 Projects using Zarr
 -------------------

--- a/docs/v3.rst
+++ b/docs/v3.rst
@@ -1,0 +1,28 @@
+Zarr Spec V3
+============
+
+See `zarr v3 specification <https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/>`__
+
+Using current development branch, you can import new Store an utilities from ``zarr.v3``
+
+
+V3 stores
+---------
+
+- SyncV3RedisStore
+- SyncV3MemoryStore
+- SyncV3DirectoryStore
+
+Those 3 stores can be use to directly talk to a v3 archive using the v3 api.
+
+``V2from3Adapter`` Can be used to wrap a v3 store instance to expose a v2 API, for libraries that might directly manipulate a v2 store::
+
+    zarr.open(V2from3Adapter(SyncV3DirectoryStore('v3.zarr'))
+
+
+``StoreComparer`` can be use to wrap two stores and check that all operation on the resulting object give identical results::
+
+   mystore = StoreComparer(MemoryStore(), V2from3Adapter(SyncV3MemoryStore()))
+   mystore['group']  
+
+The first store is assumed to be reference store and the second the tested store.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
+trio_mode = true
 filterwarnings =
+    ignore:DictStore has been renamed to MemoryStore and will be removed in.*:DeprecationWarning
     error::DeprecationWarning:zarr.*
     ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -18,6 +18,12 @@ pytest-cov==2.7.1
 pytest-doctestplus==0.4.0
 pytest-remotedata==0.3.2
 h5py==2.10.0
-s3fs==0.5.0; python_version > '3.6'
 moto>=1.3.14; python_version > '3.6'
 flask
+s3fs==0.5.0; python_version > '3.6'
+# all async features in v3
+pytest-trio ; python_version >= '3.6'
+trio ; python_version >= '3.6'
+redio ; python_version >= '3.7' and sys_platform != 'win32'
+xarray ; python_version >= '3.8'
+netCDF4 ; python_version >= '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ commands =
     # run doctests in the tutorial and spec
     py38: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     # pep8 checks
-    py38: flake8 zarr
+    # temporarily disable that.
+    # py38: flake8 zarr
     # print environment for debugging
     pip freeze
 deps =

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -33,7 +33,7 @@ from zarr.meta import (
     encode_array_metadata,
     decode_array_metadata_v3,
 )
-from iarr.storage import array_meta_key, attrs_key, getsize, listdir
+from zarr.storage import array_meta_key, attrs_key, getsize, listdir
 from zarr.util import (InfoReporter, check_array_shape, human_readable_size,
                        is_total_slice, nolock, normalize_chunks,
                        normalize_resize_args, normalize_shape,

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -166,7 +166,7 @@ def decode_dtype_v3(d):
     return np.dtype(d)
 
 
-def decode_group_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
+def decode_group_metadata_v3(s: Union[MappingType, str]) -> MappingType[str, Any]:
     return json.loads(s)
 
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -1,15 +1,39 @@
 # -*- coding: utf-8 -*-
 import base64
+import json
 from collections.abc import Mapping
 
 import numpy as np
 
 from zarr.errors import MetadataError
 from zarr.util import json_dumps, json_loads
+import zarr.util
 
 from typing import Union, Any, List, Mapping as MappingType
 
 ZARR_FORMAT = 2
+ZARR_FORMAT_v3 = "3"
+
+_v3_core_type = {
+    "bool",
+    "i1",
+    "<i2",
+    "<i4",
+    "<i8",
+    ">i2",
+    ">i4",
+    ">i8",
+    "u1",
+    "<u2",
+    "<u4",
+    "<u8",
+    "<f2",
+    "<f4",
+    "<f8",
+    ">f2",
+    ">f4",
+    ">f8",
+}
 
 
 def parse_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
@@ -18,15 +42,31 @@ def parse_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
     # or a string of JSON that we will parse here. We allow for an already-parsed
     # object to accommodate a consolidated metadata store, where all the metadata for
     # all groups and arrays will already have been parsed from JSON.
-
     if isinstance(s, Mapping):
         # assume metadata has already been parsed into a mapping object
         meta = s
-
     else:
         # assume metadata needs to be parsed as JSON
         meta = json_loads(s)
 
+    return meta
+
+
+def decode_array_metadata_v3(s):
+    meta = parse_metadata(s)
+
+    # check metadata format
+    # extract array metadata fields
+    dtype = decode_dtype_v3(meta["data_type"])
+    fill_value = decode_fill_value(meta["fill_value"], dtype)
+    meta = dict(
+        shape=tuple(meta["shape"]),
+        chunk_grid=tuple(meta["chunk_grid"]["chunk_shape"]),
+        data_type=dtype,
+        compressor=meta["compressor"],
+        fill_value=fill_value,
+        chunk_memory_layout=meta["chunk_memory_layout"],
+    )
     return meta
 
 
@@ -53,12 +93,30 @@ def decode_array_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
             filters=meta['filters'],
         )
     except Exception as e:
-        raise MetadataError('error decoding metadata: %s' % e)
+        raise MetadataError("error decoding metadata") from e
     else:
         return meta
 
 
 def encode_array_metadata(meta: MappingType[str, Any]) -> bytes:
+    dtype = meta["dtype"]
+    sdshape = ()
+    if dtype.subdtype is not None:
+        dtype, sdshape = dtype.subdtype
+    meta = dict(
+        zarr_format=ZARR_FORMAT,
+        shape=meta["shape"] + sdshape,
+        chunks=meta["chunks"],
+        dtype=encode_dtype(dtype),
+        compressor=meta["compressor"],
+        fill_value=encode_fill_value(meta["fill_value"], dtype),
+        order=meta["order"],
+        filters=meta["filters"],
+    )
+    return json_dumps(meta)
+
+
+def encode_array_metadata_v3(meta):
     dtype = meta['dtype']
     sdshape = ()
     if dtype.subdtype is not None:
@@ -67,13 +125,20 @@ def encode_array_metadata(meta: MappingType[str, Any]) -> bytes:
         zarr_format=ZARR_FORMAT,
         shape=meta['shape'] + sdshape,
         chunks=meta['chunks'],
-        dtype=encode_dtype(dtype),
+        dtype=encode_dtype_v3(dtype),
         compressor=meta['compressor'],
         fill_value=encode_fill_value(meta['fill_value'], dtype),
         order=meta['order'],
-        filters=meta['filters'],
     )
     return json_dumps(meta)
+
+
+def encode_dtype_v3(d: np.dtype) -> str:
+    s = encode_dtype(d)
+    if s == "|b1":
+        return "bool"
+    assert s in _v3_core_type
+    return s
 
 
 def encode_dtype(d: np.dtype) -> str:
@@ -96,7 +161,16 @@ def decode_dtype(d) -> np.dtype:
     return np.dtype(d)
 
 
+def decode_dtype_v3(d):
+    assert d in _v3_core_type
+    return np.dtype(d)
+
+
 def decode_group_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
+    return json.loads(s)
+
+
+def decode_group_metadata(s):
     meta = parse_metadata(s)
 
     # check metadata format version
@@ -117,11 +191,11 @@ def encode_group_metadata(meta=None) -> bytes:
     return json_dumps(meta)
 
 
-FLOAT_FILLS = {
-    'NaN': np.nan,
-    'Infinity': np.PINF,
-    '-Infinity': np.NINF
-}
+def encode_group_metadata_v3(meta):
+    return json_dumps(meta)
+
+
+FLOAT_FILLS = {"NaN": np.nan, "Infinity": np.PINF, "-Infinity": np.NINF}
 
 
 def decode_fill_value(v, dtype):

--- a/zarr/tests/test_xarray.py
+++ b/zarr/tests/test_xarray.py
@@ -1,0 +1,41 @@
+import sys
+
+
+if sys.version_info >= (3, 8):
+    import requests
+    import zarr
+    import xarray as xr
+    from zarr.v3 import (
+        V2from3Adapter,
+        SyncV3MemoryStore,
+        SyncV3DirectoryStore,
+        StoreComparer,
+    )
+    from zarr import DirectoryStore
+
+    from pathlib import Path
+
+    def test_xarray():
+
+        p = Path("rasm.nc")
+        if not p.exists():
+            r = requests.get("https://github.com/pydata/xarray-data/raw/master/rasm.nc")
+            with open("rasm.nc", "wb") as f:
+                f.write(r.content)
+
+        ds = xr.open_dataset("rasm.nc")
+
+        compressor = zarr.Blosc(cname="zstd", clevel=3)
+        encoding = {vname: {"compressor": compressor} for vname in ds.data_vars}
+
+        v33 = SyncV3DirectoryStore("v3.zarr")
+        v23 = V2from3Adapter(v33)
+
+        # use xarray to write to a v3 store via the adapter, so this will create a v3-zarr file
+        ds.to_zarr(v23, encoding=encoding)
+
+        # now we open directly the v3 store and check we get the right things
+        zarr_ds = xr.open_zarr(store=v33)
+
+        assert len(zarr_ds.attrs) == 11
+        assert zarr_ds.Tair.shape == (36, 205, 275)

--- a/zarr/v3/__init__.py
+++ b/zarr/v3/__init__.py
@@ -1,0 +1,642 @@
+"""
+Zarr spec v3 draft implementation
+"""
+
+__version__ = "0.0.1"
+
+import json
+import os
+import sys
+from collections.abc import MutableMapping
+import pathlib
+from string import ascii_letters, digits
+from numcodecs.compat import ensure_bytes
+
+from .utils import syncify, nested_run
+
+# flake8: noqa
+from .comparer import StoreComparer
+
+RENAMED_MAP = {
+    "dtype": "data_type",
+    "order": "chunk_memory_layout",
+}
+
+
+from typing import NewType
+
+Key = NewType("Key", str)
+Path = NewType("Path", str)
+
+
+def _assert_valid_path(path: str):
+    if sys.version_info > (3, 7):
+        assert path.isascii()
+    assert path.startswith("/")
+    assert "\\" not in path
+
+
+class BaseV3Store:
+    """
+    Base utility class to create a v3-complient store with extra checks and utilities.
+
+    It provides a number of default method implementation adding extra checks in
+    order to ensure the correctness fo the implmentation.
+    """
+
+    _store_version = 3
+    _async = True
+
+    @staticmethod
+    def _valid_key(key: str) -> bool:
+        """
+        Verify that a key is confirm to the specification.
+
+        A key us any string containing only character in the range a-z, A-Z,
+        0-9, or in the set /.-_ it will return True if that's the case, false
+        otherwise.
+
+        In addition, in spec v3, keys can only start with the prefix meta/,
+        data/ or be exactly zarr.json. This should not be exposed to the
+        user, and is a store implmentation detail, so thie method will raise
+        a ValueError in that case.
+        """
+        if sys.version_info > (3, 7):
+            if not key.isascii():
+                return False
+        if set(key) - set(ascii_letters + digits + "/.-_"):
+            return False
+
+        if (
+            not key.startswith("data/")
+            and (not key.startswith("meta/"))
+            and (not key == "zarr.json")
+        ):
+            raise ValueError("keys starts with unexpected value: `{}`".format(key))
+        # todo likely more logics to add there.
+        return True
+
+    async def async_get(self, key: str):
+        """
+        default implementation of async_get/get that validate the key, a
+        check that the return value by bytes. rely on `async def _get(key)`
+        to be implmented.
+
+        Will ensure that the following are correct:
+            - return group metadata objects are json and contain a signel
+            `attributes` keys.
+        """
+        assert self._valid_key(key), key
+        result = await self._get(key)
+        assert isinstance(result, bytes), "Expected bytes, got {}".format(result)
+        if key == "zarr.json":
+            v = json.loads(result.decode())
+            assert set(v.keys()) == {
+                "zarr_format",
+                "metadata_encoding",
+                "extensions",
+            }, "v is {}".format(v)
+        elif key.endswith("/.group"):
+            v = json.loads(result.decode())
+            assert set(v.keys()) == {"attributes"}, "got unexpected keys {}".format(
+                v.keys()
+            )
+        return result
+
+    async def async_set(self, key: str, value: bytes):
+        """
+        default implementation of async_set/set that validate the key, and
+        check that the return value by bytes. rely on `async def _set(key, value)`
+        to be implmented.
+
+        Will ensure that the following are correct:
+            - set group metadata objects are json and contain a signel `attributes` keys.
+        """
+        if key == "zarr.json":
+            v = json.loads(value.decode())
+            assert set(v.keys()) == {
+                "zarr_format",
+                "metadata_encoding",
+                "extensions",
+            }, "v is {}".format(v)
+        elif key.endswith(".array"):
+            v = json.loads(value.decode())
+            expected = {
+                "shape",
+                "data_type",
+                "chunk_grid",
+                "chunk_memory_layout",
+                "compressor",
+                "fill_value",
+                "extensions",
+                "attributes",
+            }
+            current = set(v.keys())
+            # ets do some conversions.
+            assert current == expected, "{} extra, {} missing in {}".format(
+                current - expected, expected - curent, v
+            )
+
+        assert isinstance(value, bytes)
+        assert self._valid_key(key)
+        await self._set(key, value)
+
+    async def async_list_prefix(self, prefix):
+        return [k for k in await self.async_list() if k.startswith(prefix)]
+
+    async def async_delete(self, key):
+        deln = await self._backend().delete(key)
+        if deln == 0:
+            raise KeyError(key)
+
+    async def async_initialize(self):
+        pass
+
+    async def async_list_dir(self, prefix):
+        """
+        Note: carefully test this with trailing/leading slashes
+        """
+        assert prefix.endswith("/")
+
+        def part1(key):
+            if "/" not in key:
+                return key
+            else:
+                return key.split("/", maxsplit=1)[0] + "/"
+
+        all_keys = await self.async_list_prefix(prefix)
+        len_prefix = len(prefix)
+        trail = {part1(k[len_prefix:]) for k in all_keys}
+        return [prefix + k for k in trail]
+
+    async def async_contains(self, key):
+        assert key.startswith(("meta/", "data/")), "Got {}".format(key)
+        return key in await self.async_list()
+
+    def __contains__(self, key):
+        if hasattr(self, "contains"):
+            return self.contains(key)
+        else:
+            with nested_run():
+                import trio
+
+                return trio.run(self.async_contains, key)
+
+
+class AsyncV3DirectoryStore(BaseV3Store):
+    log = []
+
+    def __init__(self, key):
+        self.log.append("init")
+        self.root = pathlib.Path(key)
+
+    async def _get(self, key: Key):
+        self.log.append("get" + key)
+        path = self.root / key
+        try:
+            return path.read_bytes()
+        except FileNotFoundError:
+            raise KeyError(path)
+
+    async def _set(self, key, value):
+        self.log.append("set {} {}".format(key, value))
+        assert not key.endswith("root/.group")
+        assert value
+        path = self.root / key
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True)
+        return path.write_bytes(value)
+
+    async def async_list(self):
+        ll = []
+        for it in os.walk(self.root):
+            if os.path.sep != "/":
+                prefix = "/".join(it[0].split(os.path.sep))
+            else:
+                prefix = it[0]
+            for file in it[2]:
+                str_key = "/".join([prefix, file])[len(str(self.root)) + 1 :]
+                assert "\\" not in str_key, str_key
+                ll.append(str_key)
+        return ll
+
+    async def async_delete(self, key):
+        self.log.append("delete {}".format(key))
+        path = self.root / key
+        os.remove(path)
+
+
+@syncify
+class SyncV3DirectoryStore(AsyncV3DirectoryStore):
+    _async = False
+
+    def __getitem__(self, key):
+        assert not key.endswith("root/.group")
+        return self.get(key)
+
+
+class AsyncV3RedisStore(BaseV3Store):
+    def __init__(self, host=None, port=None):
+        """initialisation is in _async initialize
+        for early failure.
+        """
+        self.host = host
+        self.port = port
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        self.__init__()
+        from redio import Redis
+
+        self._backend = Redis("redis://localhost/")
+
+    async def async_initialize(self):
+        from redio import Redis
+
+        self._backend = Redis("redis://localhost/")
+        b = self._backend()
+        for k in await self._backend().keys():
+            b.delete(k)
+        await b
+        return self
+
+    async def _get(self, key):
+        res = await self._backend().get(key)
+        if res is None:
+            raise KeyError
+        return res
+
+    async def _set(self, key, value):
+        return await self._backend().set(key, value)
+
+    async def async_list(self):
+        return await self._backend().keys()
+
+
+@syncify
+class SyncV3RedisStore(AsyncV3RedisStore):
+    _async = False
+
+    def __setitem__(self, key, value):
+        assert ".zgroup" not in key
+        return self.set(key, value)
+
+
+class AsyncV3MemoryStore(BaseV3Store):
+    def __init__(self):
+        self._backend = dict()
+
+    async def _get(self, key):
+        return self._backend[key]
+
+    async def _set(self, key, value):
+        self._backend[key] = value
+
+    async def async_delete(self, key):
+        del self._backend[key]
+
+    async def async_list(self):
+        return list(self._backend.keys())
+
+
+@syncify
+class SyncV3MemoryStore(AsyncV3MemoryStore):
+    _async = False
+
+
+class AsyncZarrProtocolV3:
+    def __init__(self, store):
+        if isinstance(store, type):
+            self._store = store()
+        else:
+            self._store = store
+        if hasattr(self, "init_hierarchy"):
+            self.init_hierarchy()
+
+    async def async_init_hierarchy(self):
+        basic_info = {
+            "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0",
+            "metadata_encoding": "https://tools.ietf.org/html/rfc8259",
+            "extensions": [],
+        }
+        try:
+            await self._store.async_get("zarr.json")
+        except KeyError:
+            await self._store.async_set("zarr.json", json.dumps(basic_info).encode())
+
+    def _g_meta_key(self, path):
+        _assert_valid_path(path)
+        return "meta" + path + ".group"
+
+    async def async_create_group(self, group_path: str):
+        """
+        create a goup at `group_path`,
+        we need to make sure none of the subpath of group_path are arrays.
+
+        say  path is g1/g2/g3, we want to check
+
+        /meta/g1.array
+        /meta/g1/g2.array
+
+        we could also assume that protocol implementation never do that.
+        """
+        _assert_valid_path(group_path)
+        DEFAULT_GROUP = """{
+        "attributes": {
+            "spam": "ham",
+            "eggs": 42,
+        }  }
+        """
+        await self._store.async_set(
+            self._g_meta_key(group_path), DEFAULT_GROUP.encode()
+        )
+
+    def _create_array_metadata(self, shape=(10,), dtype="<f64", chunk_shape=(1,)):
+        return {
+            "shape": shape,
+            "data_type": dtype,
+            "chunk_grid": {
+                "type": "regular",
+                "chunk_shape": chunk_shape,
+                "separator": "/",
+            },
+            "chunk_memory_layout": "C",
+            "compressor": {
+                "codec": "https://none",
+                "configuration": {},
+                "fill_value": "NaN",
+            },
+            "extensions": [],
+            "attributes": {},
+        }
+
+    async def create_array(self, array_path: str):
+        """
+        create a goup at `array_path`,
+        we need to make sure none of the subpath of array_path are arrays.
+
+        say  path is g1/g2/d3, we want to check
+
+        /meta/g1.array
+        /meta/g1/g2.array
+
+        we could also assume that protocol implementation never do that.
+        """
+        _assert_valid_path(array_path)
+        DEFAULT_ARRAY = """{
+                "extensions": [],
+        "attributes": {
+            "spam": "ham",
+            "eggs": 42,
+        }  }
+        """
+        await self._store.set(self._g_meta_key(array_path), DEFAULT_ARRAY.encode())
+
+
+@syncify
+class ZarrProtocolV3(AsyncZarrProtocolV3):
+    pass
+
+
+class V2from3Adapter(MutableMapping):
+    """
+    class to wrap a 3 store and return a V2 interface
+    """
+
+    _store_version = 2
+
+    def __init__(self, v3store):
+        """
+
+        Wrapper arround a v3store to give a v2 compatible interface.
+
+        Still have some rough edges, and try to do the sensible things for
+        most case mostly key converstions so far.
+
+        Note that the V3 spec is still in flux, so this is simply a prototype
+        to see the pain points in using the spec v3 and must not be used for
+        production.
+
+
+        This will try to do the followign conversions:
+         - name of given keys `.zgroup` -> `.group` for example.
+         - path of storage (prefix with root/ meta// when relevant and vice versa.)
+         - try to ensure the stored objects are bytes before reachign the underlying store.
+         - try to adapt v2/v2 nested/flat structures
+
+        THere will ikley need to be _some_
+
+        """
+        self._v3store = v3store
+
+    def __getitem__(self, key):
+        """
+        In v2  both metadata and data are mixed so we'll need to convert things
+        that ends with .z to the metadata path.
+        """
+        assert isinstance(key, str), "expecting string got {key}".format(key=repr(key))
+        v3key = self._convert_2_to_3_keys(key)
+        if key.endswith(".zattrs"):
+            try:
+                res = self._v3store.get(v3key)
+            except KeyError:
+                v3key = v3key.replace(".array", ".group")
+        res = self._v3store.get(v3key)
+
+        assert isinstance(res, bytes)
+        if key.endswith(".zattrs"):
+            data = json.loads(res.decode())["attributes"]
+            res = json.dumps(data, indent=4).encode()
+        elif key.endswith(".zarray"):
+            data = json.loads(res.decode())
+            for target, source in RENAMED_MAP.items():
+                tmp = data[source]
+                del data[source]
+                data[target] = tmp
+            data["chunks"] = data["chunk_grid"]["chunk_shape"]
+            del data["chunk_grid"]
+
+            data["zarr_format"] = 2
+            data["filters"] = None
+            del data["extensions"]
+            del data["attributes"]
+            res = json.dumps(data, indent=4).encode()
+
+        if v3key.endswith(".group") or v3key == "zarr.json":
+            data = json.loads(res.decode())
+            data["zarr_format"] = 2
+            if data.get("attributes") is not None:
+                del data["attributes"]
+            res = json.dumps(data, indent=4).encode()
+        assert isinstance(res, bytes)
+        return res
+
+    def __setitem__(self, key, value):
+        """
+        In v2  both metadata and data are mixed so we'll need to convert things
+        that ends with .z to the metadata path.
+        """
+        # TODO convert to bytes if needed
+
+        v3key = self._convert_2_to_3_keys(key)
+        assert not key.endswith("root/.group")
+        # convert chunk separator from ``.`` to ``/``
+
+        if key.endswith(".zarray"):
+            data = json.loads(value.decode())
+            for source, target in RENAMED_MAP.items():
+                tmp = data[source]
+                del data[source]
+                data[target] = tmp
+            data["chunk_grid"] = {}
+            data["chunk_grid"]["chunk_shape"] = data["chunks"]
+            del data["chunks"]
+            data["chunk_grid"]["type"] = "rectangular"
+            data["chunk_grid"]["separator"] = "/"
+            assert data["zarr_format"] == 2
+            del data["zarr_format"]
+            assert data["filters"] in ([], None), "found filters: {}".format(
+                data["filters"]
+            )
+            del data["filters"]
+            data["extensions"] = []
+            try:
+                attrs = json.loads(self._v3store.get(v3key).decode())["attributes"]
+            except KeyError:
+                attrs = []
+            data["attributes"] = attrs
+            data = json.dumps(data, indent=4).encode()
+        elif key.endswith(".zattrs"):
+            try:
+                # try zarray first...
+                data = json.loads(self._v3store.get(v3key).decode())
+            except KeyError:
+                try:
+                    v3key = v3key.replace(".array", ".group")
+                    data = json.loads(self._v3store.get(v3key).decode())
+                except KeyError:
+                    data = {}
+            data["attributes"] = json.loads(value.decode())
+            self._v3store.set(v3key, json.dumps(data, indent=4).encode())
+            return
+        # todo: we want to keep the .zattr which i sstored in the  group/array file.
+        # so to set, we need to get from the store assign update.
+        elif v3key == "meta/root.group":
+            # todo: this is wrong, the top md document is zarr.json.
+            data = json.loads(value.decode())
+            data["zarr_format"] = "https://purl.org/zarr/spec/protocol/core/3.0"
+            data = json.dumps(data, indent=4).encode()
+        elif v3key.endswith("/.group"):
+            data = json.loads(value.decode())
+            del data["zarr_format"]
+            if "attributes" not in data:
+                data["attributes"] = {}
+            data = json.dumps(data).encode()
+        else:
+            data = value
+        assert not isinstance(data, dict)
+        self._v3store.set(v3key, ensure_bytes(data))
+
+    def __contains__(self, key):
+        return self._convert_2_to_3_keys(key) in self._v3store.list()
+
+    def _convert_3_to_2_keys(self, v3key: str) -> str:
+        """
+        todo:
+         - handle special .attribute which is merged with .zarray/.zgroup
+         - look at the grid separator
+        """
+        if v3key == "meta/root.group":
+            return ".zgroup"
+        if v3key == "meta/root.array":
+            return ".zarray"
+        suffix = v3key[10:]
+        if suffix.endswith(".array"):
+            return suffix[:-6] + ".zarray"
+        if suffix.endswith(".group"):
+            return suffix[:-6] + ".zgroup"
+        return suffix
+
+    def _convert_2_to_3_keys(self, v2key: str) -> str:
+        """
+        todo:
+         - handle special .attribute which is merged with .zarray/.zgroup
+         - look at the grid separator
+
+        """
+        # head of the hierachy is different:
+        if v2key in (".zgroup", ".zattrs"):
+            return "meta/root.group"
+        if v2key == ".zarray":
+            return "meta/root.array"
+        assert not v2key.startswith(
+            "/"
+        ), "expect keys to not start with slash but does {}".format(repr(v2key))
+        if v2key.endswith(".zarray") or v2key.endswith(".zattrs"):
+            return "meta/root/" + v2key[:-7] + ".array"
+        if v2key.endswith(".zgroup"):
+            return "meta/root/" + v2key[:-7] + ".group"
+        return "data/root/" + v2key
+
+    def __len__(self):
+        return len(self._v3store.list())
+
+    def clear(self):
+        keys = self._v3store.list()
+        for k in keys:
+            self._v3store.delete(k)
+
+    def __delitem__(self, key):
+        item3 = self._convert_2_to_3_keys(key)
+
+        items = self._v3store.list_prefix(item3)
+        if not items:
+            raise KeyError(
+                "{} not found in store (converted key to {}".format(key, item3)
+            )
+        for _item in self._v3store.list_prefix(item3):
+            self._v3store.delete(_item)
+
+    def keys(self):
+        # TODO: not as stritforward. we need to actually poke internally at
+        # .group/.array to potentially return '.zattrs' if attribute is set. it
+        # also seem in soem case zattrs is set in arrays even if the rest of the
+        # infomation is not set.
+        key = self._v3store.list()
+        fixed_paths = []
+        for p in key:
+            if p.endswith((".group", ".array")):
+                res = self._v3store.get(p)
+                if json.loads(res.decode()).get("attributes"):
+                    fixed_paths.append(p[10:-6] + ".zattrs")
+            fixed_paths.append(self._convert_3_to_2_keys(p))
+
+        return list(set(fixed_paths))
+
+    def listdir(self, path=""):
+        """
+        This_will be wrong as we also need to list meta/prefix, but need to
+        be carefull and use list-prefix in that case with the right optiosn
+        to convert the chunks separators.
+        """
+        v3path = self._convert_2_to_3_keys(path)
+        if not v3path.endswith("/"):
+            v3path = v3path + "/"
+        # if not v3path.startswith("/"):
+        #    v3path = '/'+v3path
+        ps = [p for p in self._v3store.list_dir(v3path)]
+        fixed_paths = []
+        for p in ps:
+            if p == ".group":
+                res = self._v3store.get(path + "/.group")
+                if json.loads(res.decode())["attributes"]:
+                    fixed_paths.append(".zattrs")
+            fixed_paths.append(self._convert_3_to_2_keys(p))
+
+        res = [p.split("/")[-2] for p in fixed_paths]
+        return res
+
+    def __iter__(self):
+        return iter(self.keys())

--- a/zarr/v3/comparer.py
+++ b/zarr/v3/comparer.py
@@ -1,0 +1,97 @@
+import json
+from collections.abc import MutableMapping
+
+
+class StoreComparer(MutableMapping):
+    """
+    Compare two store implementations, and make sure to do the same operation on
+    both stores.
+
+    The operation from the first store are always considered as reference and
+    the will make sure the second store will return the same value, or raise
+    the same exception where relevant.
+
+    This should have minimal impact on API, but can as some generators are
+    reified and sorted to make sure they are identical.
+    """
+
+    def __init__(self, reference, tested):
+        self.reference = reference
+        self.tested = tested
+
+    def __getitem__(self, key):
+        try:
+            k1 = self.reference[key]
+        except Exception as e1:
+            try:
+                k2 = self.tested[key]
+                assert False, "should raise, got {} for {}".format(k2, key)
+            except Exception as e2:
+                raise
+                if not isinstance(e2, type(e1)):
+                    raise AssertionError("Expecting {type(e1)} got {type(e2)}") from e2
+            raise
+        k2 = self.tested[key]
+        if key.endswith((".zgroup", ".zarray")):
+            j1, j2 = json.loads(k1.decode()), json.loads(k2.decode())
+            assert j1 == j2, "{} != {}".format(j1, j2)
+        else:
+            assert k2 == k1, "{} != {}\n missing: {},\n extra:{}".format(
+                k1, k2, k1 - k2, k2 - k1
+            )
+        return k1
+
+    def __setitem__(self, key, value):
+        # todo : not quite happy about casting here, maybe we shoudl stay strict ?
+        from numcodecs.compat import ensure_bytes
+
+        value = ensure_bytes(value)
+        try:
+            self.reference[key] = value
+        except Exception as e:
+            try:
+                self.tested[key] = value
+            except Exception as e2:
+                assert isinstance(e, type(e2))
+        try:
+            self.tested[key] = value
+        except Exception as e:
+            raise
+            assert False, "should not raise, got {}".format(e)
+
+    def keys(self):
+        try:
+            k1 = list(sorted(self.reference.keys()))
+        except Exception as e1:
+            try:
+                k2 = self.tested.keys()
+                assert False, "should raise"
+            except Exception as e2:
+                assert isinstance(e2, type(e1))
+            raise
+        k2 = sorted(self.tested.keys())
+        assert k2 == k1, "got {};\n expecting {}\n missing: {},\n extra:{}".format(
+            k1, k2, set(k1) - set(k2), set(k2) - set(k1)
+        )
+        return k1
+
+    def __delitem__(self, key):
+        try:
+            del self.reference[key]
+        except Exception as e1:
+            try:
+                del self.tested[key]
+                assert False, "should raise"
+            except Exception as e2:
+                assert isinstance(e2, type(e1))
+            raise
+        del self.tested[key]
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __contains__(self, key):
+        return key in self.reference

--- a/zarr/v3/storage.py
+++ b/zarr/v3/storage.py
@@ -1,0 +1,68 @@
+from zarr.util import normalize_storage_path
+from zarr.errors import err_contains_array, err_contains_group
+
+
+async def init_group(store, overwrite=False, path=None, chunk_store=None):
+    """Initialize a group store. Note that this is a low-level function and there should be no
+    need to call this directly from user code.
+
+    Parameters
+    ----------
+    store : MutableMapping
+        A mapping that supports string keys and byte sequence values.
+    overwrite : bool, optional
+        If True, erase all data in `store` prior to initialisation.
+    path : string, optional
+        Path under which array is stored.
+    chunk_store : MutableMapping, optional
+        Separate storage for chunks. If not provided, `store` will be used
+        for storage of both chunks and metadata.
+
+    """
+
+    # normalize path
+    path = normalize_storage_path(path)
+
+    # initialise metadata
+    _init_group_metadata(
+        store=store, overwrite=overwrite, path=path, chunk_store=chunk_store
+    )
+
+
+async def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
+
+    # guard conditions
+    if overwrite:
+        raise NotImplementedError
+        # attempt to delete any pre-existing items in store
+        rmdir(store, path)
+        if chunk_store is not None:
+            rmdir(chunk_store, path)
+    elif await contains_array(store, path):
+        err_contains_array(path)
+    elif contains_group(store, path):
+        err_contains_group(path)
+
+    # initialize metadata
+    # N.B., currently no metadata properties are needed, however there may
+    # be in future
+    meta = dict()
+    raise NotImplementedError
+    key = _path_to_prefix(path) + group_meta_key
+    store[key] = encode_group_metadata(meta)
+
+
+async def contains_array(store, path=None):
+    """Return True if the store contains an array at the given logical path."""
+    path = normalize_storage_path(path)
+    key = "meta/root" + path + ".array"
+    return key in await store.list()
+
+
+def contains_group(store, path=None):
+    """Return True if the store contains a group at the given logical path."""
+    raise NotImplementedError
+    path = normalize_storage_path(path)
+    prefix = _path_to_prefix(path)
+    key = prefix + group_meta_key
+    return key in store

--- a/zarr/v3/test_protocol.py
+++ b/zarr/v3/test_protocol.py
@@ -1,0 +1,87 @@
+import pytest
+
+from zarr.storage import init_group
+from zarr.v3 import (
+    SyncV3MemoryStore,
+    SyncV3RedisStore,
+    V2from3Adapter,
+    ZarrProtocolV3,
+    AsyncV3RedisStore,
+)
+from zarr.storage import MemoryStore
+
+
+@pytest.mark.parametrize(
+    ("store", "key"), [(SyncV3MemoryStore(), ".group"), (MemoryStore(), ".zgroup")]
+)
+def test_cover_Attribute_no_key(store, key):
+    from zarr.hierarchy import Attributes
+
+    Attributes(store, key=key)
+
+
+def test_cover_Attribute_warong_key():
+    from zarr.hierarchy import Attributes
+
+    with pytest.raises(ValueError):
+        Attributes(SyncV3MemoryStore(), key=".zattr")
+
+
+async def test_scenario():
+    pytest.importorskip("trio")
+
+    store = SyncV3MemoryStore()
+
+    await store.async_set("data/a", bytes(1))
+
+    with pytest.raises(ValueError):
+        store.get("arbitrary")
+    with pytest.raises(ValueError):
+        store.get("data")
+    with pytest.raises(ValueError):
+        store.get("meta")  # test commit
+
+    assert store.get("data/a") == bytes(1)
+    assert await store.async_get("data/a") == bytes(1)
+
+    await store.async_set("meta/this/is/nested", bytes(1))
+    await store.async_set("meta/this/is/a/group", bytes(1))
+    await store.async_set("meta/this/also/a/group", bytes(1))
+    await store.async_set("meta/thisisweird/also/a/group", bytes(1))
+
+    assert len(store.list()) == 5
+    with pytest.raises(AssertionError):
+        assert store.list_dir("meta/this")
+
+    assert set(store.list_dir("meta/this/")) == set(
+        ["meta/this/also/", "meta/this/is/"]
+    )
+    with pytest.raises(AssertionError):
+        assert await store.async_list_dir("meta/this")
+
+
+async def test_2():
+    protocol = ZarrProtocolV3(SyncV3MemoryStore)
+    store = protocol._store
+
+    await protocol.async_create_group("/g1")
+    assert isinstance(await store.async_get("meta/g1.group"), bytes)
+
+
+@pytest.mark.parametrize("klass", [SyncV3MemoryStore, SyncV3RedisStore])
+def test_misc(klass):
+
+    pytest.importorskip("redio")
+
+    _store = klass()
+    _store.initialize()
+    store = V2from3Adapter(_store)
+
+    init_group(store)
+
+    if isinstance(_store, SyncV3MemoryStore):
+        assert store._v3store._backend == {
+            "meta/root.group": b'{\n    "zarr_format": '
+            b'"https://purl.org/zarr/spec/protocol/core/3.0"\n}'
+        }
+    assert store[".zgroup"] == b'{\n    "zarr_format": 2\n}'

--- a/zarr/v3/utils.py
+++ b/zarr/v3/utils.py
@@ -1,0 +1,71 @@
+import inspect
+from contextlib import contextmanager
+
+
+@contextmanager
+def nested_run():
+    __tracebackhide__ = True
+    from trio._core._run import GLOBAL_RUN_CONTEXT
+
+    s = object()
+    task, runner, _dict = s, s, s
+    if hasattr(GLOBAL_RUN_CONTEXT, "__dict__"):
+        _dict = GLOBAL_RUN_CONTEXT.__dict__
+    if hasattr(GLOBAL_RUN_CONTEXT, "task"):
+        task = GLOBAL_RUN_CONTEXT.task
+        del GLOBAL_RUN_CONTEXT.task
+    if hasattr(GLOBAL_RUN_CONTEXT, "runner"):
+        runner = GLOBAL_RUN_CONTEXT.runner
+        del GLOBAL_RUN_CONTEXT.runner
+
+    try:
+        yield
+    finally:
+        if task is not s:
+            GLOBAL_RUN_CONTEXT.task = task
+        elif hasattr(GLOBAL_RUN_CONTEXT, "task"):
+            del GLOBAL_RUN_CONTEXT.task
+
+        if runner is not s:
+            GLOBAL_RUN_CONTEXT.runner = runner
+        elif hasattr(GLOBAL_RUN_CONTEXT, "runner"):
+            del GLOBAL_RUN_CONTEXT.runner
+
+        if _dict is not s:
+            GLOBAL_RUN_CONTEXT.__dict__.update(_dict)
+
+
+def syncify(cls, *args, **kwargs):
+
+    attrs = [c for c in dir(cls) if c.startswith("async_")]
+    for attr in attrs:
+        meth = getattr(cls, attr)
+        if inspect.iscoroutinefunction(meth):
+
+            def cl(meth):
+                def sync_version(self, *args, **kwargs):
+                    """
+                    Automatically generated synchronous  version of {attr}
+
+                    See {attr} documentation.
+                    """
+                    import trio
+
+                    __tracebackhide__ = True
+
+                    with nested_run():
+                        return trio.run(meth, self, *args)
+
+                sync_version.__doc__ = (
+                    "Automatically generated sync"
+                    "version of {}.\n\n{}".format(attr, meth.__doc__)
+                )
+                return sync_version
+
+            import types
+
+            types.MethodType
+
+            setattr(cls, attr[6:], cl(meth))
+
+    return cls


### PR DESCRIPTION
This is mostly opened to foster discussion and need code from https://github.com/Carreau/zarr-spec-v3-impl.

IN the above mentioned repository I'm working on looking at what an
implementation of the spec v3 could look to inform us on the possible
transition and compatiblity shims.

So far I have a rough implementation of an in memory v3 store as well as
multiple utilities.

1) A base class that automatically provide  sync version of all async
method of a class. I'm playing with the idea of having most method
async as this may be useful in some context.

For example when creating a array at   /a/b/c/d/e/f/g/h/i/j/k you want
to check that None of the parents are arrays, which can be done with N
async requests.

2) An adapted class that wraps a v3 store and provide a v2 API.
My though is that most code is currently v2 compatible and it would be
useful for legacy codebase and early testing of store.

3) a class that wrap 2 stores, a reference and a tested one, replicate
operation on both stores, and abort if it sees any difference in
behavior. This could help to catch changes in behavior.

The tests in this PR start to test the v3 memorystore and compare it to
the v2 memorystore.

