### PR TITLE
json dump can encode numpy data types

### DIFF
--- a/zarr/util.py
+++ b/zarr/util.py
@@ -19,10 +19,24 @@ object_codecs = {
 }
 
 
+# from
+# https://stackoverflow.com/questions/50916422/python-typeerror-object-of-type-int64-is-not-json-serializable/50916741
+class NpEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        else:
+            return super(NpEncoder, self).default(obj)
+
+
 def json_dumps(o):
     """Write JSON in a consistent, human-readable way."""
     return json.dumps(o, indent=4, sort_keys=True, ensure_ascii=True,
-                      separators=(',', ': ')).encode('ascii')
+                      separators=(',', ': '), cls=NpEncoder).encode('ascii')
 
 
 def json_loads(s):


### PR DESCRIPTION
It adds a numpy data type encoder to json_dumps in zarr/utils

All tests passed. No tests added
