### PR TITLE
docs: replace usages of "Dataset" with "Array"

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,11 +7,17 @@ Next release
 
 * Fix minor bug in `N5Store`. 
   By :user:`gsakkis`, :issue:`550`.
+
 * Improve error message in Jupyter when trying to use the ``ipytree`` widget
   without ``ipytree`` installed.
-  By :user:`Zain Patel <mzjp2>; :issue:`537`
+  By :user:`Zain Patel <mzjp2>`; :issue:`537`
+
 * Explicitly close stores during testing.
   By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`442`
+
+* Improve consistency of terminology regarding arrays and datasets in the 
+  documentation.
+  By :user:`Josh Moore <joshmoore>`; :issue:`571`.
 
 
 .. _release_2.4.0:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -863,13 +863,13 @@ Consolidating metadata
 
 Since there is a significant overhead for every connection to a cloud object
 store such as S3, the pattern described in the previous section may incur
-significant latency while scanning the metadata of the dataset hierarchy, even
+significant latency while scanning the metadata of the array hierarchy, even
 though each individual metadata object is small.  For cases such as these, once
 the data are static and can be regarded as read-only, at least for the
-metadata/structure of the dataset hierarchy, the many metadata objects can be
+metadata/structure of the array hierarchy, the many metadata objects can be
 consolidated into a single one via
 :func:`zarr.convenience.consolidate_metadata`. Doing this can greatly increase
-the speed of reading the dataset metadata, e.g.::
+the speed of reading the array metadata, e.g.::
 
    >>> zarr.consolidate_metadata(store)  # doctest: +SKIP
 
@@ -886,7 +886,7 @@ backend storage.
 
 Note that, the hierarchy could still be opened in the normal way and altered,
 causing the consolidated metadata to become out of sync with the real state of
-the dataset hierarchy. In this case,
+the array hierarchy. In this case,
 :func:`zarr.convenience.consolidate_metadata` would need to be called again.
 
 To protect against consolidated metadata accidentally getting out of sync, the
@@ -930,8 +930,8 @@ copying a group named 'foo' from an HDF5 file to a Zarr group::
              └── baz (100,) int64
     >>> source.close()
 
-If rather than copying a single group or dataset you would like to copy all
-groups and datasets, use :func:`zarr.convenience.copy_all`, e.g.::
+If rather than copying a single group or array you would like to copy all
+groups and arrays, use :func:`zarr.convenience.copy_all`, e.g.::
 
     >>> source = h5py.File('data/example.h5', mode='r')
     >>> dest = zarr.open_group('data/example2.zarr', mode='w')
@@ -1004,7 +1004,7 @@ String arrays
 There are several options for storing arrays of strings.
 
 If your strings are all ASCII strings, and you know the maximum length of the string in
-your dataset, then you can use an array with a fixed-length bytes dtype. E.g.::
+your array, then you can use an array with a fixed-length bytes dtype. E.g.::
 
     >>> z = zarr.zeros(10, dtype='S6')
     >>> z

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -746,6 +746,9 @@ class Group(MutableMapping):
     def create_dataset(self, name, **kwargs):
         """Create an array.
 
+        Arrays are known as "datasets" in HDF5 terminology. For compatibility
+        with h5py, Zarr groups also implement the require_dataset() method.
+
         Parameters
         ----------
         name : string
@@ -819,8 +822,12 @@ class Group(MutableMapping):
         return a
 
     def require_dataset(self, name, shape, dtype=None, exact=False, **kwargs):
-        """Obtain an array, creating if it doesn't exist. Other `kwargs` are
-        as per :func:`zarr.hierarchy.Group.create_dataset`.
+        """Obtain an array, creating if it doesn't exist.
+
+        Arrays are known as "datasets" in HDF5 terminology. For compatibility
+        with h5py, Zarr groups also implement the create_dataset() method.
+
+        Other `kwargs` are as per :func:`zarr.hierarchy.Group.create_dataset`.
 
         Parameters
         ----------

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1656,7 +1656,7 @@ class LMDBStore(MutableMapping):
         import lmdb
 
         # set default memory map size to something larger than the lmdb default, which is
-        # very likely to be too small for any moderate dataset (logic copied from zict)
+        # very likely to be too small for any moderate array (logic copied from zict)
         map_size = (2**40 if sys.maxsize >= 2**32 else 2**28)
         kwargs.setdefault('map_size', map_size)
 
@@ -2464,14 +2464,14 @@ class ConsolidatedMetadataStore(MutableMapping):
     a single key.
 
     The purpose of this class, is to be able to get all of the metadata for
-    a given dataset in a single read operation from the underlying storage.
+    a given array in a single read operation from the underlying storage.
     See :func:`zarr.convenience.consolidate_metadata` for how to create this
     single metadata key.
 
     This class loads from the one key, and stores the data in a dict, so that
     accessing the keys no longer requires operations on the backend store.
 
-    This class is read-only, and attempts to change the dataset metadata will
+    This class is read-only, and attempts to change the array metadata will
     fail, but changing the data is possible. If the backend storage is changed
     directly, then the metadata stored here could become obsolete, and
     :func:`zarr.convenience.consolidate_metadata` should be called again and the class
@@ -2484,7 +2484,7 @@ class ConsolidatedMetadataStore(MutableMapping):
     Parameters
     ----------
     store: MutableMapping
-        Containing the zarr dataset.
+        Containing the zarr array.
     metadata_key: str
         The target in the store where all of the metadata are stored. We
         assume JSON encoding.

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -54,7 +54,7 @@ CHUNK_MAX = 64*1024*1024  # Hard upper limit
 
 def guess_chunks(shape, typesize):
     """
-    Guess an appropriate chunk layout for a dataset, given its shape and
+    Guess an appropriate chunk layout for an array, given its shape and
     the size of each element in bytes.  Will allocate chunks only as large
     as MAX_SIZE.  Chunks are generally close to some power-of-2 fraction of
     each axis, slightly favoring bigger values for the last index.


### PR DESCRIPTION
As discussed during the last community call, a non-HDF5 user recently explained their confusion to me over the term "dataset" in `create_dataset`. @alimanfoo explained that this was intended for compatibility with h5py. I've added that explanation (copied from the tutorial) to the individual method blocks, and updated the few other non-HDF5 uses of "Dataset" that  I could find. The remaining uses all appear to be intentional:

```
(base) ~/opt/zarr $git grep dataset | grep -v create_dataset | grep -v require_dataset
docs/release.rst:  metadata keys within a dataset hierarchy under a single key, and
docs/talks/scipy2019/submission.rst:of datasets. Key design goals include: a simple protocol and format
docs/talks/scipy2019/submission.rst:satellite observation datasets to Zarr [6_], and have demonstrated
docs/tutorial.rst:Arrays are known as "datasets" in HDF5 terminology. For compatibility with h5py,
docs/tutorial.rst:indexing capabilities available on NumPy arrays and on h5py datasets, **the Zarr
notebooks/advanced_indexing.ipynb:       "<HDF5 dataset \"c\": shape (100000000,), type \"<i8\">"
notebooks/dask_2d_subset.ipynb:    "# create a synthetic dataset for profiling\n",
notebooks/dask_copy.ipynb:    "    \"\"\"Print some diagnostics on an HDF5 dataset.\"\"\"\n",
notebooks/dask_copy.ipynb:    "## HDF5 datasets (in-memory)"
notebooks/dask_copy.ipynb:      "<HDF5 dataset \"h1\": shape (200000000,), type \"<u2\">\n",
notebooks/dask_copy.ipynb:      "<HDF5 dataset \"h2\": shape (200000000,), type \"<f4\">\n",
notebooks/dask_count_alleles.ipynb:       "<HDF5 dataset \"genotype\": shape (13167162, 765, 2), type \"|i1\">"
notebooks/genotype_benchmark_compressors.ipynb:       "<HDF5 dataset \"genotype\": shape (13167162, 765, 2), type \"|i1\">"
zarr/convenience.py:    source : group or array/dataset
zarr/convenience.py:        A zarr group or array, or an h5py group or dataset.
zarr/convenience.py:        # copy a dataset/array
zarr/convenience.py:                # create new dataset in destination
zarr/convenience.py:    source : group or array/dataset
zarr/convenience.py:        A zarr group or array, or an h5py group or dataset.
zarr/convenience.py:        array/dataset.
zarr/hierarchy.py:        Arrays are known as "datasets" in HDF5 terminology. For compatibility
zarr/hierarchy.py:        Arrays are known as "datasets" in HDF5 terminology. For compatibility
zarr/n5.py:            # group if not a dataset (attributes do not contain 'dimensions')
zarr/n5.py:            "might not be able to open the dataset with another N5 library.",
zarr/n5.py:                "might not be able to open the dataset with another N5 library.",
(base) ~/opt/zarr $git diff
```