### PR TITLE
Try to converge on internal types consistency.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -5,6 +5,11 @@ Release notes
 Next release
 ------------
 
+* For consistency across stores, the `ConsolidatedMetadataStore` will return
+  bytes instead of objects for metadata. Internally zarr tries to be more type
+  stable and attempt to always pass bytes-likes object when storing objects on
+  stores.
+
 * Fix minor bug in `N5Store`. 
   By :user:`gsakkis`, :issue:`550`.
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1489,7 +1489,7 @@ class Array(object):
             chunk[selection] = value
 
         # encode and store
-        cdata = self._encode_chunk(chunk)
+        cdata = ensure_bytes(self._encode_chunk(chunk))
         self.chunk_store[ckey] = cdata
 
     def _set_basic_selection_nd(self, selection, value, fields=None):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -44,7 +44,7 @@ from zarr.errors import (MetadataError, err_bad_compressor, err_contains_array,
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.util import (buffer_size, json_loads, nolock, normalize_chunks,
                        normalize_dtype, normalize_fill_value, normalize_order,
-                       normalize_shape, normalize_storage_path)
+                       normalize_shape, normalize_storage_path, json_dumps)
 
 __doctest_requires__ = {
     ('RedisStore', 'RedisStore.*'): ['redis'],
@@ -2479,6 +2479,10 @@ class ConsolidatedMetadataStore(MutableMapping):
 
     .. versionadded:: 2.3
 
+    .. versionchanged:: 2.5
+
+        __getitem__ will now return bytes for metadata for consistency across stores.
+
     .. note:: This is an experimental feature.
 
     Parameters
@@ -2507,7 +2511,9 @@ class ConsolidatedMetadataStore(MutableMapping):
                                 consolidated_format)
 
         # decode metadata
-        self.meta_store = meta['metadata']
+        self.meta_store = {}
+        for k, v in meta["metadata"].items():
+            self.meta_store[k] = json_dumps(v)
 
     def __getitem__(self, key):
         return self.meta_store[key]

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -697,12 +697,6 @@ class TestCopy(unittest.TestCase):
             copy(source['foo'], dest, dry_run=True, log=True)
 
 
-try:
-    import h5py
-except ImportError:  # pragma: no cover
-    h5py = None
-
-
 def temp_h5f():
     h5py = pytest.importorskip("h5py")
     fn = tempfile.mktemp()

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -424,15 +424,15 @@ def test_encode_decode_dtype():
 def test_decode_group():
 
     # typical
-    b = '''{
+    b = b'''{
         "zarr_format": %s
-    }''' % ZARR_FORMAT
+    }''' % str(ZARR_FORMAT).encode()
     meta = decode_group_metadata(b)
     assert ZARR_FORMAT == meta['zarr_format']
 
     # unsupported format
-    b = '''{
+    b = b'''{
         "zarr_format": %s
-    }''' % (ZARR_FORMAT - 1)
+    }''' % str(ZARR_FORMAT - 1).encode()
     with pytest.raises(MetadataError):
         decode_group_metadata(b)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -30,6 +30,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.tests.util import CountingDict, skip_test_env_var
+from zarr.util import json_dumps
 
 
 @contextmanager
@@ -1627,11 +1628,26 @@ class TestConsolidatedMetadataStore(unittest.TestCase):
         # setup store with consolidated metdata
         store = dict()
         consolidated = {
-            'zarr_consolidated_format': 1,
-            'metadata': {
-                'foo': 'bar',
-                'baz': 42,
-            }
+            "zarr_consolidated_format": 1,
+            "metadata": {
+                ".zgroup": {"zarr_format": 2},
+                "g2/arr/.zarray": {
+                    "chunks": [5, 5],
+                    "compressor": {
+                        "blocksize": 0,
+                        "clevel": 5,
+                        "cname": "lz4",
+                        "id": "blosc",
+                        "shuffle": 1,
+                    },
+                    "dtype": "<f8",
+                    "fill_value": 0.0,
+                    "filters": None,
+                    "order": "C",
+                    "shape": [20, 20],
+                    "zarr_format": 2,
+                },
+            },
         }
         store['.zmetadata'] = json.dumps(consolidated).encode()
 
@@ -1641,7 +1657,7 @@ class TestConsolidatedMetadataStore(unittest.TestCase):
         # test __contains__, __getitem__
         for key, value in consolidated['metadata'].items():
             assert key in cs
-            assert value == cs[key]
+            assert json_dumps(value) == cs[key]
 
         # test __delitem__, __setitem__
         with pytest.raises(PermissionError):


### PR DESCRIPTION
While it is convenient for user on high level API to be able to pass
arround many types (array, bytes, or even dictionary, list, strings),
It can make it relatively hard to follow internally if the types are not
consistant.

In particular this can relatively complicate weaving the v3 spec into
the core of Zarr and add a number of conditional if we are not sure of
the type we get.

This try to be a little more consistent in what the implementation
_emits_ right now this try to make sure that all the core only try to
converge toward bytes, so that store users can expect to alway get bytes
back from Zarr-Python stores, and as much as possible give bytes back,
and mostly affects the ConsolidatedMetadataStore which used to – unlike
other store – return objects instead of bytes, as well as the tests
directly testing the stores.

We of course can't be too strict as some existing store may have stored
some values as not-bytes (pickle), and we still want to support this for
the time being,but with this changes, we can add many `assert
isinstance(x, bytes_like)` in many places ans still have the test suite
to pass.

In particular in all the decode/encode metadata functions, and Group
class.

One extra change in test is the removal of an old conditional import of
h5py in the test suite which is unnecessary since introduction of the
pytest's `importorskip` for h5py tests.

[Description of PR]

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
