### PR TITLE
enable arbitrary compressors for N5Store

### DIFF
--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -404,7 +404,6 @@ def compressor_config_to_n5(compressor_config):
         compressor_config = compressor_config['compressor_config']
 
     codec_id = compressor_config['id']
-    compressor_config.pop('id')
     n5_config = {'type': codec_id}
 
     if codec_id == 'bz2':
@@ -461,7 +460,7 @@ def compressor_config_to_n5(compressor_config):
 
     else:  # pragma: no cover
 
-        n5_config.update(compressor_config)
+        n5_config.update({k: v for k,v in compressor_config.items() if k != 'type'})
 
     return n5_config
 
@@ -469,7 +468,6 @@ def compressor_config_to_n5(compressor_config):
 def compressor_config_to_zarr(compressor_config):
 
     codec_id = compressor_config['type']
-    compressor_config.pop('type')
     zarr_config = {'id': codec_id}
 
     if codec_id == 'bzip2':
@@ -514,7 +512,7 @@ def compressor_config_to_zarr(compressor_config):
 
     else:  # pragma: no cover
 
-        zarr_config.update(compressor_config)
+        zarr_config.update({k: v for k,v in compressor_config.items() if k != 'type'})
 
     return zarr_config
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -404,6 +404,7 @@ def compressor_config_to_n5(compressor_config):
         compressor_config = compressor_config['compressor_config']
 
     codec_id = compressor_config['id']
+    compressor_config.pop('id')
     n5_config = {'type': codec_id}
 
     if codec_id == 'bz2':
@@ -460,7 +461,7 @@ def compressor_config_to_n5(compressor_config):
 
     else:  # pragma: no cover
 
-        raise RuntimeError("Unknown compressor with id %s" % codec_id)
+        n5_config.update(compressor_config)
 
     return n5_config
 
@@ -512,6 +513,7 @@ def compressor_config_to_zarr(compressor_config):
         return None
 
     else:  # pragma: no cover
+
         zarr_config.update(compressor_config)
         
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -468,6 +468,7 @@ def compressor_config_to_n5(compressor_config):
 def compressor_config_to_zarr(compressor_config):
 
     codec_id = compressor_config['type']
+    compressor_config.pop('type')
     zarr_config = {'id': codec_id}
 
     if codec_id == 'bzip2':
@@ -511,8 +512,8 @@ def compressor_config_to_zarr(compressor_config):
         return None
 
     else:  # pragma: no cover
-
-        raise RuntimeError("Unknown compressor with id %s" % codec_id)
+        zarr_config.update(compressor_config)
+        
 
     return zarr_config
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -515,7 +515,6 @@ def compressor_config_to_zarr(compressor_config):
     else:  # pragma: no cover
 
         zarr_config.update(compressor_config)
-        
 
     return zarr_config
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -460,7 +460,7 @@ def compressor_config_to_n5(compressor_config):
 
     else:  # pragma: no cover
 
-        n5_config.update({k: v for k,v in compressor_config.items() if k != 'type'})
+        n5_config.update({k: v for k, v in compressor_config.items() if k != 'type'})
 
     return n5_config
 
@@ -512,7 +512,7 @@ def compressor_config_to_zarr(compressor_config):
 
     else:  # pragma: no cover
 
-        zarr_config.update({k: v for k,v in compressor_config.items() if k != 'type'})
+        zarr_config.update({k: v for k, v in compressor_config.items() if k != 'type'})
 
     return zarr_config
 


### PR DESCRIPTION
We are interested in using lossy jpeg compression for 2D / 3D uint8 data. A java implementation of this exists for n5: https://github.com/saalfeldlab/n5-jpeg, but zarr cannot decode these chunks because `jpeg` is not in the list of hard-coded compressors in `zarr/n5.py` . Because this jpeg compression is specialized to the point of being a hack, it doesn't make sense to add it to the list of hard-coded compressors. Instead, this PR enables reading/writing an `N5Store` with an arbitrary compressor.   

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
