### PR TITLE
Make metadata parameter mandatory in encode_group_metadata

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -20,6 +20,9 @@ Next release
   By :user:`Josh Moore <joshmoore>`; :issue:`571`.
 
 
+* ``encode_group_metadata`` metadata parameter is now mandatory.
+
+
 .. _release_2.4.0:
 
 2.4.0

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -106,12 +106,8 @@ def decode_group_metadata(s):
     return meta
 
 
-# N.B., keep `meta` parameter as a placeholder for future
-# noinspection PyUnusedLocal
-def encode_group_metadata(meta=None):
-    meta = dict(
-        zarr_format=ZARR_FORMAT,
-    )
+def encode_group_metadata(meta):
+    meta["zarr_format"] = ZARR_FORMAT
     return json_dumps(meta)
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -499,7 +499,7 @@ class StoreTests(object):
         # setup
         path = 'foo/bar'
         store = self.create_store()
-        store[path + '/' + group_meta_key] = encode_group_metadata()
+        store[path + "/" + group_meta_key] = encode_group_metadata({})
 
         # don't overwrite
         with pytest.raises(ValueError):


### PR DESCRIPTION
This will make it a little less magical and will make it a tiny bit more
consistant with v3.

[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
