### PR TITLE
Use Error subclasses instead of functions.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,6 +15,10 @@ Next release
 * Explicitly close stores during testing.
   By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`442`
 
+* Many of the convenience functions to emit errors (``err_*`` from
+  ``zarr.errors``  have been replaced by ``ValueError`` subclasses. The
+  functions are deprecated and will be removed in the future. :issue:`590` )
+
 * Improve consistency of terminology regarding arrays and datasets in the 
   documentation.
   By :user:`Josh Moore <joshmoore>`; :issue:`571`.

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from zarr.core import Array
 from zarr.creation import array as _create_array
 from zarr.creation import normalize_store_arg, open_array
-from zarr.errors import CopyError, err_path_not_found
+from zarr.errors import CopyError, PathNotFoundError
 from zarr.hierarchy import Group
 from zarr.hierarchy import group as _create_group
 from zarr.hierarchy import open_group
@@ -99,7 +99,7 @@ def open(store=None, mode='a', **kwargs):
         elif contains_group(store, path):
             return open_group(store, mode=mode, **kwargs)
         else:
-            err_path_not_found(path)
+            raise PathNotFoundError(path)
 
 
 def save_array(store, arr, **kwargs):

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -12,7 +12,7 @@ from numcodecs.compat import ensure_bytes, ensure_ndarray
 
 from zarr.attrs import Attributes
 from zarr.codecs import AsType, get_codec
-from zarr.errors import err_array_not_found, err_read_only
+from zarr.errors import ArrayNotFoundError, ReadOnlyError
 from zarr.indexing import (BasicIndexer, CoordinateIndexer, MaskIndexer,
                            OIndex, OrthogonalIndexer, VIndex, check_fields,
                            check_no_multi_fields, ensure_tuple,
@@ -149,7 +149,7 @@ class Array(object):
             mkey = self._key_prefix + array_meta_key
             meta_bytes = self._store[mkey]
         except KeyError:
-            err_array_not_found(self._path)
+            raise ArrayNotFoundError(self._path)
         else:
 
             # decode and store metadata as instance members
@@ -1197,7 +1197,7 @@ class Array(object):
 
         # guard conditions
         if self._read_only:
-            err_read_only()
+            raise ReadOnlyError()
 
         # refresh metadata
         if not self._cache_metadata:
@@ -1288,7 +1288,7 @@ class Array(object):
 
         # guard conditions
         if self._read_only:
-            err_read_only()
+            raise ReadOnlyError()
 
         # refresh metadata
         if not self._cache_metadata:
@@ -1360,7 +1360,7 @@ class Array(object):
 
         # guard conditions
         if self._read_only:
-            err_read_only()
+            raise ReadOnlyError()
 
         # refresh metadata
         if not self._cache_metadata:
@@ -1441,7 +1441,7 @@ class Array(object):
 
         # guard conditions
         if self._read_only:
-            err_read_only()
+            raise ReadOnlyError()
 
         # refresh metadata
         if not self._cache_metadata:
@@ -1966,7 +1966,7 @@ class Array(object):
 
         # guard condition
         if self._read_only:
-            err_read_only()
+            raise ReadOnlyError()
 
         return self._synchronized_op(f, *args, **kwargs)
 

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -5,8 +5,11 @@ import numpy as np
 from numcodecs.registry import codec_registry
 
 from zarr.core import Array
-from zarr.errors import (err_array_not_found, err_contains_array,
-                         err_contains_group)
+from zarr.errors import (
+    ArrayNotFoundError,
+    ContainsArrayError,
+    ContainsGroupError,
+)
 from zarr.n5 import N5Store
 from zarr.storage import (DirectoryStore, ZipStore, contains_array,
                           contains_group, default_compressor, init_array,
@@ -460,9 +463,9 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
 
     if mode in ['r', 'r+']:
         if contains_group(store, path=path):
-            err_contains_group(path)
+            raise ContainsGroupError(path)
         elif not contains_array(store, path=path):
-            err_array_not_found(path)
+            raise ArrayNotFoundError(path)
 
     elif mode == 'w':
         init_array(store, shape=shape, chunks=chunks, dtype=dtype,
@@ -472,7 +475,7 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
 
     elif mode == 'a':
         if contains_group(store, path=path):
-            err_contains_group(path)
+            raise ContainsGroupError(path)
         elif not contains_array(store, path=path):
             init_array(store, shape=shape, chunks=chunks, dtype=dtype,
                        compressor=compressor, fill_value=fill_value,
@@ -481,9 +484,9 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
 
     elif mode in ['w-', 'x']:
         if contains_group(store, path=path):
-            err_contains_group(path)
+            raise ContainsGroupError(path)
         elif contains_array(store, path=path):
-            err_contains_array(path)
+            raise ContainsArrayError(path)
         else:
             init_array(store, shape=shape, chunks=chunks, dtype=dtype,
                        compressor=compressor, fill_value=fill_value,

--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -9,24 +9,51 @@ class CopyError(RuntimeError):
     pass
 
 
+class _BaseZarrError(ValueError):
+    _msg = ""
+
+    def __init__(self, *args):
+        super().__init__(self._msg.format(*args))
+
+
+class ContainsGroupError(_BaseZarrError):
+    _msg = "path {0!r} contains a group"
+
+
 def err_contains_group(path):
-    raise ValueError('path %r contains a group' % path)
+    raise ContainsGroupError(path)  # pragma: no cover
+
+
+class ContainsArrayError(_BaseZarrError):
+    _msg = "path {0!r} contains an array"
 
 
 def err_contains_array(path):
-    raise ValueError('path %r contains an array' % path)
+    raise ContainsArrayError(path)  # pragma: no cover
+
+
+class ArrayNotFoundError(_BaseZarrError):
+    _msg = "array not found at path %r' {0!r}"
 
 
 def err_array_not_found(path):
-    raise ValueError('array not found at path %r' % path)
+    raise ArrayNotFoundError(path)  # pragma: no cover
+
+
+class GroupNotFoundError(_BaseZarrError):
+    _msg = "group not found at path {0!r}"
 
 
 def err_group_not_found(path):
-    raise ValueError('group not found at path %r' % path)
+    raise GroupNotFoundError(path)  # pragma: no cover
+
+
+class PathNotFoundError(_BaseZarrError):
+    _msg = "nothing found at path {0!r}"
 
 
 def err_path_not_found(path):
-    raise ValueError('nothing found at path %r' % path)
+    raise PathNotFoundError(path)  # pragma: no cover
 
 
 def err_bad_compressor(compressor):
@@ -34,12 +61,17 @@ def err_bad_compressor(compressor):
                      compressor)
 
 
-def err_fspath_exists_notdir(fspath):
-    raise ValueError('path exists but is not a directory: %r' % fspath)
+class FSPathExistNotDir(GroupNotFoundError):
+    _msg = "path exists but is not a directory: %r"
+
+
+class ReadOnlyError(PermissionError):
+    def __init__(self):
+        super().__init__("object is read-only")
 
 
 def err_read_only():
-    raise PermissionError('object is read-only')
+    raise ReadOnlyError()  # pragma: no cover
 
 
 def err_boundscheck(dim_len):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -38,9 +38,14 @@ import time
 from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
 from numcodecs.registry import codec_registry
 
-from zarr.errors import (MetadataError, err_bad_compressor, err_contains_array,
-                         err_contains_group, err_fspath_exists_notdir,
-                         err_read_only)
+from zarr.errors import (
+    MetadataError,
+    err_bad_compressor,
+    ContainsArrayError,
+    ContainsGroupError,
+    FSPathExistNotDir,
+    ReadOnlyError,
+)
 from zarr.meta import encode_array_metadata, encode_group_metadata
 from zarr.util import (buffer_size, json_loads, nolock, normalize_chunks,
                        normalize_dtype, normalize_fill_value, normalize_order,
@@ -335,9 +340,9 @@ def _init_array_metadata(store, shape, chunks=None, dtype=None, compressor='defa
         if chunk_store is not None:
             rmdir(chunk_store, path)
     elif contains_array(store, path):
-        err_contains_array(path)
+        raise ContainsArrayError(path)
     elif contains_group(store, path):
-        err_contains_group(path)
+        raise ContainsGroupError(path)
 
     # normalize metadata
     dtype, object_codec = normalize_dtype(dtype, object_codec)
@@ -442,9 +447,9 @@ def _init_group_metadata(store, overwrite=False, path=None, chunk_store=None):
         if chunk_store is not None:
             rmdir(chunk_store, path)
     elif contains_array(store, path):
-        err_contains_array(path)
+        raise ContainsArrayError(path)
     elif contains_group(store, path):
-        err_contains_group(path)
+        raise ContainsGroupError(path)
 
     # initialize metadata
     # N.B., currently no metadata properties are needed, however there may
@@ -730,7 +735,7 @@ class DirectoryStore(MutableMapping):
         # guard conditions
         path = os.path.abspath(path)
         if os.path.exists(path) and not os.path.isdir(path):
-            err_fspath_exists_notdir(path)
+            raise FSPathExistNotDir(path)
 
         self.path = path
         self.normalize_keys = normalize_keys
@@ -973,7 +978,7 @@ class FSStore(MutableMapping):
         self.mode = mode
         self.exceptions = exceptions
         if self.fs.exists(url) and not self.fs.isdir(url):
-            err_fspath_exists_notdir(url)
+            raise FSPathExistNotDir(url)
 
     def _normalize_key(self, key):
         key = normalize_storage_path(key).lstrip('/')
@@ -991,7 +996,7 @@ class FSStore(MutableMapping):
 
     def __setitem__(self, key, value):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         key = self._normalize_key(key)
         path = self.dir_path(key)
         value = ensure_contiguous_ndarray(value)
@@ -1004,7 +1009,7 @@ class FSStore(MutableMapping):
 
     def __delitem__(self, key):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         key = self._normalize_key(key)
         path = self.dir_path(key)
         if self.fs.isdir(path):
@@ -1044,7 +1049,7 @@ class FSStore(MutableMapping):
 
     def rmdir(self, path=None):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         store_path = self.dir_path(path)
         if self.fs.isdir(store_path):
             self.fs.rm(store_path, recursive=True)
@@ -1055,7 +1060,7 @@ class FSStore(MutableMapping):
 
     def clear(self):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         self.map.clear()
 
 
@@ -1365,7 +1370,7 @@ class ZipStore(MutableMapping):
 
     def __setitem__(self, key, value):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         value = ensure_contiguous_ndarray(value)
         with self.mutex:
             # writestr(key, value) writes with default permissions from
@@ -1449,7 +1454,7 @@ class ZipStore(MutableMapping):
 
     def clear(self):
         if self.mode == 'r':
-            err_read_only()
+            raise ReadOnlyError()
         with self.mutex:
             self.close()
             os.remove(self.path)
@@ -2635,10 +2640,10 @@ class ConsolidatedMetadataStore(MutableMapping):
         return len(self.meta_store)
 
     def __delitem__(self, key):
-        err_read_only()
+        raise ReadOnlyError()
 
     def __setitem__(self, key, value):
-        err_read_only()
+        raise ReadOnlyError()
 
     def getsize(self, path):
         return getsize(self.meta_store, path)


### PR DESCRIPTION
I believe this has several advantage:

  1) reading the code it is obvious we are directly raising instead of
  doing more stuff.

  2) in traceback the last frame will be correct, so it's easier to find
  where the error occurs.

  3) All of these are now subclasses which can be caught independently
  by libraries while still being subclass of ValueError, so backward
  compatible. Can be caught without catching other ValueErrors.

  4) the name of the class is descriptive

I'm not too sure about some naming. Is ContainsXxxxError sufficient to
understand that it contain Xxxxx but Xxxx was not expected ?



TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)


I'm not too sure if I should remove the err_ function, as they may be public APIs.
Thus the coverage will decrease; 

if you are +1 on this approach I'll do the few remaining and update the docs. 
