### PR TITLE
Pass mode paramter to open_group enabling creation of new ZipStores

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -12,6 +12,10 @@ Next release
   without ``ipytree`` installed.
   By :user:`Zain Patel <mzjp2>`; :issue:`537`
 
+* ``mode`` parameter used in ``open_group`` is now passed along to ZipStore
+  creation.
+  By :user:`Mark Harfouche <hmaarrfk>`;
+
 * Explicitly close stores during testing.
   By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`442`
 

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -127,12 +127,13 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     return z
 
 
-def normalize_store_arg(store, clobber=False, default=dict):
+def normalize_store_arg(store, clobber=False, default=dict, mode=None):
     if store is None:
         return default()
     elif isinstance(store, str):
         if store.endswith('.zip'):
-            mode = 'w' if clobber else 'r'
+            if mode is None:
+                mode = 'w' if clobber else 'r'
             return ZipStore(store, mode=mode)
         elif store.endswith('.n5'):
             return N5Store(store)

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1032,8 +1032,9 @@ class Group(MutableMapping):
         self._write_op(self._move_nosync, source, dest)
 
 
-def _normalize_store_arg(store, clobber=False):
-    return normalize_store_arg(store, clobber=clobber, default=MemoryStore)
+def _normalize_store_arg(store, clobber=False, mode=None):
+    return normalize_store_arg(store, clobber=clobber, default=MemoryStore,
+                               mode=mode)
 
 
 def group(store=None, overwrite=False, chunk_store=None,
@@ -1139,9 +1140,9 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     """
 
     # handle polymorphic store arg
-    store = _normalize_store_arg(store)
+    store = _normalize_store_arg(store, mode=mode)
     if chunk_store is not None:
-        chunk_store = _normalize_store_arg(chunk_store)
+        chunk_store = _normalize_store_arg(chunk_store, mode=mode)
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -15,7 +15,7 @@ from zarr.creation import (array, create, empty, empty_like, full, full_like,
                            zeros_like)
 from zarr.hierarchy import open_group
 from zarr.n5 import N5Store
-from zarr.storage import DirectoryStore
+from zarr.storage import DirectoryStore, ZipStore
 from zarr.sync import ThreadSynchronizer
 
 
@@ -252,6 +252,13 @@ def test_open_array():
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
+
+
+def test_open_new_group_zip_store():
+    store = 'data/array.zarr.zip'
+    z = open_group(store, mode='w')
+    assert isinstance(z.store, ZipStore)
+    z.store.close()
 
 
 def test_empty_like():


### PR DESCRIPTION
The mode parameter was ignored in the case of ZipStores because it wasn't passed along to the normalize function.

Is there a way to add notes to the changelog?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
