### PR TITLE
Set stacklevel on warning for proper issue pinpointing.

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -149,12 +149,18 @@ def _kwargs_compat(compressor, fill_value, kwargs):
 
     if compressor != 'default':
         # 'compressor' overrides 'compression'
-        if 'compression' in kwargs:
-            warn("'compression' keyword argument overridden by 'compressor'")
-            del kwargs['compression']
-        if 'compression_opts' in kwargs:
-            warn("'compression_opts' keyword argument overridden by 'compressor'")
-            del kwargs['compression_opts']
+        if "compression" in kwargs:
+            warn(
+                "'compression' keyword argument overridden by 'compressor'",
+                stacklevel=3,
+            )
+            del kwargs["compression"]
+        if "compression_opts" in kwargs:
+            warn(
+                "'compression_opts' keyword argument overridden by 'compressor'",
+                stacklevel=3,
+            )
+            del kwargs["compression_opts"]
 
     elif 'compression' in kwargs:
         compression = kwargs.pop('compression')


### PR DESCRIPTION
without the stacklevel the warning point to the frame where the warnign
is issued. In this case we likely want to be at least two callers up as
we want to see the caller of `create` or `open_array`.


* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
