### PR TITLE
End support for EOL python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ services:
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
       env: BUILD_DOCS='true'
     - python: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,6 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5"
-
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -7,6 +7,8 @@ Next Release
 
 This release will be the first release of Zarr not supporting Python 3.5.
 
+* End Python 3.5 support.
+  By :user:`Chris Barnes <clbarnes>`; :issue:`602`.
 
 2.5.0
 -----
@@ -20,7 +22,7 @@ This release will be the last to support Python 3.5, next version of Zarr will b
 * Remove a few remaining Python 2-isms.
   By :user:`Poruri Sai Rahul <rahulporuri>`; :issue:`393`.
 
-* Fix minor bug in `N5Store`. 
+* Fix minor bug in `N5Store`.
   By :user:`gsakkis`, :issue:`550`.
 
 * Improve error message in Jupyter when trying to use the ``ipytree`` widget

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import sys
-
 from setuptools import setup
 
 DESCRIPTION = 'An implementation of chunked, compressed, ' \
@@ -35,7 +33,7 @@ setup(
             'ipytree',
         ],
     },
-    python_requires='>=3.5',
+    python_requires='>=3.6, <4',
     install_requires=dependencies,
     package_dir={'': '.'},
     packages=['zarr', 'zarr.tests'],
@@ -49,7 +47,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37-npy{115,116,latest}, py38, docs
+envlist = py36, py37-npy{115,116,latest}, py38, docs
 
 [testenv]
 install_command = pip install --no-binary=numcodecs {opts} {packages}


### PR DESCRIPTION
Remove references to 3.5 from CI and test configuration, setup.py, and tox, as per #602

Note that the ipython notebooks seem to have been run against 3.5; we should consider running them against 3.8 and check them in again to future-proof us a little longer.


Strictly, 3.5 only becomes EOL 2020-09-13, so take the weekend ;) As stated in https://github.com/zarr-developers/governance/issues/11 it may be worth putting out a final patch version supporting 3.5 before this goes in.
