### PR TITLE
Reactivate travis on all branches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-branches:
-  only:
-    - master
-
 sudo: false
 
 addons:


### PR DESCRIPTION
limiting only to master means that forks do not run tests except on
master.

This was presumably done originally as development of feature branches
and stable were on the same repo, as everyone is going through PRs this
seem unnecesasry now.