### PR TITLE
Numpydoc consistency.

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -743,7 +743,7 @@ class DirectoryStore(MutableMapping):
 
         Parameters
         ----------
-        fn: str
+        fn : str
             Filepath to open and read from.
 
         Notes
@@ -759,10 +759,9 @@ class DirectoryStore(MutableMapping):
 
         Parameters
         ----------
-        a: array-like
+        a : array-like
             Data to write into the file.
-
-        fn: str
+        fn : str
             Filepath to open and write to.
 
         Notes


### PR DESCRIPTION
Numpydoc expect space on each side of the colon, on it may mis-parse
what this actually means.