### PR TITLE
Bump numpy version in requirements_dev.

### DIFF
--- a/requirements_dev_numpy.txt
+++ b/requirements_dev_numpy.txt
@@ -1,6 +1,7 @@
 # Break this out into a separate file to allow testing against
 # different versions of numpy. This file should pin to the latest
 # numpy version.
-numpy==1.19.2; python_version > '3.0'
+numpy==1.19.2; python_version >= '3.6'
+numpy==1.17.2; python_version < '3.6'
 # don't let pyup change this, needed until we drop support for py27
 numpy==1.16.4; python_version < '3.0' # pyup: ignore

--- a/requirements_dev_numpy.txt
+++ b/requirements_dev_numpy.txt
@@ -1,6 +1,6 @@
 # Break this out into a separate file to allow testing against
 # different versions of numpy. This file should pin to the latest
 # numpy version.
-numpy==1.17.2; python_version > '3.0'
+numpy==1.19.2; python_version > '3.0'
 # don't let pyup change this, needed until we drop support for py27
 numpy==1.16.4; python_version < '3.0' # pyup: ignore


### PR DESCRIPTION
The comment in the file suggest that the numpy version should be the
latest one, it is not.

This would help to make sure that there is no regression in numpy,
and/or that the test suite would catch numpy deprecated functionality.


* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
