### PR TITLE
Remove requirements for Python 2.7

### DIFF
--- a/requirements_dev_minimal.txt
+++ b/requirements_dev_minimal.txt
@@ -6,5 +6,3 @@ msgpack-python==0.5.6
 setuptools-scm==3.3.3
 # test requirements
 pytest==5.2.0; python_version > '3.0'
-# don't let pyup change this, needed until we drop support for py27
-pytest==4.6.5; python_version < '3.0' # pyup: ignore

--- a/requirements_dev_numpy.txt
+++ b/requirements_dev_numpy.txt
@@ -2,5 +2,3 @@
 # different versions of numpy. This file should pin to the latest
 # numpy version.
 numpy==1.17.2; python_version > '3.0'
-# don't let pyup change this, needed until we drop support for py27
-numpy==1.16.4; python_version < '3.0' # pyup: ignore


### PR DESCRIPTION
cleanup py27 requirement no longer necessary.
