### PR TITLE
Reduce number of store queries in open(mode='a').

### DIFF
--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -83,12 +83,8 @@ def open(store=None, mode='a', **kwargs):
         else:
             return open_group(store, mode=mode, **kwargs)
 
-    elif mode == 'a':
-        if contains_array(store, path):
-            return open_array(store, mode=mode, **kwargs)
-        elif contains_group(store, path):
-            return open_group(store, mode=mode, **kwargs)
-        elif 'shape' in kwargs:
+    elif mode == "a":
+        if "shape" in kwargs or contains_array(store, path):
             return open_array(store, mode=mode, **kwargs)
         else:
             return open_group(store, mode=mode, **kwargs)


### PR DESCRIPTION
In case where 'shape' is passed as argument, this will avoid calling
"contains_array" which does store queries, as well as avoid testign if
the array contains a group as anyway this is what we were going to do in
the else case.

This does change behavior in edge case:
 - if shape is passed and the key is a group, we'll try to open as array
 instead of groups.
 - if contains_array or contains_group would have raise we might skip
 over those checks.

Though both of the above case should not be found in user code and
are bugs AFAICT, and would just fail differently.

--- 

Let's see if this triggers any test failure. 


TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
