### PR TITLE
Create a  Base store class for Zarr Store.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -176,7 +176,7 @@ print some diagnostics, e.g.::
     Read-only          : False
     Compressor         : Blosc(cname='zstd', clevel=3, shuffle=BITSHUFFLE,
                        : blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 3379344 (3.2M)
     Storage ratio      : 118.4
@@ -268,7 +268,7 @@ Here is an example using a delta filter with the Blosc compressor::
     Read-only          : False
     Filter [0]         : Delta(dtype='<i4')
     Compressor         : Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 1290562 (1.2M)
     Storage ratio      : 309.9
@@ -795,8 +795,10 @@ Here is an example using S3Map to read an array created previously::
     Order              : C
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : fsspec.mapping.FSMap
+    Store type         : zarr.storage.KVStore
     No. bytes          : 21
+    No. bytes stored   : 382
+    Storage ratio      : 0.1
     Chunks initialized : 3/3
     >>> z[:]
     array([b'H', b'e', b'l', b'l', b'o', b' ', b'f', b'r', b'o', b'm', b' ',
@@ -1262,7 +1264,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : C
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 6696010 (6.4M)
     Storage ratio      : 59.7
@@ -1276,7 +1278,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : F
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 4684636 (4.5M)
     Storage ratio      : 85.4

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 ignore_missing_imports = True
 follow_imports = silent

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,6 @@ doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
 filterwarnings =
     error::DeprecationWarning:zarr.*
+    error::UserWarning:zarr.*
     ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning
+    ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -12,17 +12,21 @@ from zarr.hierarchy import Group
 from zarr.hierarchy import group as _create_group
 from zarr.hierarchy import open_group
 from zarr.meta import json_dumps, json_loads
-from zarr.storage import contains_array, contains_group
+from zarr.storage import contains_array, contains_group, Store
 from zarr.util import TreeViewer, buffer_size, normalize_storage_path
+
+from typing import Union
+
+StoreLike = Union[Store, str, None]
 
 
 # noinspection PyShadowingBuiltins
-def open(store=None, mode='a', **kwargs):
+def open(store: StoreLike = None, mode: str = "a", **kwargs):
     """Convenience function to open a group or array using file-mode-like semantics.
 
     Parameters
     ----------
-    store : MutableMapping or string, optional
+    store : Store or string, optional
         Store or path to directory in file system or name of zip file.
     mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
@@ -75,32 +79,33 @@ def open(store=None, mode='a', **kwargs):
     clobber = mode == 'w'
     # we pass storage options explicitly, since normalize_store_arg might construct
     # a store if the input is a fsspec-compatible URL
-    store = normalize_store_arg(store, clobber=clobber,
-                                storage_options=kwargs.pop("storage_options", {}))
+    _store: Store = normalize_store_arg(
+        store, clobber=clobber, storage_options=kwargs.pop("storage_options", {})
+    )
     path = normalize_storage_path(path)
 
     if mode in {'w', 'w-', 'x'}:
         if 'shape' in kwargs:
-            return open_array(store, mode=mode, **kwargs)
+            return open_array(_store, mode=mode, **kwargs)
         else:
-            return open_group(store, mode=mode, **kwargs)
+            return open_group(_store, mode=mode, **kwargs)
 
     elif mode == "a":
-        if "shape" in kwargs or contains_array(store, path):
-            return open_array(store, mode=mode, **kwargs)
+        if "shape" in kwargs or contains_array(_store, path):
+            return open_array(_store, mode=mode, **kwargs)
         else:
-            return open_group(store, mode=mode, **kwargs)
+            return open_group(_store, mode=mode, **kwargs)
 
     else:
-        if contains_array(store, path):
-            return open_array(store, mode=mode, **kwargs)
-        elif contains_group(store, path):
-            return open_group(store, mode=mode, **kwargs)
+        if contains_array(_store, path):
+            return open_array(_store, mode=mode, **kwargs)
+        elif contains_group(_store, path):
+            return open_group(_store, mode=mode, **kwargs)
         else:
             raise PathNotFoundError(path)
 
 
-def save_array(store, arr, **kwargs):
+def save_array(store: StoreLike, arr, **kwargs):
     """Convenience function to save a NumPy array to the local file system, following a
     similar API to the NumPy save() function.
 
@@ -132,16 +137,16 @@ def save_array(store, arr, **kwargs):
 
     """
     may_need_closing = isinstance(store, str)
-    store = normalize_store_arg(store, clobber=True)
+    _store: Store = normalize_store_arg(store, clobber=True)
     try:
-        _create_array(arr, store=store, overwrite=True, **kwargs)
+        _create_array(arr, store=_store, overwrite=True, **kwargs)
     finally:
-        if may_need_closing and hasattr(store, 'close'):
+        if may_need_closing:
             # needed to ensure zip file records are written
-            store.close()
+            _store.close()
 
 
-def save_group(store, *args, **kwargs):
+def save_group(store: StoreLike, *args, **kwargs):
     """Convenience function to save several NumPy arrays to the local file system, following a
     similar API to the NumPy savez()/savez_compressed() functions.
 
@@ -203,21 +208,21 @@ def save_group(store, *args, **kwargs):
         raise ValueError('at least one array must be provided')
     # handle polymorphic store arg
     may_need_closing = isinstance(store, str)
-    store = normalize_store_arg(store, clobber=True)
+    _store: Store = normalize_store_arg(store, clobber=True)
     try:
-        grp = _create_group(store, overwrite=True)
+        grp = _create_group(_store, overwrite=True)
         for i, arr in enumerate(args):
             k = 'arr_{}'.format(i)
             grp.create_dataset(k, data=arr, overwrite=True)
         for k, arr in kwargs.items():
             grp.create_dataset(k, data=arr, overwrite=True)
     finally:
-        if may_need_closing and hasattr(store, 'close'):
+        if may_need_closing:
             # needed to ensure zip file records are written
-            store.close()
+            _store.close()
 
 
-def save(store, *args, **kwargs):
+def save(store: StoreLike, *args, **kwargs):
     """Convenience function to save an array or group of arrays to the local file system.
 
     Parameters
@@ -327,7 +332,7 @@ class LazyLoader(Mapping):
         return r
 
 
-def load(store):
+def load(store: StoreLike):
     """Load data from an array or group into memory.
 
     Parameters
@@ -353,11 +358,11 @@ def load(store):
 
     """
     # handle polymorphic store arg
-    store = normalize_store_arg(store)
-    if contains_array(store, path=None):
-        return Array(store=store, path=None)[...]
-    elif contains_group(store, path=None):
-        grp = Group(store=store, path=None)
+    _store = normalize_store_arg(store)
+    if contains_array(_store, path=None):
+        return Array(store=_store, path=None)[...]
+    elif contains_group(_store, path=None):
+        grp = Group(store=_store, path=None)
         return LazyLoader(grp)
 
 
@@ -1073,7 +1078,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
     return n_copied, n_skipped, n_bytes_copied
 
 
-def consolidate_metadata(store, metadata_key='.zmetadata'):
+def consolidate_metadata(store: Store, metadata_key=".zmetadata"):
     """
     Consolidate all metadata for groups and arrays within the given store
     into a single resource and put it under the given key.
@@ -1124,7 +1129,7 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
     return open_consolidated(store, metadata_key=metadata_key)
 
 
-def open_consolidated(store, metadata_key='.zmetadata', mode='r+', **kwargs):
+def open_consolidated(store: Store, metadata_key=".zmetadata", mode="r+", **kwargs):
     """Open group using metadata previously consolidated into a single key.
 
     This is an optimised method for opening a Zarr group, where instead of

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -9,6 +9,8 @@ from functools import reduce
 import numpy as np
 from numcodecs.compat import ensure_bytes, ensure_ndarray
 
+from collections.abc import MutableMapping
+
 from zarr.attrs import Attributes
 from zarr.codecs import AsType, get_codec
 from zarr.errors import ArrayNotFoundError, ReadOnlyError, ArrayIndexError
@@ -29,7 +31,7 @@ from zarr.indexing import (
     pop_fields,
 )
 from zarr.meta import decode_array_metadata, encode_array_metadata
-from zarr.storage import array_meta_key, attrs_key, getsize, listdir
+from zarr.storage import array_meta_key, attrs_key, getsize, listdir, Store
 from zarr.util import (
     InfoReporter,
     check_array_shape,
@@ -129,7 +131,7 @@ class Array:
 
     def __init__(
         self,
-        store,
+        store: Store,
         path=None,
         read_only=False,
         chunk_store=None,
@@ -140,6 +142,9 @@ class Array:
     ):
         # N.B., expect at this point store is fully initialized with all
         # configuration metadata fully specified and normalized
+
+        store = Store._ensure_store(store)
+        chunk_store = Store._ensure_store(chunk_store)
 
         self._store = store
         self._chunk_store = chunk_store
@@ -2009,7 +2014,7 @@ class Array:
             cdata = chunk
 
         # ensure in-memory data is immutable and easy to compare
-        if isinstance(self.chunk_store, dict):
+        if isinstance(self.chunk_store, MutableMapping):
             cdata = ensure_bytes(cdata)
 
         return cdata
@@ -2042,10 +2047,10 @@ class Array:
         Order              : C
         Read-only          : False
         Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-        Store type         : builtins.dict
+        Store type         : zarr.storage.KVStore
         No. bytes          : 4000000 (3.8M)
-        No. bytes stored   : ...
-        Storage ratio      : ...
+        No. bytes stored   : 320
+        Storage ratio      : 12500.0
         Chunks initialized : 0/10
 
         """

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -15,11 +15,26 @@ from zarr.errors import (
     ReadOnlyError,
 )
 from zarr.meta import decode_group_metadata
-from zarr.storage import (MemoryStore, attrs_key, contains_array,
-                          contains_group, group_meta_key, init_group, listdir,
-                          rename, rmdir)
-from zarr.util import (InfoReporter, TreeViewer, is_valid_python_name, nolock,
-                       normalize_shape, normalize_storage_path)
+from zarr.storage import (
+    MemoryStore,
+    attrs_key,
+    contains_array,
+    contains_group,
+    group_meta_key,
+    init_group,
+    listdir,
+    rename,
+    rmdir,
+    Store,
+)
+from zarr.util import (
+    InfoReporter,
+    TreeViewer,
+    is_valid_python_name,
+    nolock,
+    normalize_shape,
+    normalize_storage_path,
+)
 
 
 class Group(MutableMapping):
@@ -96,6 +111,8 @@ class Group(MutableMapping):
 
     def __init__(self, store, path=None, read_only=False, chunk_store=None,
                  cache_attrs=True, synchronizer=None):
+        store = Store._ensure_store(store)
+        chunk_store = Store._ensure_store(chunk_store)
         self._store = store
         self._chunk_store = chunk_store
         self._path = normalize_storage_path(path)
@@ -237,11 +254,8 @@ class Group(MutableMapping):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """If the underlying Store has a ``close`` method, call it."""
-        try:
-            self.store.close()
-        except AttributeError:
-            pass
+        """If the underlying Store should always heave a ``close`` method, call it."""
+        self.store.close()
 
     def info_items(self):
 
@@ -802,11 +816,13 @@ class Group(MutableMapping):
         <zarr.core.Array '/bar/baz/qux' (100, 100, 100) float64>
 
         """
+        assert "mode" not in kwargs
 
         return self._write_op(self._create_dataset_nosync, name, **kwargs)
 
     def _create_dataset_nosync(self, name, data=None, **kwargs):
 
+        assert "mode" not in kwargs
         path = self._item_path(name)
 
         # determine synchronizer

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -225,7 +225,7 @@ def rmdir(store: Store, path: Path = None):
     this will be called, otherwise will fall back to implementation via the
     `Store` interface."""
     path = normalize_storage_path(path)
-    if hasattr(store, 'rmdir'):
+    if hasattr(store, "rmdir") and store.is_erasable():
         # pass through
         store.rmdir(path)  # type: ignore
     else:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -31,7 +31,7 @@ from collections.abc import MutableMapping
 from os import scandir
 from pickle import PicklingError
 from threading import Lock, RLock
-from typing import Optional, Union, List, Tuple, Dict
+from typing import Optional, Union, List, Tuple, Dict, Any
 import uuid
 import time
 
@@ -78,6 +78,124 @@ except ImportError:  # pragma: no cover
 Path = Union[str, bytes, None]
 
 
+class Store(MutableMapping):
+    """Base class for stores implementation.
+
+
+    Provide a number of default method as well as other typing guaranties for mypy.
+
+    Stores cannot be mutable mapping as they do have a couple of other
+    requirements that would break Liskov substitution principle (stores only
+    allow strings as keys, mutable mapping are more generic).
+
+    And Stores do requires a few other method.
+
+    Having no-op base method also helps simplifying store usage and do not need
+    to check the presence of attributes and methods, like `close()`.
+
+    Stores can be used as context manager to make sure they close on exit.
+
+    .. added: 2.5.0
+
+    """
+
+    _readable = True
+    _writeable = True
+    _erasable = True
+    _listable = True
+
+    def is_readable(self):
+        return self._readable
+
+    def is_writeable(self):
+        return self._writeable
+
+    def is_listable(self):
+        return self._listable
+
+    def is_erasable(self):
+        return self._erasable
+
+    def __enter__(self):
+        if not hasattr(self, "_open_count"):
+            self._open_count = 0
+        self._open_count += 1
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._open_count -= 1
+        if self._open_count == 0:
+            self.close()
+
+    def listdir(self, path: str = "") -> List[str]:
+        path = normalize_storage_path(path)
+        return _listdir_from_keys(self, path)
+
+    def rename(self, src_path: str, dst_path: str) -> None:
+        if not self.is_erasable():
+            raise NotImplementedError(
+                f'{type(self)} is not erasable, cannot call "rmdir"'
+            )
+        _rename_from_keys(self, src_path, dst_path)
+
+    def rmdir(self, path: str = "") -> None:
+        if not self.is_erasable():
+            raise NotImplementedError(
+                f'{type(self)} is not erasable, cannot call "rmdir"'
+            )
+        path = normalize_storage_path(path)
+        _rmdir_from_keys(self, path)
+
+    # def getsize(self, path: Path = None):
+    #    pass
+
+    # def clear(self):
+    #    pass
+
+    def close(self) -> None:
+        """Do nothing by default"""
+        pass
+
+    # def pop(self, key):
+    #    raise NotImplementedError
+
+    @staticmethod
+    def _ensure_store(store):
+        """
+        We want to make sure internally that zarr storage are internally always
+        a class with a specific interface derived from Store, which is slightly
+        different than mutable mapping.
+
+        We'll do this conversion in a few places automatically
+        """
+        if store is None:
+            return None
+        elif isinstance(store, Store):
+            return store
+        elif isinstance(store, MutableMapping):
+            return KVStore(store)
+        else:
+            for attr in [
+                "keys",
+                "values",
+                "get",
+                "__setitem__",
+                "__getitem__",
+                "__delitem__",
+                "__contains__",
+            ]:
+                if not hasattr(store, attr):
+                    break
+            else:
+                return KVStore(store)
+
+        raise ValueError(
+            "Starting with Zarr X.y.z, stores must be subclasses of Store, if "
+            "you store expose the MutableMapping interface wrap them in "
+            f"Zarr.storage.KVStore. Got {store}"
+        )
+
+
 def _path_to_prefix(path: Optional[str]) -> str:
     # assume path already normalized
     if path:
@@ -87,7 +205,7 @@ def _path_to_prefix(path: Optional[str]) -> str:
     return prefix
 
 
-def contains_array(store: MutableMapping, path: Path = None) -> bool:
+def contains_array(store: Store, path: Path = None) -> bool:
     """Return True if the store contains an array at the given logical path."""
     path = normalize_storage_path(path)
     prefix = _path_to_prefix(path)
@@ -95,7 +213,7 @@ def contains_array(store: MutableMapping, path: Path = None) -> bool:
     return key in store
 
 
-def contains_group(store: MutableMapping, path: Path = None) -> bool:
+def contains_group(store: Store, path: Path = None) -> bool:
     """Return True if the store contains a group at the given logical path."""
     path = normalize_storage_path(path)
     prefix = _path_to_prefix(path)
@@ -103,7 +221,7 @@ def contains_group(store: MutableMapping, path: Path = None) -> bool:
     return key in store
 
 
-def _rmdir_from_keys(store: MutableMapping, path: Optional[str] = None) -> None:
+def _rmdir_from_keys(store: Store, path: Optional[str] = None) -> None:
     # assume path already normalized
     prefix = _path_to_prefix(path)
     for key in list(store.keys()):
@@ -111,20 +229,20 @@ def _rmdir_from_keys(store: MutableMapping, path: Optional[str] = None) -> None:
             del store[key]
 
 
-def rmdir(store, path: Path = None):
+def rmdir(store: Store, path: Path = None):
     """Remove all items under the given path. If `store` provides a `rmdir` method,
     this will be called, otherwise will fall back to implementation via the
-    `MutableMapping` interface."""
+    `Store` interface."""
     path = normalize_storage_path(path)
     if hasattr(store, 'rmdir'):
         # pass through
-        store.rmdir(path)
+        store.rmdir(path)  # type: ignore
     else:
         # slow version, delete one key at a time
         _rmdir_from_keys(store, path)
 
 
-def _rename_from_keys(store: MutableMapping, src_path: str, dst_path: str) -> None:
+def _rename_from_keys(store: Store, src_path: str, dst_path: str) -> None:
     # assume path already normalized
     src_prefix = _path_to_prefix(src_path)
     dst_prefix = _path_to_prefix(dst_path)
@@ -134,10 +252,10 @@ def _rename_from_keys(store: MutableMapping, src_path: str, dst_path: str) -> No
             store[new_key] = store.pop(key)
 
 
-def rename(store, src_path: Path, dst_path: Path):
+def rename(store: Store, src_path: Path, dst_path: Path):
     """Rename all items under the given path. If `store` provides a `rename` method,
     this will be called, otherwise will fall back to implementation via the
-    `MutableMapping` interface."""
+    `Store` interface."""
     src_path = normalize_storage_path(src_path)
     dst_path = normalize_storage_path(dst_path)
     if hasattr(store, 'rename'):
@@ -148,7 +266,7 @@ def rename(store, src_path: Path, dst_path: Path):
         _rename_from_keys(store, src_path, dst_path)
 
 
-def _listdir_from_keys(store: MutableMapping, path: Optional[str] = None) -> List[str]:
+def _listdir_from_keys(store: Store, path: Optional[str] = None) -> List[str]:
     # assume path already normalized
     prefix = _path_to_prefix(path)
     children = set()
@@ -160,27 +278,32 @@ def _listdir_from_keys(store: MutableMapping, path: Optional[str] = None) -> Lis
     return sorted(children)
 
 
-def listdir(store, path: Path = None):
+def listdir(store: Store, path: Path = None):
     """Obtain a directory listing for the given path. If `store` provides a `listdir`
     method, this will be called, otherwise will fall back to implementation via the
     `MutableMapping` interface."""
     path = normalize_storage_path(path)
     if hasattr(store, 'listdir'):
         # pass through
-        return store.listdir(path)
+        return store.listdir(path)  # type: ignore
     else:
         # slow version, iterate through all keys
+        warnings.warn(
+            "Store {store} has not `listdir` method. From zarr 2.5 you may want"
+            "to inherit from `Store`.".format(store=store),
+            stacklevel=2,
+        )
         return _listdir_from_keys(store, path)
 
 
-def getsize(store, path: Path = None) -> int:
+def getsize(store: Store, path: Path = None) -> int:
     """Compute size of stored items for a given path. If `store` provides a `getsize`
     method, this will be called, otherwise will return -1."""
     path = normalize_storage_path(path)
     if hasattr(store, 'getsize'):
         # pass through
-        return store.getsize(path)
-    elif isinstance(store, dict):
+        return store.getsize(path)  # type: ignore
+    elif isinstance(store, MutableMapping):
         # compute from size of values
         if path in store:
             v = store[path]
@@ -206,8 +329,8 @@ def getsize(store, path: Path = None) -> int:
 
 def _require_parent_group(
     path: Optional[str],
-    store: MutableMapping,
-    chunk_store: Optional[MutableMapping],
+    store: Store,
+    chunk_store: Optional[Store],
     overwrite: bool,
 ):
     # assume path is normalized
@@ -223,7 +346,7 @@ def _require_parent_group(
 
 
 def init_array(
-    store: MutableMapping,
+    store: Store,
     shape: Tuple[int, ...],
     chunks: Union[bool, int, Tuple[int, ...]] = True,
     dtype=None,
@@ -232,7 +355,7 @@ def init_array(
     order: str = "C",
     overwrite: bool = False,
     path: Path = None,
-    chunk_store: MutableMapping = None,
+    chunk_store: Store = None,
     filters=None,
     object_codec=None,
 ):
@@ -241,7 +364,7 @@ def init_array(
 
     Parameters
     ----------
-    store : MutableMapping
+    store : Store
         A mapping that supports string keys and bytes-like values.
     shape : int or tuple of ints
         Array shape.
@@ -260,7 +383,7 @@ def init_array(
         If True, erase all data in `store` prior to initialisation.
     path : string, bytes, optional
         Path under which array is stored.
-    chunk_store : MutableMapping, optional
+    chunk_store : Store, optional
         Separate storage for chunks. If not provided, `store` will be used
         for storage of both chunks and metadata.
     filters : sequence, optional
@@ -443,23 +566,23 @@ init_store = init_array
 
 
 def init_group(
-    store: MutableMapping,
+    store: Store,
     overwrite: bool = False,
     path: Path = None,
-    chunk_store: MutableMapping = None,
+    chunk_store: Store = None,
 ):
     """Initialize a group store. Note that this is a low-level function and there should be no
     need to call this directly from user code.
 
     Parameters
     ----------
-    store : MutableMapping
+    store : Store
         A mapping that supports string keys and byte sequence values.
     overwrite : bool, optional
         If True, erase all data in `store` prior to initialisation.
     path : string, optional
         Path under which array is stored.
-    chunk_store : MutableMapping, optional
+    chunk_store : Store, optional
         Separate storage for chunks. If not provided, `store` will be used
         for storage of both chunks and metadata.
 
@@ -478,10 +601,10 @@ def init_group(
 
 
 def _init_group_metadata(
-    store: MutableMapping,
+    store: Store,
     overwrite: Optional[bool] = False,
     path: Optional[str] = None,
-    chunk_store: MutableMapping = None,
+    chunk_store: Store = None,
 ):
 
     # guard conditions
@@ -513,7 +636,69 @@ def _dict_store_keys(d: Dict, prefix="", cls=dict):
             yield prefix + k
 
 
-class MemoryStore(MutableMapping):
+class KVStore(Store):
+    """
+    This provide an default implementation of a store interface around
+    a mutable mapping, to avoid having to test stores for presence of methods
+
+    This, for most method should just be a pass-through to the underlying KV
+    store which is likely to expose a MuttableMapping interface,
+    """
+
+    def __init__(self, mutablemapping):
+        self.mm = mutablemapping
+
+    def __getitem__(self, key):
+        return self.mm[key]
+
+    def __setitem__(self, key, value):
+        # assert isinstance(value, bytes)
+        self.mm[key] = value
+
+    def __delitem__(self, key):
+        del self.mm[key]
+
+    def get(self, key, default=None):
+        return self.mm.get(key, default)
+
+    def values(self):
+        return self.mm.values()
+
+    def __iter__(self):
+        return iter(self.mm)
+
+    def __len__(self):
+        return len(self.mm)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: \n{repr(self.mm)}\n at {hex(id(self))}>"
+
+    def __eq__(self, other):
+        if isinstance(other, KVStore):
+            return self.mm == other.mm
+        else:
+            return NotImplemented
+
+    # def __contains__(self, key):
+    #    return key in self.mm
+
+    # def pop(self):
+    #    return self.mm.pop()
+
+    # def popitem
+    # def clear
+    # def update
+    # def setdefault
+    # def __eq__
+    # def __ne__
+    # def __contains__
+    # def keys()
+    # def items()
+    # def values()
+    # def get
+
+
+class MemoryStore(Store):
     """Store class that uses a hierarchy of :class:`dict` objects, thus all data
     will be held in main memory.
 
@@ -531,7 +716,7 @@ class MemoryStore(MutableMapping):
 
         >>> z = zarr.zeros(100)
         >>> type(z.store)
-        <class 'dict'>
+        <class 'zarr.storage.KVStore'>
 
     Notes
     -----
@@ -716,7 +901,7 @@ class DictStore(MemoryStore):
         super().__init__(*args, **kwargs)
 
 
-class DirectoryStore(MutableMapping):
+class DirectoryStore(Store):
     """Storage class using directories and files on a standard file system.
 
     Parameters
@@ -999,7 +1184,7 @@ def atexit_rmglob(path,
             rmtree(p)
 
 
-class FSStore(MutableMapping):
+class FSStore(Store):
     """Wraps an fsspec.FSMap to give access to arbitrary filesystems
 
     Requires that ``fsspec`` is installed, as well as any additional
@@ -1296,7 +1481,7 @@ class NestedDirectoryStore(DirectoryStore):
 
 
 # noinspection PyPep8Naming
-class ZipStore(MutableMapping):
+class ZipStore(Store):
     """Storage class using a Zip file.
 
     Parameters
@@ -1381,6 +1566,8 @@ class ZipStore(MutableMapping):
     Safe to write in multiple threads but not in multiple processes.
 
     """
+
+    _erasable = False
 
     def __init__(self, path, compression=zipfile.ZIP_STORED, allowZip64=True, mode='a'):
 
@@ -1542,7 +1729,7 @@ def migrate_1to2(store):
 
     Parameters
     ----------
-    store : MutableMapping
+    store : Store
         Store to be migrated.
 
     Notes
@@ -1586,7 +1773,7 @@ def migrate_1to2(store):
 
 
 # noinspection PyShadowingBuiltins
-class DBMStore(MutableMapping):
+class DBMStore(Store):
     """Storage class using a DBM-style database.
 
     Parameters
@@ -1774,7 +1961,7 @@ class DBMStore(MutableMapping):
         return key in self.db
 
 
-class LMDBStore(MutableMapping):
+class LMDBStore(Store):
     """Storage class using LMDB. Requires the `lmdb <http://lmdb.readthedocs.io/>`_
     package to be installed.
 
@@ -1948,7 +2135,7 @@ class LMDBStore(MutableMapping):
         return self.db.stat()['entries']
 
 
-class LRUStoreCache(MutableMapping):
+class LRUStoreCache(Store):
     """Storage class that implements a least-recently-used (LRU) cache layer over
     some other store. Intended primarily for use with stores that can be slow to
     access, e.g., remote stores that require network communication to store and
@@ -1956,7 +2143,7 @@ class LRUStoreCache(MutableMapping):
 
     Parameters
     ----------
-    store : MutableMapping
+    store : Store
         The store containing the actual data to be cached.
     max_size : int
         The maximum size that the cache may grow to, in number of bytes. Provide `None`
@@ -1985,14 +2172,14 @@ class LRUStoreCache(MutableMapping):
 
     """
 
-    def __init__(self, store, max_size):
-        self._store = store
+    def __init__(self, store: Store, max_size: int):
+        self._store = Store._ensure_store(store)
         self._max_size = max_size
         self._current_size = 0
         self._keys_cache = None
         self._contains_cache = None
-        self._listdir_cache = dict()
-        self._values_cache = OrderedDict()
+        self._listdir_cache: Dict[Path, Any] = dict()
+        self._values_cache: Dict[Path, Any] = OrderedDict()
         self._mutex = Lock()
         self.hits = self.misses = 0
 
@@ -2032,7 +2219,7 @@ class LRUStoreCache(MutableMapping):
             self._keys_cache = list(self._store.keys())
         return self._keys_cache
 
-    def listdir(self, path=None):
+    def listdir(self, path: Path = None):
         with self._mutex:
             try:
                 return self._listdir_cache[path]
@@ -2041,7 +2228,7 @@ class LRUStoreCache(MutableMapping):
                 self._listdir_cache[path] = listing
                 return listing
 
-    def getsize(self, path=None):
+    def getsize(self, path=None) -> int:
         return getsize(self._store, path=path)
 
     def _pop_value(self):
@@ -2058,7 +2245,7 @@ class LRUStoreCache(MutableMapping):
             v = self._pop_value()
             self._current_size -= buffer_size(v)
 
-    def _cache_value(self, key, value):
+    def _cache_value(self, key: Path, value):
         # cache a value
         value_size = buffer_size(value)
         # check size of the value against max size, as if the value itself exceeds max
@@ -2130,7 +2317,7 @@ class LRUStoreCache(MutableMapping):
             self._invalidate_value(key)
 
 
-class ABSStore(MutableMapping):
+class ABSStore(Store):
     """Storage class using Azure Blob Storage (ABS).
 
     Parameters
@@ -2245,7 +2432,7 @@ class ABSStore(MutableMapping):
         else:
             return False
 
-    def listdir(self, path=None):
+    def listdir(self, path: Path = None):
         from azure.storage.blob import Blob
         dir_path = normalize_storage_path(self._append_path_to_prefix(path))
         if dir_path:
@@ -2294,7 +2481,7 @@ class ABSStore(MutableMapping):
         self.rmdir()
 
 
-class SQLiteStore(MutableMapping):
+class SQLiteStore(Store):
     """Storage class using SQLite.
 
     Parameters
@@ -2493,7 +2680,7 @@ class SQLiteStore(MutableMapping):
             )
 
 
-class MongoDBStore(MutableMapping):
+class MongoDBStore(Store):
     """Storage class using MongoDB.
 
     .. note:: This is an experimental feature.
@@ -2573,7 +2760,7 @@ class MongoDBStore(MutableMapping):
         self.collection.delete_many({})
 
 
-class RedisStore(MutableMapping):
+class RedisStore(Store):
     """Storage class using Redis.
 
     .. note:: This is an experimental feature.
@@ -2639,7 +2826,7 @@ class RedisStore(MutableMapping):
             del self[key]
 
 
-class ConsolidatedMetadataStore(MutableMapping):
+class ConsolidatedMetadataStore(Store):
     """A layer over other storage, where the metadata has been consolidated into
     a single key.
 
@@ -2663,7 +2850,7 @@ class ConsolidatedMetadataStore(MutableMapping):
 
     Parameters
     ----------
-    store: MutableMapping
+    store: Store
         Containing the zarr array.
     metadata_key: str
         The target in the store where all of the metadata are stored. We
@@ -2674,7 +2861,8 @@ class ConsolidatedMetadataStore(MutableMapping):
     zarr.convenience.consolidate_metadata, zarr.convenience.open_consolidated
 
     """
-    def __init__(self, store, metadata_key='.zmetadata'):
+
+    def __init__(self, store: Store, metadata_key=".zmetadata"):
         self.store = store
 
         # retrieve consolidated metadata
@@ -2687,7 +2875,7 @@ class ConsolidatedMetadataStore(MutableMapping):
                                 consolidated_format)
 
         # decode metadata
-        self.meta_store = meta['metadata']
+        self.meta_store: Store = KVStore(meta["metadata"])
 
     def __getitem__(self, key):
         return self.meta_store[key]

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -146,18 +146,9 @@ class Store(MutableMapping):
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
 
-    # def getsize(self, path: Path = None):
-    #    pass
-
-    # def clear(self):
-    #    pass
-
     def close(self) -> None:
         """Do nothing by default"""
         pass
-
-    # def pop(self, key):
-    #    raise NotImplementedError
 
     @staticmethod
     def _ensure_store(store):
@@ -646,56 +637,37 @@ class KVStore(Store):
     """
 
     def __init__(self, mutablemapping):
-        self.mm = mutablemapping
+        self._mutable_mapping = mutablemapping
 
     def __getitem__(self, key):
-        return self.mm[key]
+        return self._mutable_mapping[key]
 
     def __setitem__(self, key, value):
-        # assert isinstance(value, bytes)
-        self.mm[key] = value
+        self._mutable_mapping[key] = value
 
     def __delitem__(self, key):
-        del self.mm[key]
+        del self._mutable_mapping[key]
 
     def get(self, key, default=None):
-        return self.mm.get(key, default)
+        return self._mutable_mapping.get(key, default)
 
     def values(self):
-        return self.mm.values()
+        return self._mutable_mapping.values()
 
     def __iter__(self):
-        return iter(self.mm)
+        return iter(self._mutable_mapping)
 
     def __len__(self):
-        return len(self.mm)
+        return len(self._mutable_mapping)
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}: \n{repr(self.mm)}\n at {hex(id(self))}>"
+        return f"<{self.__class__.__name__}: \n{repr(self._mutable_mapping)}\n at {hex(id(self))}>"
 
     def __eq__(self, other):
         if isinstance(other, KVStore):
-            return self.mm == other.mm
+            return self._mutable_mapping == other._mutable_mapping
         else:
             return NotImplemented
-
-    # def __contains__(self, key):
-    #    return key in self.mm
-
-    # def pop(self):
-    #    return self.mm.pop()
-
-    # def popitem
-    # def clear
-    # def update
-    # def setdefault
-    # def __eq__
-    # def __ne__
-    # def __contains__
-    # def keys()
-    # def items()
-    # def values()
-    # def get
 
 
 class MemoryStore(Store):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -135,14 +135,14 @@ class Store(MutableMapping):
         if not self.is_erasable():
             raise NotImplementedError(
                 f'{type(self)} is not erasable, cannot call "rmdir"'
-            )
+            )  # pragma: no cover
         _rename_from_keys(self, src_path, dst_path)
 
     def rmdir(self, path: str = "") -> None:
         if not self.is_erasable():
             raise NotImplementedError(
                 f'{type(self)} is not erasable, cannot call "rmdir"'
-            )
+            )  # pragma: no cover
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
 

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -23,8 +23,12 @@ from zarr.convenience import (
 from zarr.core import Array
 from zarr.errors import CopyError
 from zarr.hierarchy import Group, group
-from zarr.storage import (ConsolidatedMetadataStore, MemoryStore,
-                          atexit_rmtree, getsize)
+from zarr.storage import (
+    ConsolidatedMetadataStore,
+    MemoryStore,
+    atexit_rmtree,
+    getsize,
+)
 
 
 def test_open_array():

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -22,11 +22,12 @@ from zarr.storage import (
     ABSStore,
     DBMStore,
     DirectoryStore,
+    FSStore,
+    KVStore,
     LMDBStore,
     LRUStoreCache,
     NestedDirectoryStore,
     SQLiteStore,
-    FSStore,
     atexit_rmglob,
     atexit_rmtree,
     init_array,
@@ -42,8 +43,8 @@ class TestArray(unittest.TestCase):
     def test_array_init(self):
 
         # normal initialization
-        store = dict()
-        init_array(store, shape=100, chunks=10, dtype='<f8')
+        store = KVStore(dict())
+        init_array(store, shape=100, chunks=10, dtype="<f8")
         a = Array(store)
         assert isinstance(a, Array)
         assert (100,) == a.shape
@@ -53,9 +54,10 @@ class TestArray(unittest.TestCase):
         assert a.basename is None
         assert store is a.store
         assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
+        store.close()
 
         # initialize at path
-        store = dict()
+        store = KVStore(dict())
         init_array(store, shape=100, chunks=10, path='foo/bar', dtype='<f8')
         a = Array(store, path='foo/bar')
         assert isinstance(a, Array)
@@ -99,8 +101,7 @@ class TestArray(unittest.TestCase):
             if not isinstance(k, expected_type):  # pragma: no cover
                 pytest.fail("Non-text key: %s" % repr(k))
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_store_has_binary_values(self):
         # Initialize array
@@ -114,8 +115,7 @@ class TestArray(unittest.TestCase):
             except TypeError:  # pragma: no cover
                 pytest.fail("Non-bytes-like value: %s" % repr(v))
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_store_has_bytes_values(self):
         # Test that many stores do hold bytes values.
@@ -130,8 +130,7 @@ class TestArray(unittest.TestCase):
         # Check in-memory array only contains `bytes`
         assert all([isinstance(v, bytes) for v in z.chunk_store.values()])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_nbytes_stored(self):
 
@@ -149,6 +148,8 @@ class TestArray(unittest.TestCase):
             assert -1 == z.nbytes_stored
         except TypeError:
             pass
+
+        z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_1d(self):
@@ -231,8 +232,7 @@ class TestArray(unittest.TestCase):
         assert_array_equal(b[190:310], z[190:310])
         assert_array_equal(a[310:], z[310:])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_1d_fill_value(self):
         for fill_value in -1, 0, 1, 10:
@@ -248,8 +248,7 @@ class TestArray(unittest.TestCase):
             assert_array_equal(a[190:310], z[190:310])
             assert_array_equal(f[310:], z[310:])
 
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
     def test_array_1d_set_scalar(self):
         # test setting the contents of an array with a scalar value
@@ -268,8 +267,7 @@ class TestArray(unittest.TestCase):
             z[:] = value
             assert_array_equal(a, z[:])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_1d_selections(self):
         # light test here, full tests in test_indexing
@@ -313,8 +311,7 @@ class TestArray(unittest.TestCase):
         z.oindex[bix] = 9
         assert_array_equal(9, z.oindex[bix])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_2d(self):
@@ -424,8 +421,7 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[310:], z[310:])
         assert_array_equal(a[:, 7:], z[:, 7:])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_2d_edge_case(self):
         # this fails with filters - chunks extend beyond edge of array, messes with delta
@@ -439,8 +435,7 @@ class TestArray(unittest.TestCase):
         actual = z[:]
         assert_array_equal(expect, actual)
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_2d_partial(self):
         z = self.create_array(shape=(1000, 10), chunks=(100, 2), dtype='i4',
@@ -482,8 +477,7 @@ class TestArray(unittest.TestCase):
         assert -1 == z[2, 2]
         assert -1 == z[-1, -1]
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_order(self):
 
@@ -500,8 +494,7 @@ class TestArray(unittest.TestCase):
             z[:] = a
             assert_array_equal(a, z[:])
 
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
         # 2D
         a = np.arange(10000).reshape((100, 100))
@@ -517,8 +510,7 @@ class TestArray(unittest.TestCase):
             actual = z[:]
             assert_array_equal(a, actual)
 
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
     def test_setitem_data_not_shared(self):
         # check that data don't end up being shared with another array
@@ -529,41 +521,35 @@ class TestArray(unittest.TestCase):
         assert_array_equal(z[:], np.arange(20, dtype='i4'))
         a[:] = 0
         assert_array_equal(z[:], np.arange(20, dtype='i4'))
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         assert '063b02ff8d9d3bab6da932ad5828b506ef0a6578' == z.hexdigest()
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
         assert 'f97b84dc9ffac807415f750100108764e837bb82' == z.hexdigest()
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
         assert 'c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261' == z.hexdigest()
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
         assert '14470724dca6c1837edddedc490571b6a7f270bc' == z.hexdigest()
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
         assert '2a1046dd99b914459b3e86be9dde05027a07d209' == z.hexdigest()
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_resize_1d(self):
 
@@ -600,8 +586,7 @@ class TestArray(unittest.TestCase):
         assert (105,) == z.shape
         assert (105,) == z[:].shape
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_resize_2d(self):
 
@@ -647,8 +632,7 @@ class TestArray(unittest.TestCase):
         assert (105, 105) == z.shape
         assert (105, 105) == z[:].shape
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_append_1d(self):
 
@@ -677,8 +661,7 @@ class TestArray(unittest.TestCase):
         assert (10,) == z.chunks
         assert_array_equal(f, z[:])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_append_2d(self):
 
@@ -700,8 +683,7 @@ class TestArray(unittest.TestCase):
         actual = z[:]
         assert_array_equal(e, actual)
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_append_2d_axis(self):
 
@@ -721,8 +703,7 @@ class TestArray(unittest.TestCase):
         assert (10, 10) == z.chunks
         assert_array_equal(e, z[:])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_append_bad_shape(self):
         a = np.arange(100)
@@ -731,15 +712,13 @@ class TestArray(unittest.TestCase):
         b = a.reshape(10, 10)
         with pytest.raises(ValueError):
             z.append(b)
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_read_only(self):
 
         z = self.create_array(shape=1000, chunks=100)
         assert not z.read_only
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=1000, chunks=100, read_only=True)
         assert z.read_only
@@ -762,8 +741,7 @@ class TestArray(unittest.TestCase):
         with pytest.raises(PermissionError):
             z.set_mask_selection(np.ones(z.shape, dtype=bool), 42)
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_pickle(self):
 
@@ -786,8 +764,7 @@ class TestArray(unittest.TestCase):
         dump = pickle.dumps(z)
         # some stores cannot be opened twice at the same time, need to close
         # store before can round-trip through pickle
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
         z2 = pickle.loads(dump)
 
         # verify
@@ -801,8 +778,7 @@ class TestArray(unittest.TestCase):
         assert attrs_cache == z2.attrs.cache
         assert_array_equal(a, z2[:])
 
-        if hasattr(z2.store, 'close'):
-            z2.store.close()
+        z2.store.close()
 
     def test_np_ufuncs(self):
         z = self.create_array(shape=(100, 100), chunks=(10, 10))
@@ -820,8 +796,7 @@ class TestArray(unittest.TestCase):
         assert_array_equal(np.take(a, indices, axis=1),
                            np.take(z, indices, axis=1))
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # use zarr array as indices or condition
         zc = self.create_array(shape=condition.shape, dtype=condition.dtype,
@@ -829,8 +804,7 @@ class TestArray(unittest.TestCase):
         zc[:] = condition
         assert_array_equal(np.compress(condition, a, axis=0),
                            np.compress(zc, a, axis=0))
-        if hasattr(zc.store, 'close'):
-            zc.store.close()
+        zc.store.close()
 
         zi = self.create_array(shape=indices.shape, dtype=indices.dtype,
                                chunks=10, filters=None)
@@ -838,8 +812,7 @@ class TestArray(unittest.TestCase):
         # this triggers __array__() call with dtype argument
         assert_array_equal(np.take(a, indices, axis=1),
                            np.take(a, zi, axis=1))
-        if hasattr(zi.store, 'close'):
-            zi.store.close()
+        zi.store.close()
 
     # noinspection PyStatementEffect
     def test_0len_dim_1d(self):
@@ -874,8 +847,7 @@ class TestArray(unittest.TestCase):
         with pytest.raises(IndexError):
             z[0] = 42
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     # noinspection PyStatementEffect
     def test_0len_dim_2d(self):
@@ -914,8 +886,7 @@ class TestArray(unittest.TestCase):
         with pytest.raises(IndexError):
             z[:, 0] = 42
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     # noinspection PyStatementEffect
     def test_array_0d(self):
@@ -964,8 +935,7 @@ class TestArray(unittest.TestCase):
         with pytest.raises(ValueError):
             z[...] = np.array([1, 2, 3])
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_nchunks_initialized(self):
 
@@ -977,8 +947,7 @@ class TestArray(unittest.TestCase):
         z[:] = 42
         assert 10 == z.nchunks_initialized
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_array_dtype_shape(self):
 
@@ -1000,8 +969,7 @@ class TestArray(unittest.TestCase):
                     assert fill_value == z.fill_value
                 z[...] = a
                 assert_array_equal(a, z[...])
-                if hasattr(z.store, 'close'):
-                    z.store.close()
+                z.store.close()
 
     def check_structured_array(self, d, fill_values):
         for a in (d, d[:0]):
@@ -1042,8 +1010,7 @@ class TestArray(unittest.TestCase):
                     for f in a.dtype.names:
                         assert_array_equal(a[f], z[f])
 
-                if hasattr(z.store, 'close'):
-                    z.store.close()
+                z.store.close()
 
     def test_structured_array(self):
         d = np.array([(b'aaa', 1, 4.2),
@@ -1079,8 +1046,7 @@ class TestArray(unittest.TestCase):
             a = np.arange(z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_equal(a, z[:])
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
         # floats
         for dtype in 'f2', 'f4', 'f8':
@@ -1089,8 +1055,7 @@ class TestArray(unittest.TestCase):
             a = np.linspace(0, 1, z.shape[0], dtype=dtype)
             z[:] = a
             assert_array_almost_equal(a, z[:])
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
         # complex
         for dtype in 'c8', 'c16':
@@ -1100,8 +1065,7 @@ class TestArray(unittest.TestCase):
             a -= 1j * a
             z[:] = a
             assert_array_almost_equal(a, z[:])
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
         # datetime, timedelta
         for base_type in 'Mm':
@@ -1114,8 +1078,7 @@ class TestArray(unittest.TestCase):
                                       dtype='i8').view(dtype)
                 z[:] = a
                 assert_array_equal(a, z[:])
-                if hasattr(z.store, 'close'):
-                    z.store.close()
+                z.store.close()
 
         # check that datetime generic units are not allowed
         with pytest.raises(ValueError):
@@ -1133,8 +1096,7 @@ class TestArray(unittest.TestCase):
         # filters to maintain API backwards compatibility
         with pytest.warns(FutureWarning):
             z = self.create_array(shape=10, chunks=3, dtype=object, filters=[MsgPack()])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # create an object array using msgpack
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=MsgPack())
@@ -1150,8 +1112,7 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # create an object array using pickle
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=Pickle())
@@ -1167,8 +1128,7 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # create an object array using JSON
         z = self.create_array(shape=10, chunks=3, dtype=object, object_codec=JSON())
@@ -1184,8 +1144,7 @@ class TestArray(unittest.TestCase):
         assert z[4] == {'a': 'b', 'c': 'd'}
         a = z[:]
         assert a.dtype == object
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_object_arrays_vlen_text(self):
 
@@ -1202,8 +1161,7 @@ class TestArray(unittest.TestCase):
         a = z[:]
         assert a.dtype == object
         assert_array_equal(data, a)
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=str)
@@ -1211,33 +1169,28 @@ class TestArray(unittest.TestCase):
         assert isinstance(z.filters[0], VLenUTF8)
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=MsgPack())
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=JSON())
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=Pickle())
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object,
                               object_codec=Categorize(greetings, dtype=object))
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_object_arrays_vlen_bytes(self):
 
@@ -1255,8 +1208,7 @@ class TestArray(unittest.TestCase):
         a = z[:]
         assert a.dtype == object
         assert_array_equal(data, a)
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # convenience API
         z = self.create_array(shape=data.shape, dtype=bytes)
@@ -1264,14 +1216,12 @@ class TestArray(unittest.TestCase):
         assert isinstance(z.filters[0], VLenBytes)
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         z = self.create_array(shape=data.shape, dtype=object, object_codec=Pickle())
         z[:] = data
         assert_array_equal(data, z[:])
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_object_arrays_vlen_array(self):
 
@@ -1297,8 +1247,7 @@ class TestArray(unittest.TestCase):
             a = z[:]
             assert a.dtype == object
             compare_arrays(data, a, codec.dtype)
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
         # convenience API
         for item_type in 'int', '<u4':
@@ -1308,8 +1257,7 @@ class TestArray(unittest.TestCase):
             assert z.filters[0].dtype == np.dtype(item_type)
             z[:] = data
             compare_arrays(data, z[:], np.dtype(item_type))
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
     def test_object_arrays_danger(self):
 
@@ -1321,8 +1269,7 @@ class TestArray(unittest.TestCase):
             z[0] = 'foo'
         with pytest.raises(RuntimeError):
             z[:] = 42
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
         # do something else dangerous
         data = greetings * 10
@@ -1336,16 +1283,14 @@ class TestArray(unittest.TestCase):
             with pytest.raises(RuntimeError):
                 # noinspection PyStatementEffect
                 v[:]
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
     def test_object_codec_warnings(self):
 
         with pytest.warns(UserWarning):
             # provide object_codec, but not object dtype
-            z = self.create_array(shape=10, chunks=5, dtype='i4', object_codec=JSON())
-        if hasattr(z.store, 'close'):
-            z.store.close()
+            z = self.create_array(shape=10, chunks=5, dtype="i4", object_codec=JSON())
+        z.store.close()
 
     def test_iteration_exceptions(self):
         # zero d array
@@ -1379,8 +1324,7 @@ class TestArray(unittest.TestCase):
         # check behavior for start > end
         assert [] == list(z.islice(6, 5))
 
-        if hasattr(z.store, 'close'):
-            z.store.close()
+        z.store.close()
 
     def test_iter(self):
         params = (
@@ -1404,8 +1348,7 @@ class TestArray(unittest.TestCase):
             z[:] = a
             for expect, actual in zip_longest(a, z):
                 assert_array_equal(expect, actual)
-            if hasattr(z.store, 'close'):
-                z.store.close()
+            z.store.close()
 
     def test_islice(self):
         params = (
@@ -1443,8 +1386,7 @@ class TestArray(unittest.TestCase):
             assert np.all(a[0:100] == 1)
             a[:] = 1
             assert np.all(a[:] == 1)
-            if hasattr(a.store, 'close'):
-                a.store.close()
+            a.store.close()
 
     def test_endian(self):
         dtype = np.dtype('float32')
@@ -1455,10 +1397,8 @@ class TestArray(unittest.TestCase):
         a2[:] = 1
         x2 = a2[:]
         assert_array_equal(x1, x2)
-        if hasattr(a1.store, 'close'):
-            a1.store.close()
-        if hasattr(a2.store, 'close'):
-            a2.store.close()
+        a1.store.close()
+        a2.store.close()
 
     def test_attributes(self):
         a = self.create_array(shape=10, chunks=10, dtype='i8')
@@ -1472,8 +1412,7 @@ class TestArray(unittest.TestCase):
         attrs = json_loads(a.store[a.attrs.key])
         assert 'foo' in attrs and attrs['foo'] == 'bar'
         assert 'bar' in attrs and attrs['bar'] == 'foo'
-        if hasattr(a.store, 'close'):
-            a.store.close()
+        a.store.close()
 
 
 class TestArrayWithPath(TestArray):
@@ -1486,6 +1425,9 @@ class TestArrayWithPath(TestArray):
         init_array(store, path='foo/bar', **kwargs)
         return Array(store, path='foo/bar', read_only=read_only,
                      cache_metadata=cache_metadata, cache_attrs=cache_attrs)
+
+    def test_nchunks_initialized(self):
+        pass
 
     def test_hexdigest(self):
         # Check basic 1-D array
@@ -1512,7 +1454,7 @@ class TestArrayWithPath(TestArray):
 
     def test_nbytes_stored(self):
 
-        # dict as store
+        # MemoryStore as store
         z = self.create_array(shape=1000, chunks=100)
         expect_nbytes_stored = sum(buffer_size(v)
                                    for k, v in z.store.items()
@@ -2296,6 +2238,9 @@ class CustomMapping(object):
     def __init__(self):
         self.inner = dict()
 
+    def __iter__(self):
+        return iter(self.keys())
+
     def keys(self):
         return self.inner.keys()
 
@@ -2335,9 +2280,9 @@ class TestArrayWithCustomMapping(TestArray):
 
     def test_nbytes_stored(self):
         z = self.create_array(shape=1000, chunks=100)
-        assert -1 == z.nbytes_stored
+        assert 245 == z.nbytes_stored
         z[:] = 42
-        assert -1 == z.nbytes_stored
+        assert 515 == z.nbytes_stored
 
 
 class TestArrayNoCache(TestArray):

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -2,6 +2,7 @@ import atexit
 import os.path
 import shutil
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
@@ -463,29 +464,33 @@ def test_create():
 
 def test_compression_args():
 
-    z = create(100, compression='zlib', compression_opts=9)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        z = create(100, compression="zlib", compression_opts=9)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
 
-    # 'compressor' overrides 'compression'
-    z = create(100, compressor=Zlib(9), compression='bz2', compression_opts=1)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
-
-    # 'compressor' ignores 'compression_opts'
-    z = create(100, compressor=Zlib(9), compression_opts=1)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
-
-    with pytest.warns(UserWarning):
         # 'compressor' overrides 'compression'
-        create(100, compressor=Zlib(9), compression='bz2', compression_opts=1)
-    with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning):
+            z = create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
+
         # 'compressor' ignores 'compression_opts'
-        create(100, compressor=Zlib(9), compression_opts=1)
+        with pytest.warns(UserWarning):
+            z = create(100, compressor=Zlib(9), compression_opts=1)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
+
+        with pytest.warns(UserWarning):
+            # 'compressor' overrides 'compression'
+            create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+        with pytest.warns(UserWarning):
+            # 'compressor' ignores 'compression_opts'
+            create(100, compressor=Zlib(9), compression_opts=1)
 
 
 def test_create_read_only():

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -983,6 +983,11 @@ class TestGroupWithZipStore(TestGroup):
         with pytest.raises(ValueError):
             store.zf.extractall()
 
+    def test_move(self):
+        # zip store is not erasable (can so far only append to a zip
+        # so we can't test for move.
+        pass
+
 
 class TestGroupWithDBMStore(TestGroup):
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -750,42 +750,39 @@ class TestGroup(unittest.TestCase):
         data = np.arange(100)
         g['foo'] = data
 
-        try:
-            g.move('foo', 'bar')
-            assert 'foo' not in g
-            assert 'bar' in g
-            assert_array_equal(data, g['bar'])
+        g.move("foo", "bar")
+        assert "foo" not in g
+        assert "bar" in g
+        assert_array_equal(data, g["bar"])
 
-            g.move('bar', 'foo/bar')
-            assert 'bar' not in g
-            assert 'foo' in g
-            assert 'foo/bar' in g
-            assert isinstance(g['foo'], Group)
-            assert_array_equal(data, g['foo/bar'])
+        g.move("bar", "foo/bar")
+        assert "bar" not in g
+        assert "foo" in g
+        assert "foo/bar" in g
+        assert isinstance(g["foo"], Group)
+        assert_array_equal(data, g["foo/bar"])
 
-            g.move('foo', 'foo2')
-            assert 'foo' not in g
-            assert 'foo/bar' not in g
-            assert 'foo2' in g
-            assert 'foo2/bar' in g
-            assert isinstance(g['foo2'], Group)
-            assert_array_equal(data, g['foo2/bar'])
+        g.move("foo", "foo2")
+        assert "foo" not in g
+        assert "foo/bar" not in g
+        assert "foo2" in g
+        assert "foo2/bar" in g
+        assert isinstance(g["foo2"], Group)
+        assert_array_equal(data, g["foo2/bar"])
 
-            g2 = g['foo2']
-            g2.move('bar', '/bar')
-            assert 'foo2' in g
-            assert 'foo2/bar' not in g
-            assert 'bar' in g
-            assert isinstance(g['foo2'], Group)
-            assert_array_equal(data, g['bar'])
+        g2 = g["foo2"]
+        g2.move("bar", "/bar")
+        assert "foo2" in g
+        assert "foo2/bar" not in g
+        assert "bar" in g
+        assert isinstance(g["foo2"], Group)
+        assert_array_equal(data, g["bar"])
 
-            with pytest.raises(ValueError):
-                g2.move('bar', 'bar2')
+        with pytest.raises(ValueError):
+            g2.move("bar", "bar2")
 
-            with pytest.raises(ValueError):
-                g.move('bar', 'boo')
-        except NotImplementedError:
-            pass
+        with pytest.raises(ValueError):
+            g.move("bar", "boo")
 
         g.store.close()
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -9,7 +9,6 @@ import unittest
 from contextlib import contextmanager
 from pickle import PicklingError
 from zipfile import ZipFile
-import warnings
 
 import numpy as np
 import pytest

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -352,55 +352,51 @@ class StoreTests(object):
 
         # test rename (optional)
         if store.is_erasable():
-            try:
-                store.rename("c/e", "c/e2")
-                assert "c/d" in store
-                assert "c/e" not in store
-                assert "c/e/f" not in store
-                assert "c/e/g" not in store
-                assert "c/e2" not in store
-                assert "c/e2/f" in store
-                assert "c/e2/g" in store
-                store.rename("c/e2", "c/e")
-                assert "c/d" in store
-                assert "c/e2" not in store
-                assert "c/e2/f" not in store
-                assert "c/e2/g" not in store
-                assert "c/e" not in store
-                assert "c/e/f" in store
-                assert "c/e/g" in store
-                store.rename("c", "c1/c2/c3")
-                assert "a" in store
-                assert "c" not in store
-                assert "c/d" not in store
-                assert "c/e" not in store
-                assert "c/e/f" not in store
-                assert "c/e/g" not in store
-                assert "c1" not in store
-                assert "c1/c2" not in store
-                assert "c1/c2/c3" not in store
-                assert "c1/c2/c3/d" in store
-                assert "c1/c2/c3/e" not in store
-                assert "c1/c2/c3/e/f" in store
-                assert "c1/c2/c3/e/g" in store
-                store.rename("c1/c2/c3", "c")
-                assert "c" not in store
-                assert "c/d" in store
-                assert "c/e" not in store
-                assert "c/e/f" in store
-                assert "c/e/g" in store
-                assert "c1" not in store
-                assert "c1/c2" not in store
-                assert "c1/c2/c3" not in store
-                assert "c1/c2/c3/d" not in store
-                assert "c1/c2/c3/e" not in store
-                assert "c1/c2/c3/e/f" not in store
-                assert "c1/c2/c3/e/g" not in store
-            except NotImplementedError:
-                pass
+            store.rename("c/e", "c/e2")
+            assert "c/d" in store
+            assert "c/e" not in store
+            assert "c/e/f" not in store
+            assert "c/e/g" not in store
+            assert "c/e2" not in store
+            assert "c/e2/f" in store
+            assert "c/e2/g" in store
+            store.rename("c/e2", "c/e")
+            assert "c/d" in store
+            assert "c/e2" not in store
+            assert "c/e2/f" not in store
+            assert "c/e2/g" not in store
+            assert "c/e" not in store
+            assert "c/e/f" in store
+            assert "c/e/g" in store
+            store.rename("c", "c1/c2/c3")
+            assert "a" in store
+            assert "c" not in store
+            assert "c/d" not in store
+            assert "c/e" not in store
+            assert "c/e/f" not in store
+            assert "c/e/g" not in store
+            assert "c1" not in store
+            assert "c1/c2" not in store
+            assert "c1/c2/c3" not in store
+            assert "c1/c2/c3/d" in store
+            assert "c1/c2/c3/e" not in store
+            assert "c1/c2/c3/e/f" in store
+            assert "c1/c2/c3/e/g" in store
+            store.rename("c1/c2/c3", "c")
+            assert "c" not in store
+            assert "c/d" in store
+            assert "c/e" not in store
+            assert "c/e/f" in store
+            assert "c/e/g" in store
+            assert "c1" not in store
+            assert "c1/c2" not in store
+            assert "c1/c2/c3" not in store
+            assert "c1/c2/c3/d" not in store
+            assert "c1/c2/c3/e" not in store
+            assert "c1/c2/c3/e/f" not in store
+            assert "c1/c2/c3/e/g" not in store
 
-        # test rmdir (optional)
-        if store.is_erasable():
+            # test rmdir (optional)
             store.rmdir("c/e")
             assert "c/d" in store
             assert "c/e/f" not in store

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -97,8 +97,7 @@ def test_coverage_rename():
 
 def test_deprecated_listdir_nosotre():
     store = dict()
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")
+    with pytest.warns(UserWarning, match="has not `listdir`"):
         listdir(store)
 
 

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,11 +1,12 @@
 import collections
-from collections.abc import MutableMapping
 import os
+
+from zarr.storage import Store
 
 import pytest
 
 
-class CountingDict(MutableMapping):
+class CountingDict(Store):
 
     def __init__(self):
         self.wrapped = dict()


### PR DESCRIPTION
In progress, 

All existing stores in zarr-python now inherit from this; and thus all the test stop testing for a `close()` method and call it unconditionally.

The base store is a bit more strict in what it accepts than subclasses (only allow strings), as it is generally safer for the superclass to be stricter as anything that works with superclass will work with subclass, but the opposite is untrue.




TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
