### PR TITLE
Use github workflow to build sdist/wheel and upload.

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    env:
-      CIBW_TEST_COMMAND: pytest --pyargs zarr
-      CIBW_TEST_REQUIRES: pytest
-      CIBW_SKIP: "*27* pp*"
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -4,12 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build_artifacts:
-    name: Build wheel on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheel on ubuntu-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-18.04]
     env:
       CIBW_TEST_COMMAND: pytest --pyargs zarr
       CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,68 @@
+name: Wheels
+
+on: [push, pull_request]
+
+jobs:
+  build_artifacts:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+    env:
+      CIBW_TEST_COMMAND: pytest --pyargs zarr
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_SKIP: "*27* pp*"
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v1
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install PyBuil
+        run: |
+          python -m pip install build
+
+      - name: Build wheel and sdist
+        run: |
+          python -m build
+      - uses: actions/upload-artifact@v1
+        with:
+          name: releases
+          path: dist
+
+  test_dist_pypi:
+    needs: [build_artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: releases
+          path: dist
+
+      - name: test
+        run: |
+          ls
+          ls dist
+
+  upload_pypi:
+    needs: [build_artifacts]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: releases
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Install PyBuil
+      - name: Install PyBuild
         run: |
           python -m pip install build
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -54,11 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: releases
-          path: dist
-
       - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -330,6 +330,11 @@ compatibility in some way.
 Release procedure
 ~~~~~~~~~~~~~~~~~
 
+.. note:: 
+
+   Most of the release process is now handled by github workflow which should
+   automatically push a release to PyPI if a tag is pushed. 
+
 Checkout and update the master branch::
 
     $ git checkout master
@@ -347,7 +352,6 @@ Tag the version (where "X.X.X" stands for the version number, e.g., "2.2.0")::
 
 Release source code to PyPI::
 
-    $ python setup.py register sdist
     $ twine upload dist/zarr-${version}.tar.gz
 
 Obtain checksum for release to conda-forge::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Setup a github workflow based on numcodec to build sdist and wheel. Adapted from numcodec. 
I have to check what ciwheel do, as zarr wheels are likely universal and dont' need to be per-platform

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
