### PR TITLE
Remove some extra Python 3.5 conditionals.

### DIFF
--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -2,7 +2,6 @@ import atexit
 import os
 import pickle
 import shutil
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -990,8 +989,7 @@ class TestGroupWithZipStore(TestGroup):
 
         # Check that exiting the context manager closes the store,
         # and therefore the underlying ZipFile.
-        error = ValueError if sys.version_info >= (3, 6) else RuntimeError
-        with pytest.raises(error):
+        with pytest.raises(ValueError):
             store.zf.extractall()
 
 

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,8 +1,6 @@
 import collections
-from distutils.version import LooseVersion
 from collections.abc import MutableMapping
 import os
-import sys
 
 import pytest
 
@@ -50,10 +48,8 @@ def skip_test_env_var(name):
 
 
 try:
-    if LooseVersion(sys.version) >= LooseVersion("3.6"):
-        import fsspec  # noqa: F401
-        have_fsspec = True
-    else:  # pragma: no cover
-        have_fsspec = False
+    import fsspec  # noqa: F401
+
+    have_fsspec = True
 except ImportError:  # pragma: no cover
     have_fsspec = False


### PR DESCRIPTION
That should remove all the Python 3.5 codepath, at leat all the explicit
ones.

[Description of PR]

TODO:
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
