### PR TITLE
add .gitattributes to fix repo language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.py linguist-language=python
+*.ipynb linguist-documentation


### PR DESCRIPTION
[Description of PR]

Add .gitattributes so that can be correctly labelled as python project

Before
```
85.21%  Jupyter Notebook
14.53%  Python
0.23%   Roff
0.04%   Batchfile
```
After
```
98.19%  Python
1.55%   Roff
0.26%   Batchfile
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
