### PR TITLE
Remove 3.5 configuration from tox, run pyflakes on ghaction.

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -59,3 +59,26 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           # To test: repository_url: https://test.pypi.org/legacy/
+  build_artifacts:
+    name: Linting with flake8
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v1
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install pyflakes
+        run: |
+          python -m pip install pyflakes
+      - name: run pyflakes
+        run: |
+          pyflakes zarr
+

--- a/tox.ini
+++ b/tox.ini
@@ -18,13 +18,13 @@ commands =
     # clear out any data files generated during tests
     python -c 'import glob; import shutil; import os; [(shutil.rmtree(d) if os.path.isdir(d) else os.remove(d) if os.path.isfile(d) else None) for d in glob.glob("./example*")]'
     # main unit test runner
-    py35,py36,py38: pytest -v --cov=zarr --cov-config=.coveragerc zarr
+    py36,py38: pytest -v --cov=zarr --cov-config=.coveragerc zarr
     # don't collect coverage when running older numpy versions
     py37-{npy115,npy116}: pytest -v zarr
     # collect coverage and run doctests under py37
     py37-npylatest: pytest -v --cov=zarr --cov-config=.coveragerc --doctest-plus zarr --remote-data
     # generate a coverage report
-    py35,py36,py37-npylatest,py38: coverage report -m
+    py36,py37-npylatest,py38: coverage report -m
     # run doctests in the tutorial and spec
     py38: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     # pep8 checks
@@ -34,7 +34,7 @@ commands =
 deps =
     py37-npy115: numpy==1.15.4
     py37-npy116: numpy==1.16.4
-    py35,py36,py37-npylatest,py38: -rrequirements_dev_numpy.txt
+    py36,py37-npylatest,py38: -rrequirements_dev_numpy.txt
     -rrequirements_dev_minimal.txt
     -rrequirements_dev_optional.txt
 


### PR DESCRIPTION
This will run way faster than travis and should allow to distinguish
actual test failure from formatting failures in PRs if we deactivate
flake8 from tox.
