### PR TITLE
Remove unused `default` keyword that is only used internally

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -129,9 +129,9 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     return z
 
 
-def normalize_store_arg(store, clobber=False, default=dict, storage_options=None):
+def normalize_store_arg(store, clobber=False, storage_options=None):
     if store is None:
-        return default()
+        return dict()
     elif isinstance(store, str):
         mode = 'w' if clobber else 'r'
         if "://" in store or "::" in store:

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1036,7 +1036,9 @@ class Group(MutableMapping):
 
 
 def _normalize_store_arg(store, clobber=False, storage_options=None):
-    return normalize_store_arg(store, clobber=clobber, default=MemoryStore,
+    if store is None:
+        return MemoryStore()
+    return normalize_store_arg(store, clobber=clobber,
                                storage_options=storage_options)
 
 


### PR DESCRIPTION
Move it to the only two places where it is used;
technically this is a change of API, but the function
`normalize_store_arg` is only used internally.

This make it a bit easier to follow what might happens when it is
called; in particular this will let us be sure that it always returns a
Store as as long as it is passed is a Store or a string, whicl before it
could have returned anything depending on the value of default.
