### PR TITLE
Mute a bit codecov report.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,9 @@ coverage:
     patch:
       default:
         target: 100
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: true  # if true: only post the comment if coverage changes
+  branches:               # branch names that can post comment
+    - "master"


### PR DESCRIPTION
Codecov report are a bit noisy, this mute them a bit y removing the
large graph and postigin only if there is a coverage change.