### PR TITLE
n5: prevent failure on missing group metadata

### DIFF
--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -304,13 +304,18 @@ def invert_chunk_coords(key):
 def group_metadata_to_n5(group_metadata):
     '''Convert group metadata from zarr to N5 format.'''
     del group_metadata['zarr_format']
+    # TODO: This should only exist at the top-level
     group_metadata['n5'] = '2.0.0'
     return group_metadata
 
 
 def group_metadata_to_zarr(group_metadata):
     '''Convert group metadata from N5 to zarr format.'''
-    del group_metadata['n5']
+    try:
+        del group_metadata['n5']
+    except KeyError:
+        # This only exists at the top level
+        pass
     group_metadata['zarr_format'] = ZARR_FORMAT
     return group_metadata
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -311,7 +311,11 @@ def group_metadata_to_n5(group_metadata):
 
 def group_metadata_to_zarr(group_metadata):
     '''Convert group metadata from N5 to zarr format.'''
-    group_metadata.pop('n5')
+    try:
+        group_metadata.pop('n5')
+    except KeyError:
+        # This only exists at the top level
+        pass
     group_metadata['zarr_format'] = ZARR_FORMAT
     return group_metadata
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -311,11 +311,7 @@ def group_metadata_to_n5(group_metadata):
 
 def group_metadata_to_zarr(group_metadata):
     '''Convert group metadata from N5 to zarr format.'''
-    try:
-        del group_metadata['n5']
-    except KeyError:
-        # This only exists at the top level
-        pass
+    group_metadata.pop('n5')
     group_metadata['zarr_format'] = ZARR_FORMAT
     return group_metadata
 

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -252,6 +252,24 @@ def test_open_array():
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
 
+    store = 'data/group.n5'
+    z = open_group(store, mode='w')
+    i = z.create_group('inner')
+    a = i.zeros("array", shape=100, chunks=10)
+    a[:] = 42
+
+    # Edit inner/attributes.json to not include "n5"
+    with open('data/group.n5/inner/attributes.json', 'w') as o:
+        o.write("{}")
+
+    # Re-open
+    a = open_group(store)["inner"]["array"]
+    assert isinstance(a, Array)
+    assert isinstance(z.store, N5Store)
+    assert (100,) == a.shape
+    assert (10,) == a.chunks
+    assert_array_equal(np.full(100, fill_value=42), a[:])
+
 
 def test_empty_like():
 


### PR DESCRIPTION
In the N5 spec, https://github.com/saalfeldlab/n5#file-system-specification
point 3, the `{"n5": "$version"}` metadata is only expected at the root level.
Datasets missing the metadata on inner groups fail to load:

```
In [43]: list(zarr.hierarchy.Group(store=zarr.n5.N5Store("ex.n5")).groups())
...
ValueError: group not found at path 'setup0'
```

This changes the group parsing logic to not fail if the metadata is
missing. Suggestions welcome on how to detect the top group/array in
order to special case the parsing.

see https://github.com/tischi/i2k-2020-s3-zarr-workshop/issues/1#issuecomment-726224950  for the original report


TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
