### PR TITLE
fixes s3 fixture for s3 test complex

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1113,9 +1113,7 @@ class FSStore(MutableMapping):
             raise ReadOnlyError()
         store_path = self.dir_path(path)
         if self.fs.isdir(store_path):
-            # sometimes doesn't delete on first try with S3
-            while self.fs.exists(store_path):
-                self.fs.rm(store_path, recursive=True)
+            self.fs.rm(store_path, recursive=True)
 
     def getsize(self, path=None):
         store_path = self.dir_path(path)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1033,8 +1033,6 @@ def s3(request):
     s3so = dict(client_kwargs={'endpoint_url': endpoint_uri},
                 use_listings_cache=False)
     s3 = s3fs.S3FileSystem(anon=False, **s3so)
-    # if s3.exists("test"):
-    #     s3.rm("test", recursive=True)
     s3.mkdir("test")
     request.cls.s3so = s3so
     yield

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1033,8 +1033,8 @@ def s3(request):
     s3so = dict(client_kwargs={'endpoint_url': endpoint_uri},
                 use_listings_cache=False)
     s3 = s3fs.S3FileSystem(anon=False, **s3so)
-    if s3.exists("test"):
-        s3.rm("test", recursive=True)
+    # if s3.exists("test"):
+    #     s3.rm("test", recursive=True)
     s3.mkdir("test")
     request.cls.s3so = s3so
     yield

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1030,8 +1030,11 @@ def s3(request):
             pass
         timeout -= 0.1  # pragma: no cover
         time.sleep(0.1)  # pragma: no cover
-    s3so = dict(client_kwargs={'endpoint_url': endpoint_uri})
+    s3so = dict(client_kwargs={'endpoint_url': endpoint_uri},
+                use_listings_cache=False)
     s3 = s3fs.S3FileSystem(anon=False, **s3so)
+    if s3.exists("test"):
+        s3.rm("test", recursive=True)
     s3.mkdir("test")
     request.cls.s3so = s3so
     yield


### PR DESCRIPTION
Fixes directory caching issues that can occur in `zarr/tests/test_storage.py::TestFSStore::test_s3_complex`. Also removed code that was used to previously fix the issue.

fixes issue #653 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
