### PR TITLE
Provide default if `.pop(...)` errors

### DIFF
--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -311,11 +311,8 @@ def group_metadata_to_n5(group_metadata):
 
 def group_metadata_to_zarr(group_metadata):
     '''Convert group metadata from N5 to zarr format.'''
-    try:
-        group_metadata.pop('n5')
-    except KeyError:
-        # This only exists at the top level
-        pass
+    # This only exists at the top level
+    group_metadata.pop('n5', None)
     group_metadata['zarr_format'] = ZARR_FORMAT
     return group_metadata
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/zarr-developers/zarr-python/pull/651 )

As `.pop(...)` already catches the `KeyError` if a default value is supplied, use that to simplify the code a bit.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
