### PR TITLE
Copy also attributes on root in copy_all

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,6 +13,8 @@ This release will be the first release of Zarr not supporting Python 3.5.
 * Add `Array` tests for FSStore.
   By :user:`Andrew Fulton <andrewfulton9>`; :issue: `644`.
 
+* fix a bug in which ``attrs`` would not be copied on the root when using ``copy_all``; :issue:`613`
+
 2.5.0
 -----
 

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1065,6 +1065,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
             n_copied += c
             n_skipped += s
             n_bytes_copied += b
+        dest.attrs.update(**source.attrs)
 
         # log a final message with a summary of what happened
         _log_copy_summary(log, dry_run, n_copied, n_skipped, n_bytes_copied)


### PR DESCRIPTION
Closes #613 

This only affect the root as _copy does the right thing on recursion.

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] AppVeyor and Travis CI passes
* [x] Test coverage is 100% (Coveralls passes)
