### PR TITLE
Add guard as to version number;

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -21,11 +21,19 @@ jobs:
 
       - name: Install PyBuild
         run: |
-          python -m pip install build
+          python -m pip install 'build!=0.1' setuptools-scm
 
       - name: Build wheel and sdist
         run: |
           python -m build
+          git describe
+          pwd
+          if [ -f dist/zarr-0.0.0.tar.gz ]; then
+            echo "WRONG VERSION NUMBER"
+            exit 1
+          else
+            echo "All seem good"
+          fi
       - uses: actions/upload-artifact@v1
         with:
           name: releases

--- a/zarr/__init__.py
+++ b/zarr/__init__.py
@@ -16,3 +16,6 @@ from zarr.storage import (ABSStore, DBMStore, DictStore, DirectoryStore,
                           TempStore, ZipStore)
 from zarr.sync import ProcessSynchronizer, ThreadSynchronizer
 from zarr.version import version as __version__
+
+# in case setuptools scm screw up and find version to be 0.0.0
+assert not __version__.startswith("0.0.0")


### PR DESCRIPTION
It seem like setuptools scm can screw up and this should ensure we catch
that in CI before making the wheel.