### PR TITLE
Partial read

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -30,6 +30,18 @@ This release od Zarr Python is is the first release of Zarr to not supporting Py
 See `this link <https://github.com/zarr-developers/zarr-python/milestone/11?closed=1>` for the full list of closed and
 merged PR tagged with the 2.6 milestone.
 
+* Add ability to partially read and decompress arrays, see :issue:`667`. It is
+  only available to chunks stored using fs-spec and using bloc as a compressor.
+
+  For certain analysis case when only a small portion of chunks is needed it can
+  be advantageous to only access and decompress part of the chunks. Doing
+  partial read and decompression add high latency to many of the operation so
+  should be used only when the subset of the data is small compared to the full
+  chunks and is stored contiguously (that is to say either last dimensions for C
+  layout, firsts for F). Pass ``partial_decompress=True`` as argument when
+  creating an ``Array``, or when using ``open_array``. No option exists yet to
+  apply partial read and decompress on a per-operation basis.
+
 2.5.0
 -----
 

--- a/requirements_dev_minimal.txt
+++ b/requirements_dev_minimal.txt
@@ -1,7 +1,7 @@
 # library requirements
 asciitree==0.3.3
 fasteners==0.15
-numcodecs==0.6.4
+numcodecs==0.7.2
 msgpack-python==0.5.6
 setuptools-scm==3.3.3
 # test requirements

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1147,7 +1147,7 @@ class Array:
 
         See Also
         --------
-        basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
+        get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
         set_orthogonal_selection, vindex, oindex, __getitem__
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -11,22 +11,41 @@ from numcodecs.compat import ensure_bytes, ensure_ndarray
 
 from zarr.attrs import Attributes
 from zarr.codecs import AsType, get_codec
-from zarr.errors import ArrayNotFoundError, ReadOnlyError
-from zarr.indexing import (BasicIndexer, CoordinateIndexer, MaskIndexer,
-                           OIndex, OrthogonalIndexer, VIndex, check_fields,
-                           check_no_multi_fields, ensure_tuple,
-                           err_too_many_indices, is_contiguous_selection,
-                           is_scalar, pop_fields)
+from zarr.errors import ArrayNotFoundError, ReadOnlyError, ArrayIndexError
+from zarr.indexing import (
+    BasicIndexer,
+    CoordinateIndexer,
+    MaskIndexer,
+    OIndex,
+    OrthogonalIndexer,
+    VIndex,
+    PartialChunkIterator,
+    check_fields,
+    check_no_multi_fields,
+    ensure_tuple,
+    err_too_many_indices,
+    is_contiguous_selection,
+    is_scalar,
+    pop_fields,
+)
 from zarr.meta import decode_array_metadata, encode_array_metadata
 from zarr.storage import array_meta_key, attrs_key, getsize, listdir
-from zarr.util import (InfoReporter, check_array_shape, human_readable_size,
-                       is_total_slice, nolock, normalize_chunks,
-                       normalize_resize_args, normalize_shape,
-                       normalize_storage_path)
+from zarr.util import (
+    InfoReporter,
+    check_array_shape,
+    human_readable_size,
+    is_total_slice,
+    nolock,
+    normalize_chunks,
+    normalize_resize_args,
+    normalize_shape,
+    normalize_storage_path,
+    PartialReadBuffer,
+)
 
 
 # noinspection PyUnresolvedReferences
-class Array(object):
+class Array:
     """Instantiate an array from an initialized store.
 
     Parameters
@@ -51,6 +70,12 @@ class Array(object):
         If True (default), user attributes will be cached for attribute read
         operations. If False, user attributes are reloaded from the store prior
         to all attribute read operations.
+    partial_decompress : bool, optional
+        If True and while the chunk_store is a FSStore and the compresion used
+        is Blosc, when getting data from the array chunks will be partially
+        read and decompressed when possible.
+
+        .. versionadded:: 2.7
 
     Attributes
     ----------
@@ -102,8 +127,17 @@ class Array(object):
 
     """
 
-    def __init__(self, store, path=None, read_only=False, chunk_store=None,
-                 synchronizer=None, cache_metadata=True, cache_attrs=True):
+    def __init__(
+        self,
+        store,
+        path=None,
+        read_only=False,
+        chunk_store=None,
+        synchronizer=None,
+        cache_metadata=True,
+        cache_attrs=True,
+        partial_decompress=False,
+    ):
         # N.B., expect at this point store is fully initialized with all
         # configuration metadata fully specified and normalized
 
@@ -118,6 +152,7 @@ class Array(object):
         self._synchronizer = synchronizer
         self._cache_metadata = cache_metadata
         self._is_view = False
+        self._partial_decompress = partial_decompress
 
         # initialize metadata
         self._load_metadata()
@@ -1112,7 +1147,7 @@ class Array(object):
 
         See Also
         --------
-        get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
+        basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
         set_orthogonal_selection, vindex, oindex, __getitem__
 
@@ -1580,8 +1615,17 @@ class Array(object):
             self._chunk_setitems(lchunk_coords, lchunk_selection, chunk_values,
                                  fields=fields)
 
-    def _process_chunk(self, out, cdata, chunk_selection, drop_axes,
-                       out_is_ndarray, fields, out_selection):
+    def _process_chunk(
+        self,
+        out,
+        cdata,
+        chunk_selection,
+        drop_axes,
+        out_is_ndarray,
+        fields,
+        out_selection,
+        partial_read_decode=False,
+    ):
         """Take binary data from storage and fill output array"""
         if (out_is_ndarray and
                 not fields and
@@ -1604,8 +1648,9 @@ class Array(object):
                 # optimization: we want the whole chunk, and the destination is
                 # contiguous, so we can decompress directly from the chunk
                 # into the destination array
-
                 if self._compressor:
+                    if isinstance(cdata, PartialReadBuffer):
+                        cdata = cdata.read_full()
                     self._compressor.decode(cdata, dest)
                 else:
                     chunk = ensure_ndarray(cdata).view(self._dtype)
@@ -1614,6 +1659,33 @@ class Array(object):
                 return
 
         # decode chunk
+        try:
+            if partial_read_decode:
+                cdata.prepare_chunk()
+                # size of chunk
+                tmp = np.empty(self._chunks, dtype=self.dtype)
+                index_selection = PartialChunkIterator(chunk_selection, self.chunks)
+                for start, nitems, partial_out_selection in index_selection:
+                    expected_shape = [
+                        len(
+                            range(*partial_out_selection[i].indices(self.chunks[0] + 1))
+                        )
+                        if i < len(partial_out_selection)
+                        else dim
+                        for i, dim in enumerate(self.chunks)
+                    ]
+                    cdata.read_part(start, nitems)
+                    chunk_partial = self._decode_chunk(
+                        cdata.buff,
+                        start=start,
+                        nitems=nitems,
+                        expected_shape=expected_shape,
+                    )
+                    tmp[partial_out_selection] = chunk_partial
+                out[out_selection] = tmp[chunk_selection]
+                return
+        except ArrayIndexError:
+            cdata = cdata.read_full()
         chunk = self._decode_chunk(cdata)
 
         # select data from chunk
@@ -1688,11 +1760,36 @@ class Array(object):
             out_is_ndarray = False
 
         ckeys = [self._chunk_key(ch) for ch in lchunk_coords]
-        cdatas = self.chunk_store.getitems(ckeys, on_error="omit")
+        if (
+            self._partial_decompress
+            and self._compressor
+            and self._compressor.codec_id == "blosc"
+            and hasattr(self._compressor, "decode_partial")
+            and not fields
+            and self.dtype != object
+            and hasattr(self.chunk_store, "getitems")
+        ):
+            partial_read_decode = True
+            cdatas = {
+                ckey: PartialReadBuffer(ckey, self.chunk_store)
+                for ckey in ckeys
+                if ckey in self.chunk_store
+            }
+        else:
+            partial_read_decode = False
+            cdatas = self.chunk_store.getitems(ckeys, on_error="omit")
         for ckey, chunk_select, out_select in zip(ckeys, lchunk_selection, lout_selection):
             if ckey in cdatas:
-                self._process_chunk(out, cdatas[ckey], chunk_select, drop_axes,
-                                    out_is_ndarray, fields, out_select)
+                self._process_chunk(
+                    out,
+                    cdatas[ckey],
+                    chunk_select,
+                    drop_axes,
+                    out_is_ndarray,
+                    fields,
+                    out_select,
+                    partial_read_decode=partial_read_decode,
+                )
             else:
                 # check exception type
                 if self._fill_value is not None:
@@ -1706,7 +1803,8 @@ class Array(object):
         ckeys = [self._chunk_key(co) for co in lchunk_coords]
         cdatas = [self._process_for_setitem(key, sel, val, fields=fields)
                   for key, sel, val in zip(ckeys, lchunk_selection, values)]
-        self.chunk_store.setitems({k: v for k, v in zip(ckeys, cdatas)})
+        values = {k: v for k, v in zip(ckeys, cdatas)}
+        self.chunk_store.setitems(values)
 
     def _chunk_setitem(self, chunk_coords, chunk_selection, value, fields=None):
         """Replace part or whole of a chunk.
@@ -1800,11 +1898,17 @@ class Array(object):
     def _chunk_key(self, chunk_coords):
         return self._key_prefix + '.'.join(map(str, chunk_coords))
 
-    def _decode_chunk(self, cdata):
-
+    def _decode_chunk(self, cdata, start=None, nitems=None, expected_shape=None):
         # decompress
         if self._compressor:
-            chunk = self._compressor.decode(cdata)
+            # only decode requested items
+            if (
+                all([x is not None for x in [start, nitems]])
+                and self._compressor.codec_id == "blosc"
+            ) and hasattr(self._compressor, "decode_partial"):
+                chunk = self._compressor.decode_partial(cdata, start, nitems)
+            else:
+                chunk = self._compressor.decode(cdata)
         else:
             chunk = cdata
 
@@ -1829,7 +1933,7 @@ class Array(object):
 
         # ensure correct chunk shape
         chunk = chunk.reshape(-1, order='A')
-        chunk = chunk.reshape(self._chunks, order=self._order)
+        chunk = chunk.reshape(expected_shape or self._chunks, order=self._order)
 
         return chunk
 

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -362,11 +362,26 @@ def array(data, **kwargs):
     return z
 
 
-def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
-               compressor='default', fill_value=0, order='C', synchronizer=None,
-               filters=None, cache_metadata=True, cache_attrs=True, path=None,
-               object_codec=None, chunk_store=None, storage_options=None,
-               **kwargs):
+def open_array(
+    store=None,
+    mode="a",
+    shape=None,
+    chunks=True,
+    dtype=None,
+    compressor="default",
+    fill_value=0,
+    order="C",
+    synchronizer=None,
+    filters=None,
+    cache_metadata=True,
+    cache_attrs=True,
+    path=None,
+    object_codec=None,
+    chunk_store=None,
+    storage_options=None,
+    partial_decompress=False,
+    **kwargs
+):
     """Open an array using file-mode-like semantics.
 
     Parameters
@@ -415,6 +430,12 @@ def open_array(store=None, mode='a', shape=None, chunks=True, dtype=None,
     storage_options : dict
         If using an fsspec URL to create the store, these will be passed to
         the backend implementation. Ignored otherwise.
+    partial_decompress : bool, optional
+        If True and while the chunk_store is a FSStore and the compresion used
+        is Blosc, when getting data from the array chunks will be partially
+        read and decompressed when possible.
+
+        .. versionadded:: 2.7
 
     Returns
     -------

--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -15,6 +15,10 @@ class _BaseZarrError(ValueError):
         super().__init__(self._msg.format(*args))
 
 
+class ArrayIndexError(IndexError):
+    pass
+
+
 class _BaseZarrIndexError(IndexError):
     _msg = ""
 

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -829,18 +829,14 @@ def pop_fields(selection):
     return fields, selection
 
 
-def int_to_slice(dim_selection):
-    return slice(dim_selection, dim_selection + 1, 1)
-
-
 def make_slice_selection(selection):
     ls = []
     for dim_selection in selection:
         if is_integer(dim_selection):
-            ls.append(int_to_slice(dim_selection))
+            ls.append(slice(dim_selection, dim_selection + 1, 1))
         elif isinstance(dim_selection, np.ndarray):
             if len(dim_selection) == 1:
-                ls.append(int_to_slice(dim_selection[0]))
+                ls.append(slice(dim_selection[0], dim_selection[0] + 1, 1))
             else:
                 raise ArrayIndexError()
         else:

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -5,7 +5,9 @@ import numbers
 
 import numpy as np
 
+
 from zarr.errors import (
+    ArrayIndexError,
     NegativeStepError,
     err_too_many_indices,
     VindexInvalidSelectionError,
@@ -471,7 +473,7 @@ class IntArrayDimIndexer(object):
             yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
 
 
-def slice_to_range(s, l):  # noqa: E741
+def slice_to_range(s: slice, l: int):  # noqa: E741
     return range(*s.indices(l))
 
 
@@ -825,3 +827,120 @@ def pop_fields(selection):
         selection = tuple(s for s in selection if not isinstance(s, str))
         selection = selection[0] if len(selection) == 1 else selection
     return fields, selection
+
+
+def int_to_slice(dim_selection):
+    return slice(dim_selection, dim_selection + 1, 1)
+
+
+def make_slice_selection(selection):
+    ls = []
+    for dim_selection in selection:
+        if is_integer(dim_selection):
+            ls.append(int_to_slice(dim_selection))
+        elif isinstance(dim_selection, np.ndarray):
+            if len(dim_selection) == 1:
+                ls.append(int_to_slice(dim_selection[0]))
+            else:
+                raise ArrayIndexError()
+        else:
+            ls.append(dim_selection)
+    return ls
+
+
+class PartialChunkIterator(object):
+    """Iterator to retrieve the specific coordinates of requested data
+    from within a compressed chunk.
+
+    Parameters
+    ----------
+    selection : tuple
+        tuple of slice objects to take from the chunk
+    arr_shape : shape of chunk to select data from
+
+    Attributes
+    -----------
+    arr_shape
+    selection
+
+    Returns
+    -------
+    Tuple with 3 elements:
+
+    start: int
+        elements offset in the chunk to read from
+    nitems: int
+        number of elements to read in the chunk from start
+    partial_out_selection: list of slices
+        indices of a temporary empty array of size `Array._chunks` to assign
+        the decompressed data to after the partial read.
+
+    Notes
+    -----
+    An array is flattened when compressed with blosc, so this iterator takes
+    the wanted selection of an array and determines the wanted coordinates
+    of the flattened, compressed data to be read and then decompressed. The
+    decompressed data is then placed in a temporary empty array of size
+    `Array._chunks` at the indices yielded as partial_out_selection.
+    Once all the slices yielded by this iterator have been read, decompressed
+    and written to the temporary array, the wanted slice of the chunk can be
+    indexed from the temporary array and written to the out_selection slice
+    of the out array.
+
+    """
+
+    def __init__(self, selection, arr_shape):
+        selection = make_slice_selection(selection)
+        self.arr_shape = arr_shape
+
+        # number of selection dimensions can't be greater than the number of chunk dimensions
+        if len(selection) > len(self.arr_shape):
+            raise ValueError(
+                "Selection has more dimensions then the array:\n"
+                f"selection dimensions = {len(selection)}\n"
+                f"array dimensions = {len(self.arr_shape)}"
+            )
+
+        # any selection can not be out of the range of the chunk
+        selection_shape = np.empty(self.arr_shape)[tuple(selection)].shape
+        if any(
+            [
+                selection_dim < 0 or selection_dim > arr_dim
+                for selection_dim, arr_dim in zip(selection_shape, self.arr_shape)
+            ]
+        ):
+            raise IndexError(
+                "a selection index is out of range for the dimension"
+            )  # pragma: no cover
+
+        for i, dim_size in enumerate(self.arr_shape[::-1]):
+            index = len(self.arr_shape) - (i + 1)
+            if index <= len(selection) - 1:
+                slice_size = selection_shape[index]
+                if slice_size == dim_size and index > 0:
+                    selection.pop()
+                else:
+                    break
+
+        chunk_loc_slices = []
+        last_dim_slice = None if selection[-1].step > 1 else selection.pop()
+        for arr_shape_i, sl in zip(arr_shape, selection):
+            dim_chunk_loc_slices = []
+            assert isinstance(sl, slice)
+            for x in slice_to_range(sl, arr_shape_i):
+                dim_chunk_loc_slices.append(slice(x, x + 1, 1))
+            chunk_loc_slices.append(dim_chunk_loc_slices)
+        if last_dim_slice:
+            chunk_loc_slices.append([last_dim_slice])
+        self.chunk_loc_slices = list(itertools.product(*chunk_loc_slices))
+
+    def __iter__(self):
+        chunk1 = self.chunk_loc_slices[0]
+        nitems = (chunk1[-1].stop - chunk1[-1].start) * np.prod(
+            self.arr_shape[len(chunk1) :], dtype=int
+        )
+        for partial_out_selection in self.chunk_loc_slices:
+            start = 0
+            for i, sl in enumerate(partial_out_selection):
+                start += sl.start * np.prod(self.arr_shape[i + 1 :], dtype=int)
+            yield start, nitems, partial_out_selection

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -18,11 +18,20 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from zarr.core import Array
 from zarr.meta import json_loads
 from zarr.n5 import N5Store, n5_keywords
-from zarr.storage import (ABSStore, DBMStore, DirectoryStore, LMDBStore,
-                          LRUStoreCache, NestedDirectoryStore, SQLiteStore,
-                          FSStore, atexit_rmglob, atexit_rmtree, init_array,
-                          init_group
-                          )
+from zarr.storage import (
+    ABSStore,
+    DBMStore,
+    DirectoryStore,
+    LMDBStore,
+    LRUStoreCache,
+    NestedDirectoryStore,
+    SQLiteStore,
+    FSStore,
+    atexit_rmglob,
+    atexit_rmtree,
+    init_array,
+    init_group,
+)
 from zarr.util import buffer_size
 from zarr.tests.util import skip_test_env_var, have_fsspec
 
@@ -2376,7 +2385,6 @@ class TestArrayWithStoreCache(TestArray):
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestArrayWithFSStore(TestArray):
-
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -2411,3 +2419,78 @@ class TestArrayWithFSStore(TestArray):
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
         assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStorePartialRead(TestArray):
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        #use_listings_cache=kwargs.pop("use_listings_cache", True)
+        store = FSStore(path)
+        cache_metadata = kwargs.pop("cache_metadata", True)
+        cache_attrs = kwargs.pop("cache_attrs", True)
+        kwargs.setdefault("compressor", Blosc())
+        init_array(store, **kwargs)
+        return Array(
+            store,
+            read_only=read_only,
+            cache_metadata=cache_metadata,
+            cache_attrs=cache_attrs,
+            partial_decompress=True,
+        )
+
+    def test_hexdigest(self):
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        assert "f710da18d45d38d4aaf2afd7fb822fdd73d02957" == z.hexdigest()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
+        assert "1437428e69754b1e1a38bd7fc9e43669577620db" == z.hexdigest()
+
+        # Check basic 2-D array
+        z = self.create_array(
+            shape=(
+                20,
+                35,
+            ),
+            chunks=10,
+            dtype="<i4",
+        )
+        assert "6c530b6b9d73e108cc5ee7b6be3d552cc994bdbe" == z.hexdigest()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z[200:400] = np.arange(200, 400, dtype="i4")
+        assert "4c0a76fb1222498e09dcd92f7f9221d6cea8b40e" == z.hexdigest()
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z.attrs["foo"] = "bar"
+        assert "05b0663ffe1785f38d3a459dec17e57a18f254af" == z.hexdigest()
+
+    def test_non_cont(self):
+        z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
+        z[:, :, :] = 1
+        # actually go through the partial read by accessing a single item
+        assert z[0, :, 0].any()
+
+    def test_read_nitems_less_than_blocksize_from_multiple_chunks(self):
+        '''Tests to make sure decompression doesn't fail when `nitems` is
+        less than a compressed block size, but covers multiple blocks
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[40_000:80_000] = 1
+        b = Array(z.store, read_only=True, partial_decompress=True)
+        assert (b[40_000:80_000] == 1).all()
+
+    def test_read_from_all_blocks(self):
+        '''Tests to make sure `PartialReadBuffer.read_part` doesn't fail when
+        stop isn't in the `start_points` array
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[2:99_000] = 1
+        b = Array(z.store, read_only=True, partial_decompress=True)
+        assert (b[2:99_000] == 1).all()

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -3,8 +3,13 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import zarr
-from zarr.indexing import (normalize_integer_selection, oindex, oindex_set,
-                           replace_ellipsis)
+from zarr.indexing import (
+    normalize_integer_selection,
+    oindex,
+    oindex_set,
+    replace_ellipsis,
+    PartialChunkIterator,
+)
 
 
 def test_normalize_integer_selection():
@@ -1288,3 +1293,83 @@ def test_set_selections_with_fields():
             a[key][ix] = v[key][ix]
             z.set_mask_selection(ix, v[key][ix], fields=fields)
             assert_array_equal(a, z[:])
+
+
+@pytest.mark.parametrize(
+    "selection, arr, expected",
+    [
+        (
+            (slice(5, 8, 1), slice(2, 4, 1), slice(0, 100, 1)),
+            np.arange(2, 100_002).reshape((100, 10, 100)),
+            [
+                (5200, 200, (slice(5, 6, 1), slice(2, 4, 1))),
+                (6200, 200, (slice(6, 7, 1), slice(2, 4, 1))),
+                (7200, 200, (slice(7, 8, 1), slice(2, 4, 1))),
+            ],
+        ),
+        (
+            (slice(5, 8, 1), slice(2, 4, 1), slice(0, 5, 1)),
+            np.arange(2, 100_002).reshape((100, 10, 100)),
+            [
+                (5200.0, 5.0, (slice(5, 6, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (5300.0, 5.0, (slice(5, 6, 1), slice(3, 4, 1), slice(0, 5, 1))),
+                (6200.0, 5.0, (slice(6, 7, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (6300.0, 5.0, (slice(6, 7, 1), slice(3, 4, 1), slice(0, 5, 1))),
+                (7200.0, 5.0, (slice(7, 8, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (7300.0, 5.0, (slice(7, 8, 1), slice(3, 4, 1), slice(0, 5, 1))),
+            ],
+        ),
+        (
+            (slice(5, 8, 1), slice(2, 4, 1), slice(0, 5, 1)),
+            np.asfortranarray(np.arange(2, 100_002).reshape((100, 10, 100))),
+            [
+                (5200.0, 5.0, (slice(5, 6, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (5300.0, 5.0, (slice(5, 6, 1), slice(3, 4, 1), slice(0, 5, 1))),
+                (6200.0, 5.0, (slice(6, 7, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (6300.0, 5.0, (slice(6, 7, 1), slice(3, 4, 1), slice(0, 5, 1))),
+                (7200.0, 5.0, (slice(7, 8, 1), slice(2, 3, 1), slice(0, 5, 1))),
+                (7300.0, 5.0, (slice(7, 8, 1), slice(3, 4, 1), slice(0, 5, 1))),
+            ],
+        ),
+        (
+            (slice(5, 8, 1), slice(2, 4, 1)),
+            np.arange(2, 100_002).reshape((100, 10, 100)),
+            [
+                (5200, 200, (slice(5, 6, 1), slice(2, 4, 1))),
+                (6200, 200, (slice(6, 7, 1), slice(2, 4, 1))),
+                (7200, 200, (slice(7, 8, 1), slice(2, 4, 1))),
+            ],
+        ),
+        (
+            (slice(0, 10, 1),),
+            np.arange(0, 10).reshape((10)),
+            [(0, 10, (slice(0, 10, 1),))],
+        ),
+        ((0,), np.arange(0, 100).reshape((10, 10)), [(0, 10, (slice(0, 1, 1),))]),
+        (
+            (
+                0,
+                0,
+            ),
+            np.arange(0, 100).reshape((10, 10)),
+            [(0, 1, (slice(0, 1, 1), slice(0, 1, 1)))],
+        ),
+        ((0,), np.arange(0, 10).reshape((10)), [(0, 1, (slice(0, 1, 1),))]),
+        pytest.param(
+            (slice(5, 8, 1), slice(2, 4, 1), slice(0, 5, 1)),
+            np.arange(2, 100002).reshape((10, 1, 10000)),
+            None,
+            marks=[pytest.mark.xfail(reason="slice 2 is out of range")],
+        ),
+        pytest.param(
+            (slice(5, 8, 1), slice(2, 4, 1), slice(0, 5, 1)),
+            np.arange(2, 100_002).reshape((10, 10_000)),
+            None,
+            marks=[pytest.mark.xfail(reason="slice 2 is out of range")],
+        ),
+    ],
+)
+def test_PartialChunkIterator(selection, arr, expected):
+    PCI = PartialChunkIterator(selection, arr.shape)
+    results = list(PCI)
+    assert results == expected

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -967,8 +967,9 @@ class TestFSStore(StoreTests, unittest.TestCase):
                             storage_options=self.s3so)
         expected = np.empty((8, 8, 8), dtype='int64')
         expected[:] = -1
-        a = g.create_dataset("data", shape=(8, 8, 8),
-                             fill_value=-1, chunks=(1, 1, 1))
+        a = g.create_dataset(
+            "data", shape=(8, 8, 8), fill_value=-1, chunks=(1, 1, 1), overwrite=True
+        )
         expected[0] = 0
         expected[3] = 3
         expected[6, 6, 6] = 6
@@ -983,8 +984,8 @@ class TestFSStore(StoreTests, unittest.TestCase):
                              storage_options=self.s3so)
 
         assert (g2.data[:] == expected).all()
-
-        a[:] = 5  # write with scalar
+        a.chunk_store.fs.invalidate_cache("test/out.zarr/data")
+        a[:] = 5
         assert (a[:] == 5).all()
 
         assert g2.data_f['foo'].tolist() == [b"aaa"] * 4 + [b"b"] * 4
@@ -1846,6 +1847,7 @@ class TestABSStore(StoreTests, unittest.TestCase):
 
     def test_hierarchy(self):
         return super().test_hierarchy()
+
 
 class TestConsolidatedMetadataStore(unittest.TestCase):
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -3,12 +3,14 @@ import json
 import math
 import numbers
 from textwrap import TextWrapper
+import mmap
 
 import numpy as np
 from asciitree import BoxStyle, LeftAligned
 from asciitree.traversal import Traversal
 from numcodecs.compat import ensure_ndarray, ensure_text
 from numcodecs.registry import codec_registry
+from numcodecs.blosc import cbuffer_sizes, cbuffer_metainfo
 
 from typing import Any, Dict, Tuple, Union
 
@@ -532,3 +534,78 @@ class NoLock(object):
 
 
 nolock = NoLock()
+
+
+class PartialReadBuffer:
+    def __init__(self, store_key, chunk_store):
+        self.chunk_store = chunk_store
+        # is it fsstore or an actual fsspec map object
+        assert hasattr(self.chunk_store, "map")
+        self.map = self.chunk_store.map
+        self.fs = self.chunk_store.fs
+        self.store_key = store_key
+        self.key_path = self.map._key_to_str(store_key)
+        self.buff = None
+        self.nblocks = None
+        self.start_points = None
+        self.n_per_block = None
+        self.start_points_max = None
+        self.read_blocks = set()
+
+    def prepare_chunk(self):
+        assert self.buff is None
+        header = self.fs.read_block(self.key_path, 0, 16)
+        nbytes, self.cbytes, blocksize = cbuffer_sizes(header)
+        typesize, _shuffle, _memcpyd = cbuffer_metainfo(header)
+        self.buff = mmap.mmap(-1, self.cbytes)
+        self.buff[0:16] = header
+        self.nblocks = nbytes / blocksize
+        self.nblocks = (
+            int(self.nblocks)
+            if self.nblocks == int(self.nblocks)
+            else int(self.nblocks + 1)
+        )
+        if self.nblocks == 1:
+            self.buff = self.read_full()
+            return
+        start_points_buffer = self.fs.read_block(
+            self.key_path, 16, int(self.nblocks * 4)
+        )
+        self.start_points = np.frombuffer(
+            start_points_buffer, count=self.nblocks, dtype=np.int32
+        )
+        self.start_points_max = self.start_points.max()
+        self.buff[16 : (16 + (self.nblocks * 4))] = start_points_buffer
+        self.n_per_block = blocksize / typesize
+
+    def read_part(self, start, nitems):
+        assert self.buff is not None
+        if self.nblocks == 1:
+            return
+        blocks_to_decompress = nitems / self.n_per_block
+        blocks_to_decompress = (
+            blocks_to_decompress
+            if blocks_to_decompress == int(blocks_to_decompress)
+            else int(blocks_to_decompress + 1)
+        )
+        start_block = int(start / self.n_per_block)
+        wanted_decompressed = 0
+        while wanted_decompressed < nitems:
+            if start_block not in self.read_blocks:
+                start_byte = self.start_points[start_block]
+                if start_byte == self.start_points_max:
+                    stop_byte = self.cbytes
+                else:
+                    stop_byte = self.start_points[self.start_points > start_byte].min()
+                length = stop_byte - start_byte
+                data_buff = self.fs.read_block(self.key_path, start_byte, length)
+                self.buff[start_byte:stop_byte] = data_buff
+                self.read_blocks.add(start_block)
+            if wanted_decompressed == 0:
+                wanted_decompressed += ((start_block + 1) * self.n_per_block) - start
+            else:
+                wanted_decompressed += self.n_per_block
+            start_block += 1
+
+    def read_full(self):
+        return self.chunk_store[self.store_key]


### PR DESCRIPTION
This PR adds the capability to partially read and decompress chunks in an arrays that are initialized with blosc decompression and an fsspec based backend. Its related to [zarr-specs #59](https://github.com/zarr-developers/zarr-specs/issues/59)

I did some initial benchmarking showing processing time for indexing with various array and chunk shapes filled with random numbers stored on s3:

array_shape=(1000, 1000), chunk_shape=(100, 500)
-------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/13774419/100808640-bf076580-33f1-11eb-8b5a-263cd098349e.png)

array_shape=(10000, 10000), chunk_shape=(1000, 1000)
-------------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/13774419/100808744-eeb66d80-33f1-11eb-9334-d08564953f45.png)

array_shape=(10000, 10000), chunk_shape=(2000, 5000)
----------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/13774419/100808783-01c93d80-33f2-11eb-8e48-2731e0ac9520.png)

array_shape=(10000, 10000), chunk_shape=(5000, 5000)
-------------------------------------------------------------------------------
![image](https://user-images.githubusercontent.com/13774419/100808809-11e11d00-33f2-11eb-8107-c3722d4781ad.png)


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
