### PR TITLE
Simplify text handling in DB `Store`s

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -35,7 +35,10 @@ from typing import Optional, Union, List, Tuple, Dict
 import uuid
 import time
 
-from numcodecs.compat import ensure_bytes, ensure_contiguous_ndarray
+from numcodecs.compat import (
+    ensure_bytes,
+    ensure_contiguous_ndarray
+)
 from numcodecs.registry import codec_registry
 
 from zarr.errors import (

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1577,12 +1577,6 @@ def migrate_1to2(store):
     del store['attrs']
 
 
-def _dbm_encode_key(key):
-    if hasattr(key, 'encode'):
-        key = key.encode('ascii')
-    return key
-
-
 # noinspection PyShadowingBuiltins
 class DBMStore(MutableMapping):
     """Storage class using a DBM-style database.
@@ -1728,17 +1722,20 @@ class DBMStore(MutableMapping):
         self.close()
 
     def __getitem__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         return self.db[key]
 
     def __setitem__(self, key, value):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         value = ensure_bytes(value)
         with self.write_mutex:
             self.db[key] = value
 
     def __delitem__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         with self.write_mutex:
             del self.db[key]
 
@@ -1761,7 +1758,8 @@ class DBMStore(MutableMapping):
         return sum(1 for _ in self.keys())
 
     def __contains__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         return key in self.db
 
 
@@ -1885,7 +1883,8 @@ class LMDBStore(MutableMapping):
         self.close()
 
     def __getitem__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         # use the buffers option, should avoid a memory copy
         with self.db.begin(buffers=self.buffers) as txn:
             value = txn.get(key)
@@ -1894,18 +1893,21 @@ class LMDBStore(MutableMapping):
         return value
 
     def __setitem__(self, key, value):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         with self.db.begin(write=True, buffers=self.buffers) as txn:
             txn.put(key, value)
 
     def __delitem__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         with self.db.begin(write=True) as txn:
             if not txn.delete(key):
                 raise KeyError(key)
 
     def __contains__(self, key):
-        key = _dbm_encode_key(key)
+        if isinstance(key, str):
+            key = key.encode("ascii")
         with self.db.begin(buffers=self.buffers) as txn:
             with txn.cursor() as cursor:
                 return cursor.set_key(key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1583,12 +1583,6 @@ def _dbm_encode_key(key):
     return key
 
 
-def _dbm_decode_key(key):
-    if hasattr(key, 'decode'):
-        key = key.decode('ascii')
-    return key
-
-
 # noinspection PyShadowingBuiltins
 class DBMStore(MutableMapping):
     """Storage class using a DBM-style database.
@@ -1758,7 +1752,7 @@ class DBMStore(MutableMapping):
         )
 
     def keys(self):
-        return (_dbm_decode_key(k) for k in iter(self.db.keys()))
+        return (ensure_text(k, "ascii") for k in iter(self.db.keys()))
 
     def __iter__(self):
         return self.keys()


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/669

`LMDBStore` had its own way of handling text before `ensure_text` was added to Numcodecs. With that utility function now available, we can simplify this a bit and avoid some subtleties of the LMDB implementation.

Similarly `DBMStore` had some of its own text handling issues that can be solved the same way.

Finally inline all `str.encode` calls to make it clearer what is happening in both  `LMDBStore` and `DBMStore`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
