### PR TITLE
Start migrating away from Travis

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,56 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+        numpy_version: ['==1.16.4']
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        fetch-depth: 0
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@master
+      with:
+          channels: conda-forge
+          python-version: ${{ matrix.python-version }}
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    # Runs a set of commands using the runners shell
+    - name: Create Conda environment with the rights deps
+      shell: "bash -l {0}"
+      run: |
+        conda create -n zarr-env python==${{matrix.python-version}} bsddb3 numcodecs==0.6.4 lmdb pip
+    - name: Install dependencies
+      shell: "bash -l {0}"
+      run: |
+        conda activate zarr-env
+        python -m pip install --upgrade pip
+        python -m pip install -U pip setuptools wheel codecov
+        python -m pip install -rrequirements_dev_minimal.txt numpy${{ matrix.numpy_version}} -rrequirements_dev_optional.txt
+        python -m pip install -e . 
+    - name: Tests
+      shell: "bash -l {0}"
+      run: |
+        conda activate zarr-env
+        pytest --cov=zarr --cov-config=.coveragerc --doctest-plus --cov-report xml --cov=./ 
+    - uses: codecov/codecov-action@v1
+      with:
+        #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          #files: ./coverage1.xml,./coverage2.xml # optional
+          #flags: unittests # optional
+          #name: codecov-umbrella # optional
+          #fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -1,5 +1,5 @@
 # optional library requirements
-bsddb3==6.2.6; sys_platform != 'win32'
+# bsddb3==6.2.6; sys_platform != 'win32'
 lmdb==0.97; sys_platform != 'win32'
 # optional library requirements for Jupyter
 ipytree==0.1.3
@@ -15,7 +15,6 @@ coverage==5.0.3
 flake8==3.8.3
 pytest-cov==2.7.1
 pytest-doctestplus==0.4.0
-pytest-remotedata==0.3.2
 h5py==2.10.0
 s3fs==0.5.1; python_version > '3.6'
 fsspec==0.8.4; python_version > '3.6'


### PR DESCRIPTION
We are out of travis.ci hours; start migrating to actions.

Not complete; none of the coverage uploading and testing with Mongo or azure is ran here.