### PR TITLE
Grow testing matrix on 3.6, 3,8 and latest numpy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,8 @@ jobs:
         python -m pip freeze
     - name: Tests
       shell: "bash -l {0}"
+      env: 
+        COVERAGE_FILE: .coverage.${{matrix.python-version}}.${{matrix.numpy_version}}
       run: |
         conda activate zarr-env
         pytest --cov=zarr --cov-config=.coveragerc --doctest-plus --cov-report xml --cov=./ 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
-        numpy_version: ['==1.16.4']
+        python-version: ['3.6.9' , 3.7, 3.8]
+        numpy_version: ['==1.16.4', '']
     steps:
     - uses: actions/checkout@v2
       with: 
@@ -41,6 +41,7 @@ jobs:
         python -m pip install -U pip setuptools wheel codecov
         python -m pip install -rrequirements_dev_minimal.txt numpy${{ matrix.numpy_version}} -rrequirements_dev_optional.txt
         python -m pip install -e . 
+        python -m pip freeze
     - name: Tests
       shell: "bash -l {0}"
       run: |

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -11,7 +11,7 @@ redis==3.3.8
 pymongo==3.9.0
 # optional test requirements
 tox==3.14.0
-coverage==5.0.3
+coverage
 flake8==3.8.3
 pytest-cov==2.7.1
 pytest-doctestplus==0.4.0


### PR DESCRIPTION
Travis not working anymore; so now we are using github action. 
Slowly rebuild the functionality of travis-ci and test on 3.6 and 3.8 as well as multiple numpy version. 
