### PR TITLE
Ignore bench file in coverage report, ignore skipped tests.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,7 @@
 [run]
-omit = zarr/meta_v1.py
+omit =
+    zarr/meta_v1.py
+    bench/compress_normal.py
 
 [report]
 exclude_lines =

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1306,10 +1306,10 @@ class TestDBMStoreNDBM(TestDBMStore):
 
     def create_store(self):
         ndbm = pytest.importorskip("dbm.ndbm")
-        path = tempfile.mktemp(suffix='.ndbm')
-        atexit.register(atexit_rmglob, path + '*')
-        store = DBMStore(path, flag='n', open=ndbm.open)
-        return store
+        path = tempfile.mktemp(suffix=".ndbm")  # pragma: no cover
+        atexit.register(atexit_rmglob, path + "*")  # pragma: no cover
+        store = DBMStore(path, flag="n", open=ndbm.open)  # pragma: no cover
+        return store  # pragma: no cover
 
 
 class TestDBMStoreBerkeleyDB(TestDBMStore):


### PR DESCRIPTION
The ndbm tests are also ignored from coverage as ndb is not installable
on ghaction on non-macos.
