### PR TITLE
Test Azure on only one version of Python on windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,18 +14,20 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build.cmd"
     EMULATOR_LOC: C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\Storage Emulator\\AzureStorageEmulator.exe
-    ZARR_TEST_ABS: 1
 
   matrix:
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
+      ZARR_TEST_ABS: 0
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
+      ZARR_TEST_ABS: 0
 
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8"
+      ZARR_TEST_ABS: 1
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"


### PR DESCRIPTION
1) On appveyor, ABS store represent close to 25% of the test time  8min
total, see 10 slowest tests below).
2) Appveyor is the slowest of the CI, the one we wait for most of the
time.
3) ABS has not reason to behave differently on different Python
versions.
4) We might be able to also test windows on WSL in GH-actions.

```
========================== slowest 10 test durations ==========================
43.32s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_resize_2d
21.28s call     zarr/tests/test_hierarchy.py::TestGroupWithABSStore::test_getitem_contains_iterators
17.72s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_np_ufuncs
17.54s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_array_2d
14.79s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_iter
13.76s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_append_2d
13.55s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_append_2d_axis
12.01s call     zarr/tests/test_core.py::TestArrayWithABSStore::test_array_order
11.77s call     zarr/tests/test_indexing.py::test_set_orthogonal_selection_3d
8.52s call     zarr/tests/test_storage.py::TestFSStore::test_s3_complex
==== 1808 passed, 303 skipped, 3 xpassed, 13 warnings in 333.74s (0:05:33) ====
```