### PR TITLE
Update azure code and skip gdbm coverage.

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2231,6 +2231,7 @@ class ABSStore(MutableMapping):
 
     def __contains__(self, key):
         blob_name = self._append_path_to_prefix(key)
+        assert len(blob_name) >= 1
         if self.client.exists(self.container, blob_name):
             return True
         else:
@@ -2255,6 +2256,7 @@ class ABSStore(MutableMapping):
         if dir_path:
             dir_path += '/'
         for blob in self.client.list_blobs(self.container, prefix=dir_path):
+            assert len(blob.name) >= 1
             self.client.delete_blob(self.container, blob.name)
 
     def getsize(self, path=None):
@@ -2263,9 +2265,11 @@ class ABSStore(MutableMapping):
         fs_path = self.prefix
         if store_path:
             fs_path = self._append_path_to_prefix(store_path)
-        if self.client.exists(self.container, fs_path):
-            return self.client.get_blob_properties(self.container,
-                                                   fs_path).properties.content_length
+
+        if fs_path != "" and self.client.exists(self.container, fs_path):
+            return self.client.get_blob_properties(
+                self.container, fs_path
+            ).properties.content_length
         else:
             size = 0
             if fs_path == '':

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1296,10 +1296,12 @@ class TestDBMStoreGnu(TestDBMStore):
 
     def create_store(self):
         gdbm = pytest.importorskip("dbm.gnu")
-        path = tempfile.mktemp(suffix='.gdbm')
-        atexit.register(os.remove, path)
-        store = DBMStore(path, flag='n', open=gdbm.open, write_lock=False)
-        return store
+        path = tempfile.mktemp(suffix=".gdbm")  # pragma: no cover
+        atexit.register(os.remove, path)  # pragma: no cover
+        store = DBMStore(
+            path, flag="n", open=gdbm.open, write_lock=False
+        )  # pragma: no cover
+        return store  # pragma: no cover
 
 
 class TestDBMStoreNDBM(TestDBMStore):
@@ -1839,11 +1841,9 @@ class TestABSStore(StoreTests, unittest.TestCase):
             assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
                     set(store.items()))
 
-    @pytest.mark.xfail
     def test_getsize(self):
         return super().test_getsize()
 
-    @pytest.mark.xfail
     def test_hierarchy(self):
         return super().test_hierarchy()
 


### PR DESCRIPTION
Newer version of azure and azurite are stricter on allowing queries on
empty blob names; here we add checks that blob names are non empty, as
well as take the slow path (which is the correct one) when trying to get
a store size.

