### PR TITLE
Reenable mypy and flake8 linting on CI.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,7 +83,7 @@ jobs:
       shell: "bash -l {0}"
       run: |
         conda activate zarr-env
-        flake8
+        flake8 zarr
         mypy
 
     

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Linux Testing
 
 on:
   push:
@@ -47,7 +47,7 @@ jobs:
     - name: Create Conda environment with the rights deps
       shell: "bash -l {0}"
       run: |
-        conda create -n zarr-env python==${{matrix.python-version}} bsddb3 numcodecs==0.6.4 lmdb pip nodejs
+        conda create -n zarr-env python==${{matrix.python-version}} bsddb3 numcodecs==0.6.4 lmdb pip nodejs flake8 mypy
         conda activate zarr-env
         npm install -g azurite
     - name: Install dependencies
@@ -79,3 +79,11 @@ jobs:
           #name: codecov-umbrella # optional
           #fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
+    - name: Linting
+      shell: "bash -l {0}"
+      run: |
+        conda activate zarr-env
+        flake8
+        mypy
+
+    

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -84,6 +84,6 @@ jobs:
       run: |
         conda activate zarr-env
         flake8 zarr
-        mypy
+        mypy zarr
 
     

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -933,10 +933,10 @@ class PartialChunkIterator(object):
     def __iter__(self):
         chunk1 = self.chunk_loc_slices[0]
         nitems = (chunk1[-1].stop - chunk1[-1].start) * np.prod(
-            self.arr_shape[len(chunk1) :], dtype=int
+            self.arr_shape[len(chunk1):], dtype=int
         )
         for partial_out_selection in self.chunk_loc_slices:
             start = 0
             for i, sl in enumerate(partial_out_selection):
-                start += sl.start * np.prod(self.arr_shape[i + 1 :], dtype=int)
+                start += sl.start * np.prod(self.arr_shape[i + 1:], dtype=int)
             yield start, nitems, partial_out_selection

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2427,7 +2427,6 @@ class TestArrayWithFSStorePartialRead(TestArray):
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
         atexit.register(shutil.rmtree, path)
-        #use_listings_cache=kwargs.pop("use_listings_cache", True)
         store = FSStore(path)
         cache_metadata = kwargs.pop("cache_metadata", True)
         cache_attrs = kwargs.pop("cache_attrs", True)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -575,7 +575,7 @@ class PartialReadBuffer:
             start_points_buffer, count=self.nblocks, dtype=np.int32
         )
         self.start_points_max = self.start_points.max()
-        self.buff[16 : (16 + (self.nblocks * 4))] = start_points_buffer
+        self.buff[16: (16 + (self.nblocks * 4))] = start_points_buffer
         self.n_per_block = blocksize / typesize
 
     def read_part(self, start, nitems):


### PR DESCRIPTION
Those were ran by tox, and got lost in the migration.
Maybe we want to make them a separate  job at some point for speed and not run them on all matrix elements.