### PR TITLE
Only check alternate node type if desired isn't present

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -488,9 +488,9 @@ def open_array(
     # ensure store is initialized
 
     if mode in ['r', 'r+']:
-        if contains_group(store, path=path):
-            raise ContainsGroupError(path)
-        elif not contains_array(store, path=path):
+        if not contains_array(store, path=path):
+            if contains_group(store, path=path):
+                raise ContainsGroupError(path)
             raise ArrayNotFoundError(path)
 
     elif mode == 'w':
@@ -500,9 +500,9 @@ def open_array(
                    object_codec=object_codec, chunk_store=chunk_store)
 
     elif mode == 'a':
-        if contains_group(store, path=path):
-            raise ContainsGroupError(path)
-        elif not contains_array(store, path=path):
+        if not contains_array(store, path=path):
+            if contains_group(store, path=path):
+                raise ContainsGroupError(path)
             init_array(store, shape=shape, chunks=chunks, dtype=dtype,
                        compressor=compressor, fill_value=fill_value,
                        order=order, filters=filters, path=path,

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1160,18 +1160,18 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     # ensure store is initialized
 
     if mode in ['r', 'r+']:
-        if contains_array(store, path=path):
-            raise ContainsArrayError(path)
-        elif not contains_group(store, path=path):
+        if not contains_group(store, path=path):
+            if contains_array(store, path=path):
+                raise ContainsArrayError(path)
             raise GroupNotFoundError(path)
 
     elif mode == 'w':
         init_group(store, overwrite=True, path=path, chunk_store=chunk_store)
 
     elif mode == 'a':
-        if contains_array(store, path=path):
-            raise ContainsArrayError(path)
         if not contains_group(store, path=path):
+            if contains_array(store, path=path):
+                raise ContainsArrayError(path)
             init_group(store, path=path, chunk_store=chunk_store)
 
     elif mode in ['w-', 'x']:


### PR DESCRIPTION
This PR rearranges the control flow in `open_array` and `open_group` when `mode` is `a`, `r`, or `r+`, so that fewer store methods are called when the correct node already exists. The previous logic required two calls to `store.__containsitem__`. Now, `open_array` checks if the node is a group only if it is not an array (and vis versa for `open_group`). This may seem like a minor nit, but if `store.__containsitem__` wraps a network call, you can avoid an unnecessary network request. 

I noticed this in the `zarr.js` implementation because we get a lot of HTTP 404s errors for `.zgroup` in the console when opening a remote array. https://github.com/gzuidhof/zarr.js/pull/73



TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
