### PR TITLE
FSStore: key_separator fix

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1016,6 +1016,8 @@ class FSStore(MutableMapping):
     storage_options : passed to the fsspec implementation
     """
 
+    _META_KEYS = (attrs_key, group_meta_key, array_meta_key)
+
     def __init__(self, url, normalize_keys=True, key_separator='.',
                  mode='w',
                  exceptions=(KeyError, PermissionError, IOError),
@@ -1035,7 +1037,11 @@ class FSStore(MutableMapping):
         key = normalize_storage_path(key).lstrip('/')
         if key:
             *bits, end = key.split('/')
-            key = '/'.join(bits + [end.replace('.', self.key_separator)])
+
+            if end not in FSStore._META_KEYS:
+                end = end.replace('.', self.key_separator)
+                key = '/'.join(bits + [end])
+
         return key.lower() if self.normalize_keys else key
 
     def getitems(self, keys, **kwargs):


### PR DESCRIPTION
    key_separator: fix handling of meta keys

    This rebases and cleans a fix from Martin's original PR.
    Two new test methods fail without it and pass with since
    keys for meta-files like `.zarray` were being converted
    into `/zarray`.

 see: https://github.com/martindurant/zarr/pull/1/commits/5795bc7368eb0b86aaeb1956ffed514e672db96e

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] AppVeyor and Travis CI passes
* [ ] Test coverage is 100% (Coveralls passes)
