### PR TITLE
2.7.0: update release section

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,6 +3,7 @@ name: Wheels
 on: [push, pull_request]
 
 jobs:
+
   build_artifacts:
     name: Build wheel on ubuntu-latest
     runs-on: ubuntu-latest
@@ -67,26 +68,3 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_password }}
           # To test: repository_url: https://test.pypi.org/legacy/
-  build_artifacts:
-    name: Linting with flake8
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-
-      - uses: actions/setup-python@v1
-        name: Install Python
-        with:
-          python-version: '3.8'
-
-      - name: Install pyflakes
-        run: |
-          python -m pip install pyflakes
-      - name: run pyflakes
-        run: |
-          pyflakes zarr
-

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,10 +1,40 @@
 Release notes
 =============
 
+2.7.0
+-----
+
+* Compare test data's content generally
+  By :user:`John Kirkham <jakirkham>`; :issue:`436`.
+
+* Fix dtype usage in zarr/meta.py
+  By :user:`Josh Moore <joshmoore>`; :issue:`700`.
+
+* Fix FSStore key_seperator usage
+  By :user:`Josh Moore <joshmoore>`; :issue:`669`.
+
+* Add capability to partially read and decompress chunks
+  By :user:`Andrew Fulton <andrewfulton9>`; :issue:`667`.
+
+* Simplify text handling in DB Store
+  By :user:`John Kirkham <jakirkham>`; :issue:`670`.
+
+* GitHub Actions migration
+  By :user:`Matthias Bussonnier <Carreau>`;
+  :issue:`641`, :issue:`671`, :issue:`674`, :issue:`676`, :issue:`677`, :issue:`678`,
+  :issue:`679`, :issue:`680`, :issue:`682`, :issue:`684`, :issue:`685`, :issue:`686`,
+  :issue:`687`, :issue:`695`.
+
+2.6.1
+-----
+
+* Minor build fix
+  By :user:`Matthias Bussonnier <Carreau>`; :issue:`666`.
+
 2.6.0
 -----
 
-This release od Zarr Python is is the first release of Zarr to not supporting Python 3.5.
+This release of Zarr Python is is the first release of Zarr to not support Python 3.5.
 
 * End Python 3.5 support.
   By :user:`Chris Barnes <clbarnes>`; :issue:`602`.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,8 +1,8 @@
 Release notes
 =============
 
-2.7.0
------
+Next release (e.g. 2.7.0)
+-------------------------
 
 * Compare test data's content generally
   By :user:`John Kirkham <jakirkham>`; :issue:`436`.

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -18,5 +18,4 @@ pytest-doctestplus==0.4.0
 h5py==2.10.0
 s3fs==0.5.1; python_version > '3.6'
 fsspec==0.8.4; python_version > '3.6'
-moto>=1.3.14; python_version > '3.6'
-flask
+moto[server]>=1.3.14; python_version > '3.6'


### PR DESCRIPTION
Prepares the release notes for a version before merging more v3 specific code, during which `master` will be in a pre-release state (`.devX`, `.betaY`, etc.)

Also fixes two build issues which are making recent PRs fail:
 * duplicate block in `releases.yml` likely introduced during conflict resolution
 * moto recently went to 2.0 and now requires `moto[server]` for installation