### PR TITLE
[WIP] Expand (and pass) nested FSStore tests

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1051,11 +1051,8 @@ class FSStore(MutableMapping):
         return key.lower() if self.normalize_keys else key
 
     def getitems(self, keys, **kwargs):
-        keys_transformed = [self._normalize_key(key) for key in keys]
-        results = self.map.getitems(keys_transformed, on_error="omit")
-        # The function calling this method may not recognize the transformed keys
-        # So we send the values returned by self.map.getitems back with the input keys.
-        return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
+        keys = [self._normalize_key(key) for key in keys]
+        return self.map.getitems(keys, on_error="omit")
 
     def __getitem__(self, key):
         key = self._normalize_key(key)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1119,7 +1119,9 @@ class FSStore(MutableMapping):
         try:
             children = sorted(p.rstrip('/').rsplit('/', 1)[-1]
                               for p in self.fs.ls(dir_path, detail=False))
-            if self.key_separator == '/':
+            if self.key_separator != "/":
+                return children
+            else:
                 if array_meta_key in children:
                     # special handling of directories containing an array to map nested chunk
                     # keys back to standard chunk keys
@@ -1136,7 +1138,8 @@ class FSStore(MutableMapping):
                         else:
                             new_children.append(entry)
                     return sorted(new_children)
-            return children
+                else:
+                    return children
         except IOError:
             return []
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1130,11 +1130,10 @@ class FSStore(MutableMapping):
                     for entry in children:
                         entry_path = os.path.join(root_path, entry)
                         if _prog_number.match(entry) and self.fs.isdir(entry_path):
-                            for dir_path, _, file_names in self.fs.walk(entry_path):
-                                for file_name in file_names:
-                                    file_path = os.path.join(dir_path, file_name)
-                                    rel_path = file_path.split(root_path)[1]
-                                    new_children.append(rel_path.replace(os.path.sep, '.'))
+                            for file_name in self.fs.find(entry_path):
+                                file_path = os.path.join(dir_path, file_name)
+                                rel_path = file_path.split(root_path)[1]
+                                new_children.append(rel_path.replace(os.path.sep, '.'))
                         else:
                             new_children.append(entry)
                     return sorted(new_children)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1051,8 +1051,11 @@ class FSStore(MutableMapping):
         return key.lower() if self.normalize_keys else key
 
     def getitems(self, keys, **kwargs):
-        keys = [self._normalize_key(key) for key in keys]
-        return self.map.getitems(keys, on_error="omit")
+        keys_transformed = [self._normalize_key(key) for key in keys]
+        results = self.map.getitems(keys_transformed, on_error="omit")
+        # The function calling this method may not recognize the transformed keys
+        # So we send the values returned by self.map.getitems back with the input keys.
+        return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
 
     def __getitem__(self, key):
         key = self._normalize_key(key)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -35,8 +35,9 @@ from zarr.storage import (
 from zarr.util import buffer_size
 from zarr.tests.util import skip_test_env_var, have_fsspec
 
-
 # noinspection PyMethodMayBeStatic
+
+
 class TestArray(unittest.TestCase):
 
     def test_array_init(self):
@@ -1066,7 +1067,7 @@ class TestArray(unittest.TestCase):
                       (1, (1, ((1, 2), (2, 3), (3, 4)), 1), b'bbb'),
                       (2, (2, ((2, 3), (3, 4), (4, 5)), 2), b'ccc')],
                      dtype=[('foo', 'i8'), ('bar', [('foo', 'i4'), ('bar', '(3, 2)f4'),
-                            ('baz', 'u1')]), ('baz', 'S3')])
+                                                    ('baz', 'u1')]), ('baz', 'S3')])
         fill_values = None, b'', (0, (0, ((0, 0), (1, 1), (2, 2)), 0), b'zzz')
         self.check_structured_array(d, fill_values)
 
@@ -1780,7 +1781,7 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
                       (1, (1, ((1, 2), (2, 3), (3, 4)), 1), b'bbb'),
                       (2, (2, ((2, 3), (3, 4), (4, 5)), 2), b'ccc')],
                      dtype=[('foo', 'i8'), ('bar', [('foo', 'i4'), ('bar', '(3, 2)f4'),
-                            ('baz', 'u1')]), ('baz', 'S3')])
+                                                    ('baz', 'u1')]), ('baz', 'S3')])
         fill_values = None, b'', (0, (0, ((0, 0), (1, 1), (2, 2)), 0), b'zzz')
         with pytest.raises(TypeError):
             self.check_structured_array(d, fill_values)
@@ -2435,7 +2436,7 @@ class TestArrayWithFSStore(TestArray):
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
         atexit.register(shutil.rmtree, path)
-        key_separator = kwargs.pop('key_separator', "/")
+        key_separator = kwargs.pop('key_separator', ".")
         store = FSStore(path, key_separator=key_separator, auto_mkdir=True)
         cache_metadata = kwargs.pop('cache_metadata', True)
         cache_attrs = kwargs.pop('cache_attrs', True)
@@ -2475,6 +2476,120 @@ class TestArrayWithFSStorePartialRead(TestArray):
         path = mkdtemp()
         atexit.register(shutil.rmtree, path)
         store = FSStore(path)
+        cache_metadata = kwargs.pop("cache_metadata", True)
+        cache_attrs = kwargs.pop("cache_attrs", True)
+        kwargs.setdefault("compressor", Blosc())
+        init_array(store, **kwargs)
+        return Array(
+            store,
+            read_only=read_only,
+            cache_metadata=cache_metadata,
+            cache_attrs=cache_attrs,
+            partial_decompress=True,
+        )
+
+    def test_hexdigest(self):
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        assert "f710da18d45d38d4aaf2afd7fb822fdd73d02957" == z.hexdigest()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
+        assert "1437428e69754b1e1a38bd7fc9e43669577620db" == z.hexdigest()
+
+        # Check basic 2-D array
+        z = self.create_array(
+            shape=(
+                20,
+                35,
+            ),
+            chunks=10,
+            dtype="<i4",
+        )
+        assert "6c530b6b9d73e108cc5ee7b6be3d552cc994bdbe" == z.hexdigest()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z[200:400] = np.arange(200, 400, dtype="i4")
+        assert "4c0a76fb1222498e09dcd92f7f9221d6cea8b40e" == z.hexdigest()
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z.attrs["foo"] = "bar"
+        assert "05b0663ffe1785f38d3a459dec17e57a18f254af" == z.hexdigest()
+
+    def test_non_cont(self):
+        z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
+        z[:, :, :] = 1
+        # actually go through the partial read by accessing a single item
+        assert z[0, :, 0].any()
+
+    def test_read_nitems_less_than_blocksize_from_multiple_chunks(self):
+        '''Tests to make sure decompression doesn't fail when `nitems` is
+        less than a compressed block size, but covers multiple blocks
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[40_000:80_000] = 1
+        b = Array(z.store, read_only=True, partial_decompress=True)
+        assert (b[40_000:80_000] == 1).all()
+
+    def test_read_from_all_blocks(self):
+        '''Tests to make sure `PartialReadBuffer.read_part` doesn't fail when
+        stop isn't in the `start_points` array
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[2:99_000] = 1
+        b = Array(z.store, read_only=True, partial_decompress=True)
+        assert (b[2:99_000] == 1).all()
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreNested(TestArray):
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        key_separator = kwargs.pop('key_separator', "/")
+        store = FSStore(path, key_separator=key_separator, auto_mkdir=True)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        kwargs.setdefault('compressor', Blosc())
+        init_array(store, **kwargs)
+        return Array(store, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs)
+
+    def test_hexdigest(self):
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        assert 'f710da18d45d38d4aaf2afd7fb822fdd73d02957' == z.hexdigest()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
+        assert '1437428e69754b1e1a38bd7fc9e43669577620db' == z.hexdigest()
+
+        # Check basic 2-D array
+        z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
+        assert '6c530b6b9d73e108cc5ee7b6be3d552cc994bdbe' == z.hexdigest()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z[200:400] = np.arange(200, 400, dtype='i4')
+        assert '4c0a76fb1222498e09dcd92f7f9221d6cea8b40e' == z.hexdigest()
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z.attrs['foo'] = 'bar'
+        assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreNestedPartialRead(TestArray):
+    @staticmethod
+    def create_array(read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        key_separator = kwargs.pop('key_separator', "/")
+        store = FSStore(path, key_separator=key_separator, auto_mkdir=True)
         cache_metadata = kwargs.pop("cache_metadata", True)
         cache_attrs = kwargs.pop("cache_attrs", True)
         kwargs.setdefault("compressor", Blosc())

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2443,7 +2443,7 @@ class TestArrayWithFSStore(TestArray):
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
-    
+
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
@@ -2466,7 +2466,7 @@ class TestArrayWithFSStore(TestArray):
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
         assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
-    
+
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestArrayWithFSStorePartialRead(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2435,7 +2435,8 @@ class TestArrayWithFSStore(TestArray):
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
         atexit.register(shutil.rmtree, path)
-        store = FSStore(path)
+        key_separator = kwargs.pop('key_separator', "/")
+        store = FSStore(path, key_separator=key_separator, auto_mkdir=True)
         cache_metadata = kwargs.pop('cache_metadata', True)
         cache_attrs = kwargs.pop('cache_attrs', True)
         kwargs.setdefault('compressor', Blosc())

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2443,7 +2443,7 @@ class TestArrayWithFSStore(TestArray):
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
-
+    
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
@@ -2466,7 +2466,7 @@ class TestArrayWithFSStore(TestArray):
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
         assert '05b0663ffe1785f38d3a459dec17e57a18f254af' == z.hexdigest()
-
+    
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestArrayWithFSStorePartialRead(TestArray):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1216,7 +1216,7 @@ class TestNestedFSStore(TestNestedDirectoryStore):
         group = zarr.group(store=store)
         arr = group.create_dataset('0', shape=(10, 10))
         arr[1] = 1
-        
+
         # Read it back
         store = self.create_store(path=store.path)
         zarr.open_group(store.path)["0"]


### PR DESCRIPTION
This PR adds tests to `FSStore(..., key_separator="/")`. The first test checks that writing to a zarr array backed by a nested FSStore succeeds. This test fails without changes to `FSStore.getitems` -- the original `getitems` implementation normalizes keys, calls `self.map.getitems(normalized_keys)`, and returns a dict with those normalized keys. It seems that the code calling `FSStore.getitems()` may not recognize these keys and thus discard all the values, producing an array with only fill value. I modified `FSStore.getitems` to return a dict with the input keys.   

This PR also expands on a second test (reading the same array with a separate store instance) which currently fails. I will try to get this second test passing, but any pointers would be appreciated. cc @martindurant 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
