### PR TITLE
Implement `dimension_separator` for Python storage classes (See #715)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,20 @@
 Release notes
 =============
 
+.. _release_2.8.0:
+
+2.8.0
+-----
+
+V2 Specification Update
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Introduce optional dimension_separator .zarray key for nested chunks.
+  By :user:`Josh Moore <joshmoore>`; :issue:`715`, :issue:`716`.
+
+.. _release_2.7.0:
+
+
 .. _release_2.7.1:
 
 2.7.1

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -89,6 +89,7 @@ class Array:
     dtype
     compression
     compression_opts
+    dimension_separator
     fill_value
     order
     synchronizer
@@ -194,6 +195,7 @@ class Array:
             self._dtype = meta['dtype']
             self._fill_value = meta['fill_value']
             self._order = meta['order']
+            self._dimension_separator = meta.get('dimension_separator', '.')
 
             # setup compressor
             config = meta['compressor']

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -69,7 +69,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
         A codec to encode object arrays, only needed if dtype=object.
     dimension_separator : {'.', '/'}, optional
         Separator placed between the dimensions of a chunk.
-      .. versionadded:: 2.8
+        .. versionadded:: 2.8
 
     Returns
     -------

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -123,7 +123,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
 
     # optional array metadata
     if dimension_separator is None:
-        dimension_separator = getattr(store, "_dimension_separator", ".")
+        dimension_separator = getattr(store, "_dimension_separator", None)
     dimension_separator = normalize_dimension_separator(dimension_separator)
 
     # initialize array metadata

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -13,13 +13,14 @@ from zarr.n5 import N5Store
 from zarr.storage import (DirectoryStore, ZipStore, contains_array,
                           contains_group, default_compressor, init_array,
                           normalize_storage_path, FSStore)
+from zarr.util import normalize_dimension_separator
 
 
 def create(shape, chunks=True, dtype=None, compressor='default',
            fill_value=0, order='C', store=None, synchronizer=None,
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
-           object_codec=None, **kwargs):
+           object_codec=None, dimension_separator=None, **kwargs):
     """Create an array.
 
     Parameters
@@ -66,6 +67,9 @@ def create(shape, chunks=True, dtype=None, compressor='default',
         True if array should be protected against modification.
     object_codec : Codec, optional
         A codec to encode object arrays, only needed if dtype=object.
+    dimension_separator : {'.', '/'}, optional
+        Separator placed between the dimensions of a chunk.
+      .. versionadded:: 2.8
 
     Returns
     -------
@@ -117,10 +121,16 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     # API compatibility with h5py
     compressor, fill_value = _kwargs_compat(compressor, fill_value, kwargs)
 
+    # optional array metadata
+    if dimension_separator is None:
+        dimension_separator = getattr(store, "_dimension_separator", ".")
+    dimension_separator = normalize_dimension_separator(dimension_separator)
+
     # initialize array metadata
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
                fill_value=fill_value, order=order, overwrite=overwrite, path=path,
-               chunk_store=chunk_store, filters=filters, object_codec=object_codec)
+               chunk_store=chunk_store, filters=filters, object_codec=object_codec,
+               dimension_separator=dimension_separator)
 
     # instantiate array
     z = Array(store, path=path, chunk_store=chunk_store, synchronizer=synchronizer,

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -783,6 +783,8 @@ class Group(MutableMapping):
             lifetime of the object. If False, array metadata will be reloaded
             prior to all data access and modification operations (may incur
             overhead depending on storage and data access pattern).
+        dimension_separator : {'.', '/'}, optional
+            Separator placed between the dimensions of a chunk.
 
         Returns
         -------

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -50,6 +50,7 @@ def decode_array_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
             fill_value=fill_value,
             order=meta['order'],
             filters=meta['filters'],
+            dimension_separator=meta.get('dimension_separator', '.'),
         )
     except Exception as e:
         raise MetadataError('error decoding metadata: %s' % e)
@@ -71,6 +72,7 @@ def encode_array_metadata(meta: MappingType[str, Any]) -> bytes:
         fill_value=encode_fill_value(meta['fill_value'], dtype),
         order=meta['order'],
         filters=meta['filters'],
+        dimension_separator=meta.get('dimension_separator', '.'),
     )
     return json_dumps(meta)
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -52,6 +52,7 @@ def decode_array_metadata(s: Union[MappingType, str]) -> MappingType[str, Any]:
             filters=meta['filters'],
             dimension_separator=meta.get('dimension_separator', '.'),
         )
+
     except Exception as e:
         raise MetadataError('error decoding metadata: %s' % e)
     else:
@@ -63,6 +64,9 @@ def encode_array_metadata(meta: MappingType[str, Any]) -> bytes:
     sdshape = ()
     if dtype.subdtype is not None:
         dtype, sdshape = dtype.subdtype
+
+    dimension_separator = meta.get('dimension_separator')
+
     meta = dict(
         zarr_format=ZARR_FORMAT,
         shape=meta['shape'] + sdshape,
@@ -72,8 +76,11 @@ def encode_array_metadata(meta: MappingType[str, Any]) -> bytes:
         fill_value=encode_fill_value(meta['fill_value'], dtype),
         order=meta['order'],
         filters=meta['filters'],
-        dimension_separator=meta.get('dimension_separator', '.'),
     )
+
+    if dimension_separator:
+        meta['dimension_separator'] = dimension_separator
+
     return json_dumps(meta)
 
 

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -355,6 +355,9 @@ def array_metadata_to_n5(array_metadata):
     compressor_config = compressor_config_to_n5(compressor_config)
     array_metadata['compression'] = compressor_config
 
+    if 'dimension_separator' in array_metadata:
+        del array_metadata['dimension_separator']
+
     return array_metadata
 
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1838,6 +1838,8 @@ class LMDBStore(MutableMapping):
     buffers : bool, optional
         If True (default) use support for buffers, which should increase performance by
         reducing memory copies.
+    dimension_separator : {'.', '/'}, optional
+        Separator placed between the dimensions of a chunk.
     **kwargs
         Keyword arguments passed through to the `lmdb.open` function.
 
@@ -1880,7 +1882,7 @@ class LMDBStore(MutableMapping):
 
     """
 
-    def __init__(self, path, buffers=True, **kwargs):
+    def __init__(self, path, buffers=True, dimension_separator=None, **kwargs):
         import lmdb
 
         # set default memory map size to something larger than the lmdb default, which is
@@ -1918,6 +1920,7 @@ class LMDBStore(MutableMapping):
         self.buffers = buffers
         self.path = path
         self.kwargs = kwargs
+        self._dimension_separator = dimension_separator
 
     def __getstate__(self):
         try:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1029,7 +1029,7 @@ class FSStore(MutableMapping):
     normalize_keys : bool
     key_separator : str
         public API for accessing dimension_separator. Never `None`
-        See dimension_separator for more informatino.
+        See dimension_separator for more information.
     mode : str
         "w" for writable, "r" for read-only
     exceptions : list of Exception subclasses

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -297,7 +297,6 @@ def init_array(
                 "id": "blosc",
                 "shuffle": 1
             },
-            "dimension_separator": ".",
             "dtype": "<f8",
             "fill_value": null,
             "filters": null,
@@ -327,7 +326,6 @@ def init_array(
                 "id": "blosc",
                 "shuffle": 1
             },
-            "dimension_separator": ".",
             "dtype": "|i1",
             "fill_value": null,
             "filters": null,

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1027,8 +1027,9 @@ class FSStore(MutableMapping):
         The destination to map. Should include protocol and path,
         like "s3://bucket/root"
     normalize_keys : bool
-    key_separator : str (deprecated)
-        See dimension_separator
+    key_separator : str
+        public API for accessing dimension_separator. Never `None`
+        See dimension_separator for more informatino.
     mode : str
         "w" for writable, "r" for read-only
     exceptions : list of Exception subclasses
@@ -1054,14 +1055,10 @@ class FSStore(MutableMapping):
         self.mode = mode
         self.exceptions = exceptions
 
-        # Handle deprecated properties
+        # For backwards compatibility. Guaranteed to be non-None
         if key_separator is not None:
-            warnings.warn(
-                "key_separator has been replaced by dimension_separator "
-                "in 2.8.0", DeprecationWarning)
             dimension_separator = key_separator
 
-        # For backwards compatibility. Guaranteed to be non-None
         self.key_separator = dimension_separator
         if self.key_separator is None:
             self.key_separator = "."
@@ -1651,7 +1648,7 @@ class DBMStore(MutableMapping):
     write_lock: bool, optional
         Use a lock to prevent concurrent writes from multiple threads (True by default).
     dimension_separator : {'.', '/'}, optional
-        Separator placed between the dimensions of a chunk.
+        Separator placed between the dimensions of a chunk.e
     **open_kwargs
         Keyword arguments to pass the `open` function.
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1677,14 +1677,6 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
 class TestArrayWithN5Store(TestArrayWithDirectoryStore):
 
-    DIGESTS = (
-        "453feae4fa9c7086da9e77982e313a45180e4954",
-        "35e50e63ec4443b6f73094daee51af9a28b8702f",
-        "8946a49684c3ca9432c896c6129cb00e5d70ad80",
-        "c71ad4699147c54cde28a54d23ea83e4c80b14b6",
-        "eb997d6507c5bf9ab994b75b28e24ad2a99fa3d6",
-    )
-
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1935,27 +1927,37 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
             assert np.all(a2[:] == 1)
 
     def test_hexdigest(self):
+        expecting = [
+            'c6b83adfad999fbd865057531d749d87cf138f58',
+            'a3d6d187536ecc3a9dd6897df55d258e2f52f9c5',
+            'ec2e008525ae09616dbc1d2408cbdb42532005c8',
+            'b63f031031dcd5248785616edcb2d6fe68203c28',
+            '0cfc673215a8292a87f3c505e2402ce75243c601',
+        ]
+        found = []
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert self.DIGESTS[0] == z.hexdigest()
+        found.append(z.hexdigest())
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert self.DIGESTS[1] == z.hexdigest()
+        found.append(z.hexdigest())
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert self.DIGESTS[2] == z.hexdigest()
+        found.append(z.hexdigest())
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert self.DIGESTS[3] == z.hexdigest()
+        found.append(z.hexdigest())
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert self.DIGESTS[4] == z.hexdigest()
+        found.append(z.hexdigest())
+
+        assert expecting == found
 
 
 class TestArrayWithDBMStore(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -39,6 +39,14 @@ from zarr.tests.util import skip_test_env_var, have_fsspec
 # noinspection PyMethodMayBeStatic
 class TestArray(unittest.TestCase):
 
+    DIGESTS = (
+        "063b02ff8d9d3bab6da932ad5828b506ef0a6578",
+        "f97b84dc9ffac807415f750100108764e837bb82",
+        "c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261",
+        "14470724dca6c1837edddedc490571b6a7f270bc",
+        "2a1046dd99b914459b3e86be9dde05027a07d209",
+    )
+
     def test_array_init(self):
 
         # normal initialization
@@ -535,33 +543,33 @@ class TestArray(unittest.TestCase):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert '063b02ff8d9d3bab6da932ad5828b506ef0a6578' == z.hexdigest()
+        assert self.DIGESTS[0] == z.hexdigest()
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert 'f97b84dc9ffac807415f750100108764e837bb82' == z.hexdigest()
+        assert self.DIGESTS[1] == z.hexdigest()
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert 'c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261' == z.hexdigest()
+        assert self.DIGESTS[2] == z.hexdigest()
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert '14470724dca6c1837edddedc490571b6a7f270bc' == z.hexdigest()
+        assert self.DIGESTS[3] == z.hexdigest()
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert '2a1046dd99b914459b3e86be9dde05027a07d209' == z.hexdigest()
+        assert self.DIGESTS[4] == z.hexdigest()
         if hasattr(z.store, 'close'):
             z.store.close()
 
@@ -1585,6 +1593,14 @@ class TestArrayWithChunkStore(TestArray):
 
 class TestArrayWithDirectoryStore(TestArray):
 
+    DIGESTS = (
+        "063b02ff8d9d3bab6da932ad5828b506ef0a6578",
+        "f97b84dc9ffac807415f750100108764e837bb82",
+        "c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261",
+        "14470724dca6c1837edddedc490571b6a7f270bc",
+        "2a1046dd99b914459b3e86be9dde05027a07d209",
+    )
+
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1638,6 +1654,14 @@ class TestArrayWithABSStore(TestArray):
 
 class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
+    DIGESTS = (
+        "d174aa384e660eb51c6061fc8d20850c1159141f",
+        "125f00eea40032f16016b292f6767aa3928c00a7",
+        "1b52ead0ed889a781ebd4db077a29e35d513c1f3",
+        "719a88b34e362ff65df30e8f8810c1146ab72bc1",
+        "6e0abf30daf45de51593c227fb907759ca725551",
+    )
+
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1652,6 +1676,14 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
 
 class TestArrayWithN5Store(TestArrayWithDirectoryStore):
+
+    DIGESTS = (
+        "453feae4fa9c7086da9e77982e313a45180e4954",
+        "35e50e63ec4443b6f73094daee51af9a28b8702f",
+        "8946a49684c3ca9432c896c6129cb00e5d70ad80",
+        "c71ad4699147c54cde28a54d23ea83e4c80b14b6",
+        "eb997d6507c5bf9ab994b75b28e24ad2a99fa3d6",
+    )
 
     @staticmethod
     def create_array(read_only=False, **kwargs):
@@ -1905,25 +1937,25 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert 'c6b83adfad999fbd865057531d749d87cf138f58' == z.hexdigest()
+        assert self.DIGESTS[0] == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert 'a3d6d187536ecc3a9dd6897df55d258e2f52f9c5' == z.hexdigest()
+        assert self.DIGESTS[1] == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert 'ec2e008525ae09616dbc1d2408cbdb42532005c8' == z.hexdigest()
+        assert self.DIGESTS[2] == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert 'b63f031031dcd5248785616edcb2d6fe68203c28' == z.hexdigest()
+        assert self.DIGESTS[3] == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert '0cfc673215a8292a87f3c505e2402ce75243c601' == z.hexdigest()
+        assert self.DIGESTS[4] == z.hexdigest()
 
 
 class TestArrayWithDBMStore(TestArray):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -39,14 +39,6 @@ from zarr.tests.util import skip_test_env_var, have_fsspec
 # noinspection PyMethodMayBeStatic
 class TestArray(unittest.TestCase):
 
-    DIGESTS = (
-        "063b02ff8d9d3bab6da932ad5828b506ef0a6578",
-        "f97b84dc9ffac807415f750100108764e837bb82",
-        "c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261",
-        "14470724dca6c1837edddedc490571b6a7f270bc",
-        "2a1046dd99b914459b3e86be9dde05027a07d209",
-    )
-
     def test_array_init(self):
 
         # normal initialization
@@ -540,38 +532,51 @@ class TestArray(unittest.TestCase):
         if hasattr(z.store, 'close'):
             z.store.close()
 
+    def expected(self):
+        return [
+            "063b02ff8d9d3bab6da932ad5828b506ef0a6578",
+            "f97b84dc9ffac807415f750100108764e837bb82",
+            "c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261",
+            "14470724dca6c1837edddedc490571b6a7f270bc",
+            "2a1046dd99b914459b3e86be9dde05027a07d209",
+        ]
+
     def test_hexdigest(self):
+        found = []
+
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert self.DIGESTS[0] == z.hexdigest()
+        found.append(z.hexdigest())
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert self.DIGESTS[1] == z.hexdigest()
+        found.append(z.hexdigest())
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert self.DIGESTS[2] == z.hexdigest()
+        found.append(z.hexdigest())
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert self.DIGESTS[3] == z.hexdigest()
+        found.append(z.hexdigest())
         if hasattr(z.store, 'close'):
             z.store.close()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert self.DIGESTS[4] == z.hexdigest()
+        found.append(z.hexdigest())
         if hasattr(z.store, 'close'):
             z.store.close()
+
+        self.expected() == found
 
     def test_resize_1d(self):
 
@@ -1593,14 +1598,6 @@ class TestArrayWithChunkStore(TestArray):
 
 class TestArrayWithDirectoryStore(TestArray):
 
-    DIGESTS = (
-        "063b02ff8d9d3bab6da932ad5828b506ef0a6578",
-        "f97b84dc9ffac807415f750100108764e837bb82",
-        "c7190ad2bea1e9d2e73eaa2d3ca9187be1ead261",
-        "14470724dca6c1837edddedc490571b6a7f270bc",
-        "2a1046dd99b914459b3e86be9dde05027a07d209",
-    )
-
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1654,14 +1651,6 @@ class TestArrayWithABSStore(TestArray):
 
 class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
-    DIGESTS = (
-        "d174aa384e660eb51c6061fc8d20850c1159141f",
-        "125f00eea40032f16016b292f6767aa3928c00a7",
-        "1b52ead0ed889a781ebd4db077a29e35d513c1f3",
-        "719a88b34e362ff65df30e8f8810c1146ab72bc1",
-        "6e0abf30daf45de51593c227fb907759ca725551",
-    )
-
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1673,6 +1662,15 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
                      cache_attrs=cache_attrs)
+
+    def expected(self):
+        return [
+            "d174aa384e660eb51c6061fc8d20850c1159141f",
+            "125f00eea40032f16016b292f6767aa3928c00a7",
+            "1b52ead0ed889a781ebd4db077a29e35d513c1f3",
+            "719a88b34e362ff65df30e8f8810c1146ab72bc1",
+            "6e0abf30daf45de51593c227fb907759ca725551",
+        ]
 
 
 class TestArrayWithN5Store(TestArrayWithDirectoryStore):
@@ -1926,14 +1924,16 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
             a2[:] = 1
             assert np.all(a2[:] == 1)
 
-    def test_hexdigest(self):
-        expecting = [
+    def expected(self):
+        return [
             'c6b83adfad999fbd865057531d749d87cf138f58',
             'a3d6d187536ecc3a9dd6897df55d258e2f52f9c5',
             'ec2e008525ae09616dbc1d2408cbdb42532005c8',
             'b63f031031dcd5248785616edcb2d6fe68203c28',
             '0cfc673215a8292a87f3c505e2402ce75243c601',
         ]
+
+    def test_hexdigest(self):
         found = []
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
@@ -1957,7 +1957,7 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
         z.attrs['foo'] = 'bar'
         found.append(z.hexdigest())
 
-        assert expecting == found
+        assert self.expected() == found
 
 
 class TestArrayWithDBMStore(TestArray):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -5,7 +5,6 @@ import os
 import pickle
 import shutil
 import tempfile
-import unittest
 from contextlib import contextmanager
 from pickle import PicklingError
 from zipfile import ZipFile
@@ -37,6 +36,20 @@ from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var
 @contextmanager
 def does_not_raise():
     yield
+
+
+@pytest.fixture(params=[
+    (None, "."),
+    (".", "."),
+    ("/", "/"),
+])
+def dimension_separator_fixture(request):
+    return request.param
+
+
+def skip_if_nested_chunks(**kwargs):
+    if kwargs.get("dimension_separator") == "/":
+        pytest.skip("nested chunks are unsupported")
 
 
 class StoreTests(object):
@@ -371,8 +384,11 @@ class StoreTests(object):
         if hasattr(store, 'close'):
             store.close()
 
-    def test_init_array(self):
-        store = self.create_store()
+    def test_init_array(self, dimension_separator_fixture):
+
+        pass_dim_sep, want_dim_sep = dimension_separator_fixture
+
+        store = self.create_store(dimension_separator=pass_dim_sep)
         init_array(store, shape=1000, chunks=100)
 
         # check metadata
@@ -384,6 +400,8 @@ class StoreTests(object):
         assert np.dtype(None) == meta['dtype']
         assert default_compressor.get_config() == meta['compressor']
         assert meta['fill_value'] is None
+        # Missing MUST be assumed to be "."
+        assert meta.get('dimension_separator', ".") is want_dim_sep
 
         if hasattr(store, 'close'):
             store.close()
@@ -700,9 +718,10 @@ class StoreTests(object):
             chunk_store.close()
 
 
-class TestMappingStore(StoreTests, unittest.TestCase):
+class TestMappingStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
         return dict()
 
     def test_set_invalid_content(self):
@@ -747,10 +766,11 @@ def setdel_hierarchy_checks(store):
     assert 'r/s' not in store
 
 
-class TestMemoryStore(StoreTests, unittest.TestCase):
+class TestMemoryStore(StoreTests):
 
-    def create_store(self):
-        return MemoryStore()
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+        return MemoryStore(**kwargs)
 
     def test_store_contains_bytes(self):
         store = self.create_store()
@@ -762,11 +782,13 @@ class TestMemoryStore(StoreTests, unittest.TestCase):
         setdel_hierarchy_checks(store)
 
 
-class TestDictStore(StoreTests, unittest.TestCase):
+class TestDictStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+
         with pytest.warns(DeprecationWarning):
-            return DictStore()
+            return DictStore(**kwargs)
 
     def test_deprecated(self):
         store = self.create_store()
@@ -778,12 +800,14 @@ class TestDictStore(StoreTests, unittest.TestCase):
             super().test_pickle()
 
 
-class TestDirectoryStore(StoreTests, unittest.TestCase):
+class TestDirectoryStore(StoreTests):
 
-    def create_store(self, normalize_keys=False):
+    def create_store(self, normalize_keys=False, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
-        store = DirectoryStore(path, normalize_keys=normalize_keys)
+        store = DirectoryStore(path, normalize_keys=normalize_keys, **kwargs)
         return store
 
     def test_filesystem_path(self):
@@ -863,20 +887,33 @@ class TestDirectoryStore(StoreTests, unittest.TestCase):
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
-class TestFSStore(StoreTests, unittest.TestCase):
+class TestFSStore(StoreTests):
 
-    def create_store(self, normalize_keys=False, key_separator="."):
+    def create_store(self, normalize_keys=False, dimension_separator="."):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
         store = FSStore(
             path,
             normalize_keys=normalize_keys,
-            key_separator=key_separator)
+            dimension_separator=dimension_separator)
         return store
 
-    def test_key_separator(self):
+    def test_init_array(self):
+        store = self.create_store()
+        init_array(store, shape=1000, chunks=100)
+
+        # check metadata
+        assert array_meta_key in store
+        meta = decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunks']
+        assert np.dtype(None) == meta['dtype']
+        assert meta['dimension_separator'] is "."
+
+    def test_dimension_separator(self):
         for x in (".", "/"):
-            store = self.create_store(key_separator=x)
+            store = self.create_store(dimension_separator=x)
             norm = store._normalize_key
             assert ".zarray" == norm(".zarray")
             assert ".zarray" == norm("/.zarray")
@@ -1022,6 +1059,23 @@ class TestFSStore(StoreTests, unittest.TestCase):
         assert (a[:] == -np.ones((8, 8, 8))).all()
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestFSStoreWithKeySeparator(StoreTests):
+
+    def create_store(self, normalize_keys=False, key_separator=".", **kwargs):
+
+        # Since the user is passing key_separator, that will take priority.
+        skip_if_nested_chunks(**kwargs)
+
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        with pytest.warns(DeprecationWarning):
+            return FSStore(
+                path,
+                normalize_keys=normalize_keys,
+                key_separator=key_separator)
+
+
 @pytest.fixture()
 def s3(request):
     # writable local S3 system
@@ -1063,13 +1117,26 @@ def s3(request):
     proc.wait()
 
 
-class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
+class TestNestedDirectoryStore(TestDirectoryStore):
 
     def create_store(self, normalize_keys=False):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
         store = NestedDirectoryStore(path, normalize_keys=normalize_keys)
         return store
+
+    def test_init_array(self):
+        store = self.create_store()
+        init_array(store, shape=1000, chunks=100)
+
+        # check metadata
+        assert array_meta_key in store
+        meta = decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunks']
+        assert np.dtype(None) == meta['dtype']
+        assert meta['dimension_separator'] is "/"
 
     def test_chunk_nesting(self):
         store = self.create_store()
@@ -1084,7 +1151,7 @@ class TestNestedDirectoryStore(TestDirectoryStore, unittest.TestCase):
         assert b'zzz' == store['42']
 
 
-class TestN5Store(TestNestedDirectoryStore, unittest.TestCase):
+class TestN5Store(TestNestedDirectoryStore):
 
     def create_store(self, normalize_keys=False):
         path = tempfile.mkdtemp(suffix='.n5')
@@ -1200,12 +1267,12 @@ class TestN5Store(TestNestedDirectoryStore, unittest.TestCase):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestNestedFSStore(TestNestedDirectoryStore):
 
-    def create_store(self, normalize_keys=False, path=None):
+    def create_store(self, normalize_keys=False, path=None, **kwargs):
         if path is None:
             path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
         store = FSStore(path, normalize_keys=normalize_keys,
-                        key_separator='/', auto_mkdir=True)
+                        dimension_separator='/', auto_mkdir=True, **kwargs)
         return store
 
     def test_numbered_groups(self):
@@ -1222,22 +1289,23 @@ class TestNestedFSStore(TestNestedDirectoryStore):
         zarr.open_group(store.path)["0"]
 
 
-class TestTempStore(StoreTests, unittest.TestCase):
+class TestTempStore(StoreTests):
 
-    def create_store(self):
-        return TempStore()
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+        return TempStore(**kwargs)
 
     def test_setdel(self):
         store = self.create_store()
         setdel_hierarchy_checks(store)
 
 
-class TestZipStore(StoreTests, unittest.TestCase):
+class TestZipStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         path = tempfile.mktemp(suffix='.zip')
         atexit.register(os.remove, path)
-        store = ZipStore(path, mode='w')
+        store = ZipStore(path, mode='w', **kwargs)
         return store
 
     def test_mode(self):
@@ -1297,13 +1365,13 @@ class TestZipStore(StoreTests, unittest.TestCase):
         z.close()
 
 
-class TestDBMStore(StoreTests, unittest.TestCase):
+class TestDBMStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, dimension_separator=None):
         path = tempfile.mktemp(suffix='.anydbm')
         atexit.register(atexit_rmglob, path + '*')
         # create store using default dbm implementation
-        store = DBMStore(path, flag='n')
+        store = DBMStore(path, flag='n', dimension_separator=dimension_separator)
         return store
 
     def test_context_manager(self):
@@ -1315,55 +1383,55 @@ class TestDBMStore(StoreTests, unittest.TestCase):
 
 class TestDBMStoreDumb(TestDBMStore):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         path = tempfile.mktemp(suffix='.dumbdbm')
         atexit.register(atexit_rmglob, path + '*')
 
         import dbm.dumb as dumbdbm
-        store = DBMStore(path, flag='n', open=dumbdbm.open)
+        store = DBMStore(path, flag='n', open=dumbdbm.open, **kwargs)
         return store
 
 
 class TestDBMStoreGnu(TestDBMStore):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         gdbm = pytest.importorskip("dbm.gnu")
         path = tempfile.mktemp(suffix=".gdbm")  # pragma: no cover
         atexit.register(os.remove, path)  # pragma: no cover
         store = DBMStore(
-            path, flag="n", open=gdbm.open, write_lock=False
+            path, flag="n", open=gdbm.open, write_lock=False, **kwargs
         )  # pragma: no cover
         return store  # pragma: no cover
 
 
 class TestDBMStoreNDBM(TestDBMStore):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         ndbm = pytest.importorskip("dbm.ndbm")
         path = tempfile.mktemp(suffix=".ndbm")  # pragma: no cover
         atexit.register(atexit_rmglob, path + "*")  # pragma: no cover
-        store = DBMStore(path, flag="n", open=ndbm.open)  # pragma: no cover
+        store = DBMStore(path, flag="n", open=ndbm.open, **kwargs)  # pragma: no cover
         return store  # pragma: no cover
 
 
 class TestDBMStoreBerkeleyDB(TestDBMStore):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         bsddb3 = pytest.importorskip("bsddb3")
         path = tempfile.mktemp(suffix='.dbm')
         atexit.register(os.remove, path)
-        store = DBMStore(path, flag='n', open=bsddb3.btopen, write_lock=False)
+        store = DBMStore(path, flag='n', open=bsddb3.btopen, write_lock=False, **kwargs)
         return store
 
 
-class TestLMDBStore(StoreTests, unittest.TestCase):
+class TestLMDBStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         pytest.importorskip("lmdb")
         path = tempfile.mktemp(suffix='.lmdb')
         atexit.register(atexit_rmtree, path)
         buffers = True
-        store = LMDBStore(path, buffers=buffers)
+        store = LMDBStore(path, buffers=buffers, **kwargs)
         return store
 
     def test_context_manager(self):
@@ -1373,13 +1441,13 @@ class TestLMDBStore(StoreTests, unittest.TestCase):
             assert 2 == len(store)
 
 
-class TestSQLiteStore(StoreTests, unittest.TestCase):
+class TestSQLiteStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         pytest.importorskip("sqlite3")
         path = tempfile.mktemp(suffix='.db')
         atexit.register(atexit_rmtree, path)
-        store = SQLiteStore(path)
+        store = SQLiteStore(path, **kwargs)
         return store
 
     def test_underscore_in_name(self):
@@ -1392,11 +1460,11 @@ class TestSQLiteStore(StoreTests, unittest.TestCase):
         assert 'a_b' in store
 
 
-class TestSQLiteStoreInMemory(TestSQLiteStore, unittest.TestCase):
+class TestSQLiteStoreInMemory(TestSQLiteStore):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         pytest.importorskip("sqlite3")
-        store = SQLiteStore(':memory:')
+        store = SQLiteStore(':memory:', **kwargs)
         return store
 
     def test_pickle(self):
@@ -1412,33 +1480,35 @@ class TestSQLiteStoreInMemory(TestSQLiteStore, unittest.TestCase):
 
 
 @skip_test_env_var("ZARR_TEST_MONGO")
-class TestMongoDBStore(StoreTests, unittest.TestCase):
+class TestMongoDBStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         pytest.importorskip("pymongo")
         store = MongoDBStore(host='127.0.0.1', database='zarr_tests',
-                             collection='zarr_tests')
+                             collection='zarr_tests', **kwargs)
         # start with an empty store
         store.clear()
         return store
 
 
 @skip_test_env_var("ZARR_TEST_REDIS")
-class TestRedisStore(StoreTests, unittest.TestCase):
+class TestRedisStore(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
         # TODO: this is the default host for Redis on Travis,
         # we probably want to generalize this though
         pytest.importorskip("redis")
-        store = RedisStore(host='localhost', port=6379)
+        store = RedisStore(host='localhost', port=6379, **kwargs)
         # start with an empty store
         store.clear()
         return store
 
 
-class TestLRUStoreCache(StoreTests, unittest.TestCase):
+class TestLRUStoreCache(StoreTests):
 
-    def create_store(self):
+    def create_store(self, **kwargs):
+        # wrapper therefore no dimension_separator argument
+        skip_if_nested_chunks(**kwargs)
         return LRUStoreCache(dict(), max_size=2**27)
 
     def test_cache_values_no_max_size(self):
@@ -1831,9 +1901,9 @@ def test_format_compatibility():
 
 
 @skip_test_env_var("ZARR_TEST_ABS")
-class TestABSStore(StoreTests, unittest.TestCase):
+class TestABSStore(StoreTests):
 
-    def create_store(self, prefix=None):
+    def create_store(self, prefix=None, **kwargs):
         asb = pytest.importorskip("azure.storage.blob")
         blob_client = asb.BlockBlobService(is_emulated=True, socket_timeout=10)
         blob_client.delete_container("test")
@@ -1844,6 +1914,7 @@ class TestABSStore(StoreTests, unittest.TestCase):
             account_name="foo",
             account_key="bar",
             blob_service_kwargs={"is_emulated": True, "socket_timeout": 10},
+            **kwargs,
         )
         store.rmdir()
         return store
@@ -1880,7 +1951,7 @@ class TestABSStore(StoreTests, unittest.TestCase):
         return super().test_hierarchy()
 
 
-class TestConsolidatedMetadataStore(unittest.TestCase):
+class TestConsolidatedMetadataStore:
 
     def test_bad_format(self):
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1151,6 +1151,17 @@ class TestNestedDirectoryStore(TestDirectoryStore):
         assert b'zzz' == store['42']
 
 
+class TestNestedDirectoryStoreNone:
+
+    def test_value_error(self):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = NestedDirectoryStore(
+            path, normalize_keys=True,
+            dimension_separator=None)
+        assert store._dimension_separator == "/"
+
+
 class TestNestedDirectoryStoreWithWrongValue:
 
     def test_value_error(self):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1119,14 +1119,15 @@ def s3(request):
 
 class TestNestedDirectoryStore(TestDirectoryStore):
 
-    def create_store(self, normalize_keys=False):
+    def create_store(self, normalize_keys=False, **kwargs):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
-        store = NestedDirectoryStore(path, normalize_keys=normalize_keys)
+        store = NestedDirectoryStore(path, normalize_keys=normalize_keys, **kwargs)
         return store
 
     def test_init_array(self):
         store = self.create_store()
+        assert store._dimension_separator == "/"
         init_array(store, shape=1000, chunks=100)
 
         # check metadata
@@ -1136,7 +1137,7 @@ class TestNestedDirectoryStore(TestDirectoryStore):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunks']
         assert np.dtype(None) == meta['dtype']
-        assert meta['dimension_separator'] is "/"
+        assert meta['dimension_separator'] == "/"
 
     def test_chunk_nesting(self):
         store = self.create_store()

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1069,11 +1069,10 @@ class TestFSStoreWithKeySeparator(StoreTests):
 
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
-        with pytest.warns(DeprecationWarning):
-            return FSStore(
-                path,
-                normalize_keys=normalize_keys,
-                key_separator=key_separator)
+        return FSStore(
+            path,
+            normalize_keys=normalize_keys,
+            key_separator=key_separator)
 
 
 @pytest.fixture()

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1151,6 +1151,17 @@ class TestNestedDirectoryStore(TestDirectoryStore):
         assert b'zzz' == store['42']
 
 
+class TestNestedDirectoryStoreWithWrongValue:
+
+    def test_value_error(self):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        with pytest.raises(ValueError):
+            NestedDirectoryStore(
+                path, normalize_keys=True,
+                dimension_separator=".")
+
+
 class TestN5Store(TestNestedDirectoryStore):
 
     def create_store(self, normalize_keys=False):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -909,7 +909,7 @@ class TestFSStore(StoreTests):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunks']
         assert np.dtype(None) == meta['dtype']
-        assert meta['dimension_separator'] is "."
+        assert meta['dimension_separator'] == "."
 
     def test_dimension_separator(self):
         for x in (".", "/"):

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -18,7 +18,7 @@ def test_normalize_dimension_separator():
     assert '/' == normalize_dimension_separator('/')
     assert '.' == normalize_dimension_separator('.')
     with pytest.raises(ValueError):
-        normalize_shape('X')
+        normalize_dimension_separator('X')
 
 
 def test_normalize_shape():

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -6,10 +6,19 @@ import pytest
 
 from zarr.util import (guess_chunks, human_readable_size, info_html_report,
                        info_text_report, is_total_slice, normalize_chunks,
+                       normalize_dimension_separator,
                        normalize_fill_value, normalize_order,
                        normalize_resize_args, normalize_shape, retry_call,
                        tree_array_icon, tree_group_icon, tree_get_icon,
                        tree_widget)
+
+
+def test_normalize_dimension_separator():
+    assert None is normalize_dimension_separator(None)
+    assert '/' == normalize_dimension_separator('/')
+    assert '.' == normalize_dimension_separator('.')
+    with pytest.raises(ValueError):
+        normalize_shape('X')
 
 
 def test_normalize_shape():

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -13,7 +13,7 @@ from numcodecs.compat import ensure_ndarray, ensure_text
 from numcodecs.registry import codec_registry
 from numcodecs.blosc import cbuffer_sizes, cbuffer_metainfo
 
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 
 # codecs to use for object dtype convenience API
@@ -241,6 +241,16 @@ def normalize_order(order: str) -> str:
     if order not in ['C', 'F']:
         raise ValueError("order must be either 'C' or 'F', found: %r" % order)
     return order
+
+
+def normalize_dimension_separator(sep: Optional[str]) -> str:
+    if sep is None:
+        return "."
+    elif sep not in (".", "/"):
+        raise ValueError(
+            "dimension_separator must be either '.' or '/', found: %r" % sep)
+    else:
+        return sep
 
 
 def normalize_fill_value(fill_value, dtype: np.dtype):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -243,9 +243,9 @@ def normalize_order(order: str) -> str:
     return order
 
 
-def normalize_dimension_separator(sep: Optional[str]) -> str:
+def normalize_dimension_separator(sep: Optional[str]) -> Optional[str]:
     if sep is None:
-        return "."
+        return None
     elif sep not in (".", "/"):
         raise ValueError(
             "dimension_separator must be either '.' or '/', found: %r" % sep)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -244,13 +244,11 @@ def normalize_order(order: str) -> str:
 
 
 def normalize_dimension_separator(sep: Optional[str]) -> Optional[str]:
-    if sep is None:
-        return None
-    elif sep not in (".", "/"):
+    if sep in (".", "/", None):
+        return sep
+    else:
         raise ValueError(
             "dimension_separator must be either '.' or '/', found: %r" % sep)
-    else:
-        return sep
 
 
 def normalize_fill_value(fill_value, dtype: np.dtype):


### PR DESCRIPTION
Implements the new optional array metadata key, `dimension_separator`, from #715 for the Python library.

close: #530

## Details

* All top-level storage classes now take an optional `dimension_separator`
  parameter which defaults to `None`, but can also be `.` or `/`.

* A ValueError is raised at normalization time if this is not the case.

* `None`s are normalized to the default of `.` in all except the
  NestedDirectoryStore case.

* The value is stored as `self._dimension_separator` on participating classes
  so that array creation can lookup the value.

* This value deprecates the `key_separator` value from FSStore.

* Wrapper classes like LRUCacheStore and ConsolidatedMetadataStore *do not*
  follow this pattern and instead rely on the value in the underlying store.

## Discussion

* [ ] The major issues I see with this is the propagation of "Yet Another Constructor Argument". A more complete proposal might take all array initialization parameters similar to those which might be stored in the entry-level metadata in v3.

* [ ] Additionally, this only stores the flat separator (`.`) in `.zarray` if the user actively requests it. Since the value is optional, implementations will default to that value anyway.

## TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
