### PR TITLE
Update Array to respect FSStore's key_separator 

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1950,7 +1950,11 @@ class Array:
         return self._encode_chunk(chunk)
 
     def _chunk_key(self, chunk_coords):
-        return self._key_prefix + '.'.join(map(str, chunk_coords))
+        if hasattr(self._store, 'key_separator'):
+            separator = self._store.key_separator
+        else:
+            separator = '.'
+        return self._key_prefix + separator.join(map(str, chunk_coords))
 
     def _decode_chunk(self, cdata, start=None, nitems=None, expected_shape=None):
         # decompress

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -17,7 +17,6 @@ except ImportError:  # pragma: no cover
 from numcodecs import Zlib
 from numpy.testing import assert_array_equal
 
-import zarr
 from zarr.attrs import Attributes
 from zarr.core import Array
 from zarr.creation import open_array
@@ -986,10 +985,10 @@ class TestGroupWithFSStore(TestGroup):
         name = 'raw'
 
         store, _ = self.create_store()
-        f = zarr.open(store, mode='w')
+        f = open_group(store, mode='w')
         f.create_dataset(name, data=data, chunks=(5, 5, 5),
                          compressor=None)
-        h = zarr.open(store, mode='r')
+        h = open_group(store, mode='r')
         np.testing.assert_array_equal(h[name][:], data)
 
 
@@ -1008,10 +1007,10 @@ class TestGroupWithNestedFSStore(TestGroup):
         name = 'raw'
 
         store, _ = self.create_store()
-        f = zarr.open(store, mode='w')
+        f = open_group(store, mode='w')
         f.create_dataset(name, data=data, chunks=(5, 5, 5),
                          compressor=None)
-        h = zarr.open(store, mode='r')
+        h = open_group(store, mode='r')
         np.testing.assert_array_equal(h[name][:], data)
 
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -27,7 +27,7 @@ from zarr.storage import (ABSStore, DBMStore, DirectoryStore, FSStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
                           group_meta_key, init_array, init_group)
 from zarr.util import InfoReporter
-from zarr.tests.util import skip_test_env_var
+from zarr.tests.util import skip_test_env_var, have_fsspec
 
 
 # noinspection PyStatementEffect
@@ -971,6 +971,7 @@ class TestGroupWithNestedDirectoryStore(TestGroup):
         return store, None
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestGroupWithFSStore(TestGroup):
 
     @staticmethod
@@ -992,6 +993,7 @@ class TestGroupWithFSStore(TestGroup):
         np.testing.assert_array_equal(h[name][:], data)
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestGroupWithNestedFSStore(TestGroupWithFSStore):
 
     @staticmethod

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -992,7 +992,7 @@ class TestGroupWithFSStore(TestGroup):
         np.testing.assert_array_equal(h[name][:], data)
 
 
-class TestGroupWithNestedFSStore(TestGroup):
+class TestGroupWithNestedFSStore(TestGroupWithFSStore):
 
     @staticmethod
     def create_store():
@@ -1000,18 +1000,6 @@ class TestGroupWithNestedFSStore(TestGroup):
         atexit.register(atexit_rmtree, path)
         store = FSStore(path, key_separator='/', auto_mkdir=True)
         return store, None
-
-    def test_round_trip_nd(self):
-        # data must be >1D to test the key_separator
-        data = np.arange(1000).reshape(10, 10, 10)
-        name = 'raw'
-
-        store, _ = self.create_store()
-        f = open_group(store, mode='w')
-        f.create_dataset(name, data=data, chunks=(5, 5, 5),
-                         compressor=None)
-        h = open_group(store, mode='r')
-        np.testing.assert_array_equal(h[name][:], data)
 
 
 class TestGroupWithZipStore(TestGroup):


### PR DESCRIPTION
[Description of PR]

closes #717

I added a couple of FSStore test classes to test_hierarchy.py. The "NestedFSStore" class tests the fix on the specific case raised in #717.

TODO:
* [x] Add unit tests and/or doctests in docstrings
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in docs/tutorial.rst~
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
