### PR TITLE
Updated ipytree warning for jlab3

### DIFF
--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -170,7 +170,7 @@ def test_tree_widget_missing_ipytree():
     pattern = (
         "Run `pip install zarr[jupyter]` or `conda install ipytree`"
         "to get the required ipytree dependency for displaying the tree "
-        "widget. If using jupyterlab, you also need to run "
+        "widget. If using jupyterlab<3, you also need to run "
         "`jupyter labextension install ipytree`"
         )
     with pytest.raises(ImportError, match=re.escape(pattern)):

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -441,7 +441,7 @@ def tree_widget(group, expand, level):
         raise ImportError(
             "{}: Run `pip install zarr[jupyter]` or `conda install ipytree`"
             "to get the required ipytree dependency for displaying the tree "
-            "widget. If using jupyterlab, you also need to run "
+            "widget. If using jupyterlab<3, you also need to run "
             "`jupyter labextension install ipytree`".format(error)
         )
 


### PR DESCRIPTION
Jupyterlab 3 changed how widgets are installed. Now both the frontend and backend are installed via pip/conda. If a user also then installs the front using the `jupyter labextension install` command then they can end up breaking things by trying to install
an old version. This should hopefully help avoid leading users astray.

[Description of PR]

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [NA] Add docstrings and API docs for any new/modified user-facing classes and functions
* [NA] New/modified features documented in docs/tutorial.rst
* [NA?] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
