### PR TITLE
raise an error if create_dataset's dimension_separator is inconsistent with the provided store

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -124,6 +124,12 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     # optional array metadata
     if dimension_separator is None:
         dimension_separator = getattr(store, "_dimension_separator", None)
+    else:
+        if getattr(store, "_dimension_separator", None) != dimension_separator:
+            raise ValueError(
+                f"Specified dimension_separtor: {dimension_separator}"
+                f"conflicts with store's separator: "
+                f"{store._dimension_separator}")
     dimension_separator = normalize_dimension_separator(dimension_separator)
 
     # initialize array metadata

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1003,6 +1003,18 @@ class TestGroupWithNestedFSStore(TestGroupWithFSStore):
         store = FSStore(path, key_separator='/', auto_mkdir=True)
         return store, None
 
+    def test_inconsistent_dimension_separator(self):
+        data = np.arange(1000).reshape(10, 10, 10)
+        name = 'raw'
+
+        store, _ = self.create_store()
+        f = open_group(store, mode='w')
+
+        # cannot specify dimension_separator that conflicts with the store
+        with pytest.raises(ValueError):
+            f.create_dataset(name, data=data, chunks=(5, 5, 5),
+                             compressor=None, dimension_separator='.')
+
 
 class TestGroupWithZipStore(TestGroup):
 


### PR DESCRIPTION
#Description

While working on the zarr_implementations repository, at one point I generated data with `create_dataset` using `dimension_separator='/'`, but with the default FSStore which has a key_separator of '.'. This did not result in any warning, but generated a flat storage format despite the specification of `dimension_separator`. This PR is intended to prevent this by checking for consistency between a store's dimension separator and the one passed as an argument to `create_dataset`.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
