### PR TITLE
Revert "Update Array to respect FSStore's key_separator  (#718)"

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1952,11 +1952,7 @@ class Array:
         return self._encode_chunk(chunk)
 
     def _chunk_key(self, chunk_coords):
-        if hasattr(self._store, 'key_separator'):
-            separator = self._store.key_separator
-        else:
-            separator = '.'
-        return self._key_prefix + separator.join(map(str, chunk_coords))
+        return self._key_prefix + '.'.join(map(str, chunk_coords))
 
     def _decode_chunk(self, cdata, start=None, nitems=None, expected_shape=None):
         # decompress

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -21,13 +21,13 @@ from zarr.attrs import Attributes
 from zarr.core import Array
 from zarr.creation import open_array
 from zarr.hierarchy import Group, group, open_group
-from zarr.storage import (ABSStore, DBMStore, DirectoryStore, FSStore,
-                          LMDBStore, LRUStoreCache, MemoryStore,
-                          NestedDirectoryStore, SQLiteStore, ZipStore,
-                          array_meta_key, atexit_rmglob, atexit_rmtree,
-                          group_meta_key, init_array, init_group)
+from zarr.storage import (ABSStore, DBMStore, DirectoryStore, LMDBStore,
+                          LRUStoreCache, MemoryStore, NestedDirectoryStore,
+                          SQLiteStore, ZipStore, array_meta_key, atexit_rmglob,
+                          atexit_rmtree, group_meta_key, init_array,
+                          init_group)
 from zarr.util import InfoReporter
-from zarr.tests.util import skip_test_env_var, have_fsspec
+from zarr.tests.util import skip_test_env_var
 
 
 # noinspection PyStatementEffect
@@ -969,51 +969,6 @@ class TestGroupWithNestedDirectoryStore(TestGroup):
         atexit.register(atexit_rmtree, path)
         store = NestedDirectoryStore(path)
         return store, None
-
-
-@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
-class TestGroupWithFSStore(TestGroup):
-
-    @staticmethod
-    def create_store():
-        path = tempfile.mkdtemp()
-        atexit.register(atexit_rmtree, path)
-        store = FSStore(path)
-        return store, None
-
-    def test_round_trip_nd(self):
-        data = np.arange(1000).reshape(10, 10, 10)
-        name = 'raw'
-
-        store, _ = self.create_store()
-        f = open_group(store, mode='w')
-        f.create_dataset(name, data=data, chunks=(5, 5, 5),
-                         compressor=None)
-        h = open_group(store, mode='r')
-        np.testing.assert_array_equal(h[name][:], data)
-
-
-@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
-class TestGroupWithNestedFSStore(TestGroupWithFSStore):
-
-    @staticmethod
-    def create_store():
-        path = tempfile.mkdtemp()
-        atexit.register(atexit_rmtree, path)
-        store = FSStore(path, key_separator='/', auto_mkdir=True)
-        return store, None
-
-    def test_inconsistent_dimension_separator(self):
-        data = np.arange(1000).reshape(10, 10, 10)
-        name = 'raw'
-
-        store, _ = self.create_store()
-        f = open_group(store, mode='w')
-
-        # cannot specify dimension_separator that conflicts with the store
-        with pytest.raises(ValueError):
-            f.create_dataset(name, data=data, chunks=(5, 5, 5),
-                             compressor=None, dimension_separator='.')
 
 
 class TestGroupWithZipStore(TestGroup):


### PR DESCRIPTION
This reverts commit 449ed26fbb63915f159735214ce840b3ddcb42a9.

see: #709 #728