### PR TITLE
FSStore: default to normalize_keys=False

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1042,7 +1042,7 @@ class FSStore(MutableMapping):
 
     _META_KEYS = (attrs_key, group_meta_key, array_meta_key)
 
-    def __init__(self, url, normalize_keys=True, key_separator=None,
+    def __init__(self, url, normalize_keys=False, key_separator=None,
                  mode='w',
                  exceptions=(KeyError, PermissionError, IOError),
                  dimension_separator=None,


### PR DESCRIPTION
close #739

Set normalize_keys to False by default to have unification across all the store implementations.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
