### PR TITLE
Drop the additional numpy 1.16 test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        numpy_version: ['']
+        numpy_version: ['', '==1.17.*']
     services:
       redis:
         image: redis

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        numpy_version: ['==1.16.4', '']
+        numpy_version: ['']
     services:
       redis:
         image: redis

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37-npy{115,116,latest}, py38, docs
+envlist = py37-npy{117,latest}, py38, docs
 
 [testenv]
 install_command = pip install --no-binary=numcodecs {opts} {packages}
@@ -20,7 +20,7 @@ commands =
     # main unit test runner
     py38: pytest -v --cov=zarr --cov-config=.coveragerc zarr
     # don't collect coverage when running older numpy versions
-    py37-{npy115,npy116}: pytest -v zarr
+    py37-npy117: pytest -v zarr
     # collect coverage and run doctests under py37
     py37-npylatest: pytest -v --cov=zarr --cov-config=.coveragerc --doctest-plus zarr --remote-data
     # generate a coverage report
@@ -32,8 +32,7 @@ commands =
     # print environment for debugging
     pip freeze
 deps =
-    py37-npy115: numpy==1.15.4
-    py37-npy116: numpy==1.16.4
+    py37-npy117: numpy==1.17.*
     py37-npylatest,py38: -rrequirements_dev_numpy.txt
     -rrequirements_dev_minimal.txt
     -rrequirements_dev_optional.txt


### PR DESCRIPTION
Builds that are pinned to the 1.16.x numpy series are starting to fail. Dropping those in favor of 1.17.x numpy to keep as much backwards compatibility as possible.

see:
 * #774 which drops Python 3.6
 * #749 which bumps h5py to 3.2
