### PR TITLE
Create a Base store class for Zarr Store (update)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -176,7 +176,7 @@ print some diagnostics, e.g.::
     Read-only          : False
     Compressor         : Blosc(cname='zstd', clevel=3, shuffle=BITSHUFFLE,
                        : blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 3379344 (3.2M)
     Storage ratio      : 118.4
@@ -268,7 +268,7 @@ Here is an example using a delta filter with the Blosc compressor::
     Read-only          : False
     Filter [0]         : Delta(dtype='<i4')
     Compressor         : Blosc(cname='zstd', clevel=1, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 1290562 (1.2M)
     Storage ratio      : 309.9
@@ -795,8 +795,10 @@ Here is an example using S3Map to read an array created previously::
     Order              : C
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : fsspec.mapping.FSMap
+    Store type         : zarr.storage.KVStore
     No. bytes          : 21
+    No. bytes stored   : 382
+    Storage ratio      : 0.1
     Chunks initialized : 3/3
     >>> z[:]
     array([b'H', b'e', b'l', b'l', b'o', b' ', b'f', b'r', b'o', b'm', b' ',
@@ -1264,7 +1266,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : C
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 6696010 (6.4M)
     Storage ratio      : 59.7
@@ -1278,7 +1280,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Order              : F
     Read-only          : False
     Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-    Store type         : builtins.dict
+    Store type         : zarr.storage.KVStore
     No. bytes          : 400000000 (381.5M)
     No. bytes stored   : 4684636 (4.5M)
     Storage ratio      : 85.4

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 ignore_missing_imports = True
 follow_imports = silent

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,6 @@ doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
 filterwarnings =
     error::DeprecationWarning:zarr.*
+    error::UserWarning:zarr.*
     ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning
+    ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -12,17 +12,21 @@ from zarr.hierarchy import Group
 from zarr.hierarchy import group as _create_group
 from zarr.hierarchy import open_group
 from zarr.meta import json_dumps, json_loads
-from zarr.storage import contains_array, contains_group
+from zarr.storage import contains_array, contains_group, Store
 from zarr.util import TreeViewer, buffer_size, normalize_storage_path
+
+from typing import Union
+
+StoreLike = Union[Store, str, None]
 
 
 # noinspection PyShadowingBuiltins
-def open(store=None, mode='a', **kwargs):
+def open(store: StoreLike = None, mode: str = "a", **kwargs):
     """Convenience function to open a group or array using file-mode-like semantics.
 
     Parameters
     ----------
-    store : MutableMapping or string, optional
+    store : Store or string, optional
         Store or path to directory in file system or name of zip file.
     mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
@@ -75,32 +79,33 @@ def open(store=None, mode='a', **kwargs):
     clobber = mode == 'w'
     # we pass storage options explicitly, since normalize_store_arg might construct
     # a store if the input is a fsspec-compatible URL
-    store = normalize_store_arg(store, clobber=clobber,
-                                storage_options=kwargs.pop("storage_options", {}))
+    _store: Store = normalize_store_arg(
+        store, clobber=clobber, storage_options=kwargs.pop("storage_options", {})
+    )
     path = normalize_storage_path(path)
 
     if mode in {'w', 'w-', 'x'}:
         if 'shape' in kwargs:
-            return open_array(store, mode=mode, **kwargs)
+            return open_array(_store, mode=mode, **kwargs)
         else:
-            return open_group(store, mode=mode, **kwargs)
+            return open_group(_store, mode=mode, **kwargs)
 
     elif mode == "a":
-        if "shape" in kwargs or contains_array(store, path):
-            return open_array(store, mode=mode, **kwargs)
+        if "shape" in kwargs or contains_array(_store, path):
+            return open_array(_store, mode=mode, **kwargs)
         else:
-            return open_group(store, mode=mode, **kwargs)
+            return open_group(_store, mode=mode, **kwargs)
 
     else:
-        if contains_array(store, path):
-            return open_array(store, mode=mode, **kwargs)
-        elif contains_group(store, path):
-            return open_group(store, mode=mode, **kwargs)
+        if contains_array(_store, path):
+            return open_array(_store, mode=mode, **kwargs)
+        elif contains_group(_store, path):
+            return open_group(_store, mode=mode, **kwargs)
         else:
             raise PathNotFoundError(path)
 
 
-def save_array(store, arr, **kwargs):
+def save_array(store: StoreLike, arr, **kwargs):
     """Convenience function to save a NumPy array to the local file system, following a
     similar API to the NumPy save() function.
 
@@ -132,16 +137,16 @@ def save_array(store, arr, **kwargs):
 
     """
     may_need_closing = isinstance(store, str)
-    store = normalize_store_arg(store, clobber=True)
+    _store: Store = normalize_store_arg(store, clobber=True)
     try:
-        _create_array(arr, store=store, overwrite=True, **kwargs)
+        _create_array(arr, store=_store, overwrite=True, **kwargs)
     finally:
-        if may_need_closing and hasattr(store, 'close'):
+        if may_need_closing:
             # needed to ensure zip file records are written
-            store.close()
+            _store.close()
 
 
-def save_group(store, *args, **kwargs):
+def save_group(store: StoreLike, *args, **kwargs):
     """Convenience function to save several NumPy arrays to the local file system, following a
     similar API to the NumPy savez()/savez_compressed() functions.
 
@@ -203,21 +208,21 @@ def save_group(store, *args, **kwargs):
         raise ValueError('at least one array must be provided')
     # handle polymorphic store arg
     may_need_closing = isinstance(store, str)
-    store = normalize_store_arg(store, clobber=True)
+    _store: Store = normalize_store_arg(store, clobber=True)
     try:
-        grp = _create_group(store, overwrite=True)
+        grp = _create_group(_store, overwrite=True)
         for i, arr in enumerate(args):
             k = 'arr_{}'.format(i)
             grp.create_dataset(k, data=arr, overwrite=True)
         for k, arr in kwargs.items():
             grp.create_dataset(k, data=arr, overwrite=True)
     finally:
-        if may_need_closing and hasattr(store, 'close'):
+        if may_need_closing:
             # needed to ensure zip file records are written
-            store.close()
+            _store.close()
 
 
-def save(store, *args, **kwargs):
+def save(store: StoreLike, *args, **kwargs):
     """Convenience function to save an array or group of arrays to the local file system.
 
     Parameters
@@ -327,7 +332,7 @@ class LazyLoader(Mapping):
         return r
 
 
-def load(store):
+def load(store: StoreLike):
     """Load data from an array or group into memory.
 
     Parameters
@@ -353,11 +358,11 @@ def load(store):
 
     """
     # handle polymorphic store arg
-    store = normalize_store_arg(store)
-    if contains_array(store, path=None):
-        return Array(store=store, path=None)[...]
-    elif contains_group(store, path=None):
-        grp = Group(store=store, path=None)
+    _store = normalize_store_arg(store)
+    if contains_array(_store, path=None):
+        return Array(store=_store, path=None)[...]
+    elif contains_group(_store, path=None):
+        grp = Group(store=_store, path=None)
         return LazyLoader(grp)
 
 
@@ -1073,7 +1078,7 @@ def copy_all(source, dest, shallow=False, without_attrs=False, log=None,
     return n_copied, n_skipped, n_bytes_copied
 
 
-def consolidate_metadata(store, metadata_key='.zmetadata'):
+def consolidate_metadata(store: Store, metadata_key=".zmetadata"):
     """
     Consolidate all metadata for groups and arrays within the given store
     into a single resource and put it under the given key.
@@ -1124,7 +1129,7 @@ def consolidate_metadata(store, metadata_key='.zmetadata'):
     return open_consolidated(store, metadata_key=metadata_key)
 
 
-def open_consolidated(store, metadata_key='.zmetadata', mode='r+', **kwargs):
+def open_consolidated(store: Store, metadata_key=".zmetadata", mode="r+", **kwargs):
     """Open group using metadata previously consolidated into a single key.
 
     This is an optimised method for opening a Zarr group, where instead of

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -2,6 +2,7 @@ from warnings import warn
 
 import numpy as np
 from numcodecs.registry import codec_registry
+from collections.abc import MutableMapping
 
 from zarr.core import Array
 from zarr.errors import (
@@ -10,9 +11,9 @@ from zarr.errors import (
     ContainsGroupError,
 )
 from zarr.n5 import N5Store
-from zarr.storage import (DirectoryStore, ZipStore, contains_array,
+from zarr.storage import (DirectoryStore, ZipStore, KVStore, contains_array,
                           contains_group, default_compressor, init_array,
-                          normalize_storage_path, FSStore)
+                          normalize_storage_path, FSStore, Store)
 from zarr.util import normalize_dimension_separator
 
 
@@ -145,9 +146,9 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     return z
 
 
-def normalize_store_arg(store, clobber=False, storage_options=None, mode='w'):
+def normalize_store_arg(store, clobber=False, storage_options=None, mode="w") -> Store:
     if store is None:
-        return dict()
+        return Store._ensure_store(dict())
     elif isinstance(store, str):
         mode = mode if clobber else "r"
         if "://" in store or "::" in store:
@@ -161,6 +162,8 @@ def normalize_store_arg(store, clobber=False, storage_options=None, mode='w'):
         else:
             return DirectoryStore(store)
     else:
+        if not isinstance(store, Store) and isinstance(store, MutableMapping):
+            store = KVStore(store)
         return store
 
 

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -254,7 +254,7 @@ class Group(MutableMapping):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """If the underlying Store should always heave a ``close`` method, call it."""
+        """Call the close method of the underlying Store."""
         self.store.close()
 
     def info_items(self):

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -15,11 +15,26 @@ from zarr.errors import (
     ReadOnlyError,
 )
 from zarr.meta import decode_group_metadata
-from zarr.storage import (MemoryStore, attrs_key, contains_array,
-                          contains_group, group_meta_key, init_group, listdir,
-                          rename, rmdir)
-from zarr.util import (InfoReporter, TreeViewer, is_valid_python_name, nolock,
-                       normalize_shape, normalize_storage_path)
+from zarr.storage import (
+    MemoryStore,
+    attrs_key,
+    contains_array,
+    contains_group,
+    group_meta_key,
+    init_group,
+    listdir,
+    rename,
+    rmdir,
+    Store,
+)
+from zarr.util import (
+    InfoReporter,
+    TreeViewer,
+    is_valid_python_name,
+    nolock,
+    normalize_shape,
+    normalize_storage_path,
+)
 
 
 class Group(MutableMapping):
@@ -96,6 +111,8 @@ class Group(MutableMapping):
 
     def __init__(self, store, path=None, read_only=False, chunk_store=None,
                  cache_attrs=True, synchronizer=None):
+        store = Store._ensure_store(store)
+        chunk_store = Store._ensure_store(chunk_store)
         self._store = store
         self._chunk_store = chunk_store
         self._path = normalize_storage_path(path)
@@ -237,11 +254,8 @@ class Group(MutableMapping):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """If the underlying Store has a ``close`` method, call it."""
-        try:
-            self.store.close()
-        except AttributeError:
-            pass
+        """If the underlying Store should always heave a ``close`` method, call it."""
+        self.store.close()
 
     def info_items(self):
 
@@ -804,11 +818,13 @@ class Group(MutableMapping):
         <zarr.core.Array '/bar/baz/qux' (100, 100, 100) float64>
 
         """
+        assert "mode" not in kwargs
 
         return self._write_op(self._create_dataset_nosync, name, **kwargs)
 
     def _create_dataset_nosync(self, name, data=None, **kwargs):
 
+        assert "mode" not in kwargs
         path = self._item_path(name)
 
         # determine synchronizer

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -82,8 +82,8 @@ Path = Union[str, bytes, None]
 class Store(MutableMapping):
     """Base class for stores implementation.
 
-
-    Provide a number of default method as well as other typing guaranties for mypy.
+    Provide a number of default method as well as other typing guaranties for
+    mypy.
 
     Stores cannot be mutable mapping as they do have a couple of other
     requirements that would break Liskov substitution principle (stores only
@@ -96,7 +96,7 @@ class Store(MutableMapping):
 
     Stores can be used as context manager to make sure they close on exit.
 
-    .. added: 2.5.0
+    .. added: 2.9.0
 
     """
 
@@ -135,7 +135,7 @@ class Store(MutableMapping):
     def rename(self, src_path: str, dst_path: str) -> None:
         if not self.is_erasable():
             raise NotImplementedError(
-                f'{type(self)} is not erasable, cannot call "rmdir"'
+                f'{type(self)} is not erasable, cannot call "rename"'
             )  # pragma: no cover
         _rename_from_keys(self, src_path, dst_path)
 
@@ -154,9 +154,9 @@ class Store(MutableMapping):
     @staticmethod
     def _ensure_store(store):
         """
-        We want to make sure internally that zarr storage are internally always
-        a class with a specific interface derived from Store, which is slightly
-        different than mutable mapping.
+        We want to make sure internally that zarr stores are always a class
+        with a specific interface derived from ``Store``, which is slightly
+        different than ``MutableMapping``.
 
         We'll do this conversion in a few places automatically
         """
@@ -182,8 +182,8 @@ class Store(MutableMapping):
                 return KVStore(store)
 
         raise ValueError(
-            "Starting with Zarr X.y.z, stores must be subclasses of Store, if "
-            "you store expose the MutableMapping interface wrap them in "
+            "Starting with Zarr 2.9.0, stores must be subclasses of Store, if "
+            "your store exposes the MutableMapping interface wrap it in "
             f"Zarr.storage.KVStore. Got {store}"
         )
 
@@ -281,8 +281,8 @@ def listdir(store: Store, path: Path = None):
     else:
         # slow version, iterate through all keys
         warnings.warn(
-            "Store {store} has not `listdir` method. From zarr 2.5 you may want"
-            "to inherit from `Store`.".format(store=store),
+            f"Store {store} has no `listdir` method. From zarr 2.9 onwards "
+            "may want to inherit from `Store`.",
             stacklevel=2,
         )
         return _listdir_from_keys(store, path)
@@ -641,10 +641,10 @@ def _dict_store_keys(d: Dict, prefix="", cls=dict):
 
 class KVStore(Store):
     """
-    This provide an default implementation of a store interface around
-    a mutable mapping, to avoid having to test stores for presence of methods
+    This provides a default implementation of a store interface around
+    a mutable mapping, to avoid having to test stores for presence of methods.
 
-    This, for most method should just be a pass-through to the underlying KV
+    This, for most methods should just be a pass-through to the underlying KV
     store which is likely to expose a MuttableMapping interface,
     """
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -226,7 +226,7 @@ def rmdir(store: Store, path: Path = None):
     this will be called, otherwise will fall back to implementation via the
     `Store` interface."""
     path = normalize_storage_path(path)
-    if hasattr(store, 'rmdir'):
+    if hasattr(store, "rmdir") and store.is_erasable():
         # pass through
         store.rmdir(path)  # type: ignore
     else:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -136,14 +136,14 @@ class Store(MutableMapping):
         if not self.is_erasable():
             raise NotImplementedError(
                 f'{type(self)} is not erasable, cannot call "rmdir"'
-            )
+            )  # pragma: no cover
         _rename_from_keys(self, src_path, dst_path)
 
     def rmdir(self, path: str = "") -> None:
         if not self.is_erasable():
             raise NotImplementedError(
                 f'{type(self)} is not erasable, cannot call "rmdir"'
-            )
+            )  # pragma: no cover
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -147,18 +147,9 @@ class Store(MutableMapping):
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
 
-    # def getsize(self, path: Path = None):
-    #    pass
-
-    # def clear(self):
-    #    pass
-
     def close(self) -> None:
         """Do nothing by default"""
         pass
-
-    # def pop(self, key):
-    #    raise NotImplementedError
 
     @staticmethod
     def _ensure_store(store):
@@ -658,56 +649,37 @@ class KVStore(Store):
     """
 
     def __init__(self, mutablemapping):
-        self.mm = mutablemapping
+        self._mutable_mapping = mutablemapping
 
     def __getitem__(self, key):
-        return self.mm[key]
+        return self._mutable_mapping[key]
 
     def __setitem__(self, key, value):
-        # assert isinstance(value, bytes)
-        self.mm[key] = value
+        self._mutable_mapping[key] = value
 
     def __delitem__(self, key):
-        del self.mm[key]
+        del self._mutable_mapping[key]
 
     def get(self, key, default=None):
-        return self.mm.get(key, default)
+        return self._mutable_mapping.get(key, default)
 
     def values(self):
-        return self.mm.values()
+        return self._mutable_mapping.values()
 
     def __iter__(self):
-        return iter(self.mm)
+        return iter(self._mutable_mapping)
 
     def __len__(self):
-        return len(self.mm)
+        return len(self._mutable_mapping)
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}: \n{repr(self.mm)}\n at {hex(id(self))}>"
+        return f"<{self.__class__.__name__}: \n{repr(self._mutable_mapping)}\n at {hex(id(self))}>"
 
     def __eq__(self, other):
         if isinstance(other, KVStore):
-            return self.mm == other.mm
+            return self._mutable_mapping == other._mutable_mapping
         else:
             return NotImplemented
-
-    # def __contains__(self, key):
-    #    return key in self.mm
-
-    # def pop(self):
-    #    return self.mm.pop()
-
-    # def popitem
-    # def clear
-    # def update
-    # def setdefault
-    # def __eq__
-    # def __ne__
-    # def __contains__
-    # def keys()
-    # def items()
-    # def values()
-    # def get
 
 
 class MemoryStore(Store):

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -23,8 +23,12 @@ from zarr.convenience import (
 from zarr.core import Array
 from zarr.errors import CopyError
 from zarr.hierarchy import Group, group
-from zarr.storage import (ConsolidatedMetadataStore, MemoryStore,
-                          atexit_rmtree, getsize)
+from zarr.storage import (
+    ConsolidatedMetadataStore,
+    MemoryStore,
+    atexit_rmtree,
+    getsize,
+)
 
 
 def test_open_array():

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -2,6 +2,7 @@ import atexit
 import os.path
 import shutil
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
@@ -463,29 +464,33 @@ def test_create():
 
 def test_compression_args():
 
-    z = create(100, compression='zlib', compression_opts=9)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        z = create(100, compression="zlib", compression_opts=9)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
 
-    # 'compressor' overrides 'compression'
-    z = create(100, compressor=Zlib(9), compression='bz2', compression_opts=1)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
-
-    # 'compressor' ignores 'compression_opts'
-    z = create(100, compressor=Zlib(9), compression_opts=1)
-    assert isinstance(z, Array)
-    assert 'zlib' == z.compressor.codec_id
-    assert 9 == z.compressor.level
-
-    with pytest.warns(UserWarning):
         # 'compressor' overrides 'compression'
-        create(100, compressor=Zlib(9), compression='bz2', compression_opts=1)
-    with pytest.warns(UserWarning):
+        with pytest.warns(UserWarning):
+            z = create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
+
         # 'compressor' ignores 'compression_opts'
-        create(100, compressor=Zlib(9), compression_opts=1)
+        with pytest.warns(UserWarning):
+            z = create(100, compressor=Zlib(9), compression_opts=1)
+        assert isinstance(z, Array)
+        assert "zlib" == z.compressor.codec_id
+        assert 9 == z.compressor.level
+
+        with pytest.warns(UserWarning):
+            # 'compressor' overrides 'compression'
+            create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+        with pytest.warns(UserWarning):
+            # 'compressor' ignores 'compression_opts'
+            create(100, compressor=Zlib(9), compression_opts=1)
 
 
 def test_create_read_only():

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -22,7 +22,7 @@ from zarr.attrs import Attributes
 from zarr.core import Array
 from zarr.creation import open_array
 from zarr.hierarchy import Group, group, open_group
-from zarr.storage import (ABSStore, DBMStore, DirectoryStore, FSStore,
+from zarr.storage import (ABSStore, DBMStore, KVStore, DirectoryStore, FSStore,
                           LMDBStore, LRUStoreCache, MemoryStore,
                           NestedDirectoryStore, SQLiteStore, ZipStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
@@ -37,7 +37,7 @@ class TestGroup(unittest.TestCase):
     @staticmethod
     def create_store():
         # can be overridden in sub-classes
-        return dict(), None
+        return KVStore(dict()), None
 
     def create_group(self, store=None, path=None, read_only=False,
                      chunk_store=None, synchronizer=None):
@@ -67,8 +67,7 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g.info, InfoReporter)
         assert isinstance(repr(g.info), str)
         assert isinstance(g.info._repr_html_(), str)
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_group_init_2(self):
         store, chunk_store = self.create_store()
@@ -80,16 +79,14 @@ class TestGroup(unittest.TestCase):
         assert '/foo/bar' == g.name
         assert 'bar' == g.basename
         assert isinstance(g.attrs, Attributes)
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_group_init_errors_1(self):
         store, chunk_store = self.create_store()
         # group metadata not initialized
         with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_group_init_errors_2(self):
         store, chunk_store = self.create_store()
@@ -97,8 +94,7 @@ class TestGroup(unittest.TestCase):
         # array blocks group
         with pytest.raises(ValueError):
             Group(store, chunk_store=chunk_store)
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_create_group(self):
         g1 = self.create_group()
@@ -169,8 +165,7 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g7, Group)
         assert g7.path == 'z'
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_require_group(self):
         g1 = self.create_group()
@@ -213,8 +208,7 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g7, Group)
         assert g7.path == 'z'
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_create_dataset(self):
         g = self.create_group()
@@ -290,8 +284,7 @@ class TestGroup(unittest.TestCase):
         assert d.compressor.codec_id == 'zlib'
         assert 1 == d.compressor.level
 
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_require_dataset(self):
         g = self.create_group()
@@ -337,8 +330,7 @@ class TestGroup(unittest.TestCase):
             g.require_dataset('foo', shape=1000, chunks=100, dtype='i2',
                               exact=True)
 
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_create_errors(self):
         g = self.create_group()
@@ -393,8 +385,7 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(PermissionError):
             g.require_dataset('zzz', shape=100, chunks=10)
 
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_create_overwrite(self):
         try:
@@ -420,8 +411,7 @@ class TestGroup(unittest.TestCase):
                 assert (400,) == d.shape
                 assert isinstance(g['foo'], Group)
 
-                if hasattr(g.store, 'close'):
-                    g.store.close()
+                g.store.close()
         except NotImplementedError:
             pass
 
@@ -649,8 +639,7 @@ class TestGroup(unittest.TestCase):
         assert g1.visitvalues(visitor1) is True
         assert g1.visititems(visitor1) is True
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_empty_getitem_contains_iterators(self):
         # setup
@@ -662,8 +651,7 @@ class TestGroup(unittest.TestCase):
         assert 0 == len(g)
         assert 'foo' not in g
 
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_iterators_recurse(self):
         # setup
@@ -689,8 +677,7 @@ class TestGroup(unittest.TestCase):
         assert 'zab' == arrays_recurse[0][0]
         assert g1['foo']['bar']['zab'] == arrays_recurse[0][1]
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_getattr(self):
         # setup
@@ -704,8 +691,7 @@ class TestGroup(unittest.TestCase):
         # test that hasattr returns False instead of an exception (issue #88)
         assert not hasattr(g1, 'unexistingattribute')
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_setitem(self):
         g = self.create_group()
@@ -722,8 +708,7 @@ class TestGroup(unittest.TestCase):
             assert 42 == g['foo'][()]
         except NotImplementedError:
             pass
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_delitem(self):
         g = self.create_group()
@@ -742,8 +727,7 @@ class TestGroup(unittest.TestCase):
             assert 'foo' in g
             assert 'bar' not in g
             assert 'bar/baz' not in g
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_move(self):
         g = self.create_group()
@@ -791,8 +775,7 @@ class TestGroup(unittest.TestCase):
         except NotImplementedError:
             pass
 
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
 
     def test_array_creation(self):
         grp = self.create_group()
@@ -829,8 +812,7 @@ class TestGroup(unittest.TestCase):
         assert isinstance(j, Array)
         assert_array_equal(np.arange(100), j[:])
 
-        if hasattr(grp.store, 'close'):
-            grp.store.close()
+        grp.store.close()
 
         grp = self.create_group(read_only=True)
         with pytest.raises(PermissionError):
@@ -856,8 +838,7 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(PermissionError):
             grp.full_like('aa', a)
 
-        if hasattr(grp.store, 'close'):
-            grp.store.close()
+        grp.store.close()
 
     def test_paths(self):
         g1 = self.create_group()
@@ -890,8 +871,7 @@ class TestGroup(unittest.TestCase):
         with pytest.raises(ValueError):
             g1['foo/../bar']
 
-        if hasattr(g1.store, 'close'):
-            g1.store.close()
+        g1.store.close()
 
     def test_pickle(self):
 
@@ -908,8 +888,7 @@ class TestGroup(unittest.TestCase):
         dump = pickle.dumps(g)
         # some stores cannot be opened twice at the same time, need to close
         # store before can round-trip through pickle
-        if hasattr(g.store, 'close'):
-            g.store.close()
+        g.store.close()
         g2 = pickle.loads(dump)
 
         # verify
@@ -920,8 +899,7 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g2['foo'], Group)
         assert isinstance(g2['foo/bar'], Array)
 
-        if hasattr(g2.store, 'close'):
-            g2.store.close()
+        g2.store.close()
 
     def test_context_manager(self):
 
@@ -1086,7 +1064,7 @@ class TestGroupWithChunkStore(TestGroup):
 
     @staticmethod
     def create_store():
-        return dict(), dict()
+        return KVStore(dict()), KVStore(dict())
 
     def test_chunk_store(self):
         # setup
@@ -1131,13 +1109,13 @@ def test_group():
     assert '/' == g.name
 
     # usage with custom store
-    store = dict()
+    store = KVStore(dict())
     g = group(store=store)
     assert isinstance(g, Group)
     assert store is g.store
 
     # overwrite behaviour
-    store = dict()
+    store = KVStore(dict())
     init_array(store, shape=100, chunks=10)
     with pytest.raises(ValueError):
         group(store)

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1017,6 +1017,11 @@ class TestGroupWithZipStore(TestGroup):
         with pytest.raises(ValueError):
             store.zf.extractall()
 
+    def test_move(self):
+        # zip store is not erasable (can so far only append to a zip
+        # so we can't test for move.
+        pass
+
 
 class TestGroupWithDBMStore(TestGroup):
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -738,42 +738,39 @@ class TestGroup(unittest.TestCase):
         data = np.arange(100)
         g['foo'] = data
 
-        try:
-            g.move('foo', 'bar')
-            assert 'foo' not in g
-            assert 'bar' in g
-            assert_array_equal(data, g['bar'])
+        g.move("foo", "bar")
+        assert "foo" not in g
+        assert "bar" in g
+        assert_array_equal(data, g["bar"])
 
-            g.move('bar', 'foo/bar')
-            assert 'bar' not in g
-            assert 'foo' in g
-            assert 'foo/bar' in g
-            assert isinstance(g['foo'], Group)
-            assert_array_equal(data, g['foo/bar'])
+        g.move("bar", "foo/bar")
+        assert "bar" not in g
+        assert "foo" in g
+        assert "foo/bar" in g
+        assert isinstance(g["foo"], Group)
+        assert_array_equal(data, g["foo/bar"])
 
-            g.move('foo', 'foo2')
-            assert 'foo' not in g
-            assert 'foo/bar' not in g
-            assert 'foo2' in g
-            assert 'foo2/bar' in g
-            assert isinstance(g['foo2'], Group)
-            assert_array_equal(data, g['foo2/bar'])
+        g.move("foo", "foo2")
+        assert "foo" not in g
+        assert "foo/bar" not in g
+        assert "foo2" in g
+        assert "foo2/bar" in g
+        assert isinstance(g["foo2"], Group)
+        assert_array_equal(data, g["foo2/bar"])
 
-            g2 = g['foo2']
-            g2.move('bar', '/bar')
-            assert 'foo2' in g
-            assert 'foo2/bar' not in g
-            assert 'bar' in g
-            assert isinstance(g['foo2'], Group)
-            assert_array_equal(data, g['bar'])
+        g2 = g["foo2"]
+        g2.move("bar", "/bar")
+        assert "foo2" in g
+        assert "foo2/bar" not in g
+        assert "bar" in g
+        assert isinstance(g["foo2"], Group)
+        assert_array_equal(data, g["bar"])
 
-            with pytest.raises(ValueError):
-                g2.move('bar', 'bar2')
+        with pytest.raises(ValueError):
+            g2.move("bar", "bar2")
 
-            with pytest.raises(ValueError):
-                g.move('bar', 'boo')
-        except NotImplementedError:
-            pass
+        with pytest.raises(ValueError):
+            g.move("bar", "boo")
 
         g.store.close()
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -91,8 +91,7 @@ def test_coverage_rename():
 
 def test_deprecated_listdir_nosotre():
     store = dict()
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")
+    with pytest.warns(UserWarning, match="has not `listdir`"):
         listdir(store)
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -346,55 +346,51 @@ class StoreTests(object):
 
         # test rename (optional)
         if store.is_erasable():
-            try:
-                store.rename("c/e", "c/e2")
-                assert "c/d" in store
-                assert "c/e" not in store
-                assert "c/e/f" not in store
-                assert "c/e/g" not in store
-                assert "c/e2" not in store
-                assert "c/e2/f" in store
-                assert "c/e2/g" in store
-                store.rename("c/e2", "c/e")
-                assert "c/d" in store
-                assert "c/e2" not in store
-                assert "c/e2/f" not in store
-                assert "c/e2/g" not in store
-                assert "c/e" not in store
-                assert "c/e/f" in store
-                assert "c/e/g" in store
-                store.rename("c", "c1/c2/c3")
-                assert "a" in store
-                assert "c" not in store
-                assert "c/d" not in store
-                assert "c/e" not in store
-                assert "c/e/f" not in store
-                assert "c/e/g" not in store
-                assert "c1" not in store
-                assert "c1/c2" not in store
-                assert "c1/c2/c3" not in store
-                assert "c1/c2/c3/d" in store
-                assert "c1/c2/c3/e" not in store
-                assert "c1/c2/c3/e/f" in store
-                assert "c1/c2/c3/e/g" in store
-                store.rename("c1/c2/c3", "c")
-                assert "c" not in store
-                assert "c/d" in store
-                assert "c/e" not in store
-                assert "c/e/f" in store
-                assert "c/e/g" in store
-                assert "c1" not in store
-                assert "c1/c2" not in store
-                assert "c1/c2/c3" not in store
-                assert "c1/c2/c3/d" not in store
-                assert "c1/c2/c3/e" not in store
-                assert "c1/c2/c3/e/f" not in store
-                assert "c1/c2/c3/e/g" not in store
-            except NotImplementedError:
-                pass
+            store.rename("c/e", "c/e2")
+            assert "c/d" in store
+            assert "c/e" not in store
+            assert "c/e/f" not in store
+            assert "c/e/g" not in store
+            assert "c/e2" not in store
+            assert "c/e2/f" in store
+            assert "c/e2/g" in store
+            store.rename("c/e2", "c/e")
+            assert "c/d" in store
+            assert "c/e2" not in store
+            assert "c/e2/f" not in store
+            assert "c/e2/g" not in store
+            assert "c/e" not in store
+            assert "c/e/f" in store
+            assert "c/e/g" in store
+            store.rename("c", "c1/c2/c3")
+            assert "a" in store
+            assert "c" not in store
+            assert "c/d" not in store
+            assert "c/e" not in store
+            assert "c/e/f" not in store
+            assert "c/e/g" not in store
+            assert "c1" not in store
+            assert "c1/c2" not in store
+            assert "c1/c2/c3" not in store
+            assert "c1/c2/c3/d" in store
+            assert "c1/c2/c3/e" not in store
+            assert "c1/c2/c3/e/f" in store
+            assert "c1/c2/c3/e/g" in store
+            store.rename("c1/c2/c3", "c")
+            assert "c" not in store
+            assert "c/d" in store
+            assert "c/e" not in store
+            assert "c/e/f" in store
+            assert "c/e/g" in store
+            assert "c1" not in store
+            assert "c1/c2" not in store
+            assert "c1/c2/c3" not in store
+            assert "c1/c2/c3/d" not in store
+            assert "c1/c2/c3/e" not in store
+            assert "c1/c2/c3/e/f" not in store
+            assert "c1/c2/c3/e/g" not in store
 
-        # test rmdir (optional)
-        if store.is_erasable():
+            # test rmdir (optional)
             store.rmdir("c/e")
             assert "c/d" in store
             assert "c/e/f" not in store

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -9,7 +9,6 @@ import tempfile
 from contextlib import contextmanager
 from pickle import PicklingError
 from zipfile import ZipFile
-import warnings
 
 import numpy as np
 import pytest

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -9,6 +9,7 @@ import tempfile
 from contextlib import contextmanager
 from pickle import PicklingError
 from zipfile import ZipFile
+import warnings
 
 import numpy as np
 import pytest
@@ -24,13 +25,14 @@ from zarr.meta import (ZARR_FORMAT, decode_array_metadata,
                        encode_group_metadata)
 from zarr.n5 import N5Store
 from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
-                          DictStore, DirectoryStore, LMDBStore, LRUStoreCache,
-                          MemoryStore, MongoDBStore, NestedDirectoryStore,
-                          RedisStore, SQLiteStore, TempStore, ZipStore,
+                          DictStore, DirectoryStore, KVStore, LMDBStore,
+                          LRUStoreCache, MemoryStore, MongoDBStore,
+                          NestedDirectoryStore, RedisStore, SQLiteStore,
+                          Store, TempStore, ZipStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
-from zarr.storage import FSStore
+from zarr.storage import FSStore, rename, listdir
 from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container
 
 
@@ -53,12 +55,57 @@ def skip_if_nested_chunks(**kwargs):
         pytest.skip("nested chunks are unsupported")
 
 
+def test_kvstore_repr():
+    repr(KVStore(dict()))
+
+
+def test_invalid_store():
+    class InvalidStore:
+        pass
+
+    with pytest.raises(ValueError):
+        Store._ensure_store(InvalidStore())
+
+
+def test_capabilities():
+    s = KVStore(dict())
+    s.is_readable()
+    s.is_listable()
+    s.is_erasable()
+    s.is_writeable()
+
+
+def test_getsize_non_implemented():
+    assert getsize(object()) == -1
+
+
+def test_kvstore_eq():
+    assert KVStore(dict()) != dict()
+
+
+def test_coverage_rename():
+    store = dict()
+    store['a'] = 1
+    rename(store, 'a', 'b')
+
+
+def test_deprecated_listdir_nosotre():
+    store = dict()
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        listdir(store)
+
+
 class StoreTests(object):
     """Abstract store tests."""
 
     def create_store(self, **kwargs):  # pragma: no cover
         # implement in sub-class
         raise NotImplementedError
+
+    def test_context_manager(self):
+        with self.create_store():
+            pass
 
     def test_get_set_del_contains(self):
         store = self.create_store()
@@ -86,8 +133,7 @@ class StoreTests(object):
                 # noinspection PyStatementEffect
                 del store['foo']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_set_invalid_content(self):
         store = self.create_store()
@@ -95,8 +141,7 @@ class StoreTests(object):
         with pytest.raises(TypeError):
             store['baz'] = list(range(5))
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_clear(self):
         store = self.create_store()
@@ -108,8 +153,7 @@ class StoreTests(object):
         assert 'foo' not in store
         assert 'baz' not in store
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_pop(self):
         store = self.create_store()
@@ -131,8 +175,7 @@ class StoreTests(object):
         v = store.pop('xxx', None)
         assert v is None
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_popitem(self):
         store = self.create_store()
@@ -144,8 +187,7 @@ class StoreTests(object):
         with pytest.raises(KeyError):
             store.popitem()
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_writeable_values(self):
         store = self.create_store()
@@ -156,8 +198,7 @@ class StoreTests(object):
         store['foo3'] = array.array('B', b'bar')
         store['foo4'] = np.frombuffer(b'bar', dtype='u1')
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_update(self):
         store = self.create_store()
@@ -167,8 +208,7 @@ class StoreTests(object):
         assert b'bar' == ensure_bytes(store['foo'])
         assert b'quux' == ensure_bytes(store['baz'])
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_iterators(self):
         store = self.create_store()
@@ -194,8 +234,7 @@ class StoreTests(object):
         assert ({('a', b'aaa'), ('b', b'bbb'), ('c/d', b'ddd'), ('c/e/f', b'fff')} ==
                 set(map(lambda kv: (kv[0], ensure_bytes(kv[1])), store.items())))
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_pickle(self):
 
@@ -210,10 +249,9 @@ class StoreTests(object):
         dump = pickle.dumps(store)
         # some stores cannot be opened twice at the same time, need to close
         # store before can round-trip through pickle
-        if hasattr(store, 'close'):
-            store.close()
-            # check can still pickle after close
-            assert dump == pickle.dumps(store)
+        store.close()
+        # check can still pickle after close
+        assert dump == pickle.dumps(store)
         store2 = pickle.loads(dump)
 
         # verify
@@ -222,8 +260,7 @@ class StoreTests(object):
         assert b'bar' == ensure_bytes(store2['foo'])
         assert b'quux' == ensure_bytes(store2['baz'])
 
-        if hasattr(store2, 'close'):
-            store2.close()
+        store2.close()
 
     def test_getsize(self):
         store = self.create_store()
@@ -245,8 +282,7 @@ class StoreTests(object):
             assert 15 == getsize(store)
             assert 5 == getsize(store, 'spong')
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     # noinspection PyStatementEffect
     def test_hierarchy(self):
@@ -311,59 +347,62 @@ class StoreTests(object):
             assert [] == store.listdir('c/e/f')
 
         # test rename (optional)
-        if hasattr(store, 'rename'):
-            store.rename('c/e', 'c/e2')
-            assert 'c/d' in store
-            assert 'c/e' not in store
-            assert 'c/e/f' not in store
-            assert 'c/e/g' not in store
-            assert 'c/e2' not in store
-            assert 'c/e2/f' in store
-            assert 'c/e2/g' in store
-            store.rename('c/e2', 'c/e')
-            assert 'c/d' in store
-            assert 'c/e2' not in store
-            assert 'c/e2/f' not in store
-            assert 'c/e2/g' not in store
-            assert 'c/e' not in store
-            assert 'c/e/f' in store
-            assert 'c/e/g' in store
-            store.rename('c', 'c1/c2/c3')
-            assert 'a' in store
-            assert 'c' not in store
-            assert 'c/d' not in store
-            assert 'c/e' not in store
-            assert 'c/e/f' not in store
-            assert 'c/e/g' not in store
-            assert 'c1' not in store
-            assert 'c1/c2' not in store
-            assert 'c1/c2/c3' not in store
-            assert 'c1/c2/c3/d' in store
-            assert 'c1/c2/c3/e' not in store
-            assert 'c1/c2/c3/e/f' in store
-            assert 'c1/c2/c3/e/g' in store
-            store.rename('c1/c2/c3', 'c')
-            assert 'c' not in store
-            assert 'c/d' in store
-            assert 'c/e' not in store
-            assert 'c/e/f' in store
-            assert 'c/e/g' in store
-            assert 'c1' not in store
-            assert 'c1/c2' not in store
-            assert 'c1/c2/c3' not in store
-            assert 'c1/c2/c3/d' not in store
-            assert 'c1/c2/c3/e' not in store
-            assert 'c1/c2/c3/e/f' not in store
-            assert 'c1/c2/c3/e/g' not in store
+        if store.is_erasable():
+            try:
+                store.rename("c/e", "c/e2")
+                assert "c/d" in store
+                assert "c/e" not in store
+                assert "c/e/f" not in store
+                assert "c/e/g" not in store
+                assert "c/e2" not in store
+                assert "c/e2/f" in store
+                assert "c/e2/g" in store
+                store.rename("c/e2", "c/e")
+                assert "c/d" in store
+                assert "c/e2" not in store
+                assert "c/e2/f" not in store
+                assert "c/e2/g" not in store
+                assert "c/e" not in store
+                assert "c/e/f" in store
+                assert "c/e/g" in store
+                store.rename("c", "c1/c2/c3")
+                assert "a" in store
+                assert "c" not in store
+                assert "c/d" not in store
+                assert "c/e" not in store
+                assert "c/e/f" not in store
+                assert "c/e/g" not in store
+                assert "c1" not in store
+                assert "c1/c2" not in store
+                assert "c1/c2/c3" not in store
+                assert "c1/c2/c3/d" in store
+                assert "c1/c2/c3/e" not in store
+                assert "c1/c2/c3/e/f" in store
+                assert "c1/c2/c3/e/g" in store
+                store.rename("c1/c2/c3", "c")
+                assert "c" not in store
+                assert "c/d" in store
+                assert "c/e" not in store
+                assert "c/e/f" in store
+                assert "c/e/g" in store
+                assert "c1" not in store
+                assert "c1/c2" not in store
+                assert "c1/c2/c3" not in store
+                assert "c1/c2/c3/d" not in store
+                assert "c1/c2/c3/e" not in store
+                assert "c1/c2/c3/e/f" not in store
+                assert "c1/c2/c3/e/g" not in store
+            except NotImplementedError:
+                pass
 
         # test rmdir (optional)
-        if hasattr(store, 'rmdir'):
-            store.rmdir('c/e')
-            assert 'c/d' in store
-            assert 'c/e/f' not in store
-            assert 'c/e/g' not in store
-            store.rmdir('c')
-            assert 'c/d' not in store
+        if store.is_erasable():
+            store.rmdir("c/e")
+            assert "c/d" in store
+            assert "c/e/f" not in store
+            assert "c/e/g" not in store
+            store.rmdir("c")
+            assert "c/d" not in store
             store.rmdir()
             assert 'a' not in store
             assert 'b' not in store
@@ -382,8 +421,7 @@ class StoreTests(object):
             assert 'c/d' in store
             assert 'c/e/f' in store
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_init_array(self, dimension_separator_fixture):
 
@@ -404,8 +442,7 @@ class StoreTests(object):
         # Missing MUST be assumed to be "."
         assert meta.get('dimension_separator', ".") is want_dim_sep
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_init_array_overwrite(self):
         self._test_init_array_overwrite('F')
@@ -456,8 +493,7 @@ class StoreTests(object):
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_init_array_path(self):
         path = 'foo/bar'
@@ -475,8 +511,7 @@ class StoreTests(object):
         assert default_compressor.get_config() == meta['compressor']
         assert meta['fill_value'] is None
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def _test_init_array_overwrite_path(self, order):
         # setup
@@ -513,8 +548,7 @@ class StoreTests(object):
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_init_array_overwrite_group(self):
         # setup
@@ -541,8 +575,7 @@ class StoreTests(object):
             assert (100,) == meta['chunks']
             assert np.dtype('i4') == meta['dtype']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def _test_init_array_overwrite_chunk_store(self, order):
         # setup
@@ -580,10 +613,8 @@ class StoreTests(object):
             assert '0' not in chunk_store
             assert '1' not in chunk_store
 
-        if hasattr(store, 'close'):
-            store.close()
-        if hasattr(chunk_store, 'close'):
-            chunk_store.close()
+        store.close()
+        chunk_store.close()
 
     def test_init_array_compat(self):
         store = self.create_store()
@@ -591,8 +622,7 @@ class StoreTests(object):
         meta = decode_array_metadata(store[array_meta_key])
         assert meta['compressor'] is None
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def test_init_group(self):
         store = self.create_store()
@@ -603,8 +633,7 @@ class StoreTests(object):
         meta = decode_group_metadata(store[group_meta_key])
         assert ZARR_FORMAT == meta['zarr_format']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def _test_init_group_overwrite(self, order):
         # setup
@@ -638,8 +667,7 @@ class StoreTests(object):
         with pytest.raises(ValueError):
             init_group(store)
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def _test_init_group_overwrite_path(self, order):
         # setup
@@ -673,8 +701,7 @@ class StoreTests(object):
             meta = decode_group_metadata(store[path + '/' + group_meta_key])
             assert ZARR_FORMAT == meta['zarr_format']
 
-        if hasattr(store, 'close'):
-            store.close()
+        store.close()
 
     def _test_init_group_overwrite_chunk_store(self, order):
         # setup
@@ -713,17 +740,15 @@ class StoreTests(object):
         with pytest.raises(ValueError):
             init_group(store)
 
-        if hasattr(store, 'close'):
-            store.close()
-        if hasattr(chunk_store, 'close'):
-            chunk_store.close()
+        store.close()
+        chunk_store.close()
 
 
 class TestMappingStore(StoreTests):
 
     def create_store(self, **kwargs):
         skip_if_nested_chunks(**kwargs)
-        return dict()
+        return KVStore(dict())
 
     def test_set_invalid_content(self):
         # Generic mappings support non-buffer types
@@ -1052,11 +1077,13 @@ class TestFSStore(StoreTests):
 
         with pytest.raises(PermissionError):
             # even though overwrite=True, store is read-only, so fails
-            g2.create_dataset("data", shape=(8, 8, 8), mode='w',
-                              fill_value=-1, chunks=(1, 1, 1), overwrite=True)
+            g2.create_dataset(
+                "data", shape=(8, 8, 8), fill_value=-1, chunks=(1, 1, 1), overwrite=True
+            )
 
-        a = g.create_dataset("data", shape=(8, 8, 8), mode='w',
-                             fill_value=-1, chunks=(1, 1, 1), overwrite=True)
+        a = g.create_dataset(
+            "data", shape=(8, 8, 8), fill_value=-1, chunks=(1, 1, 1), overwrite=True
+        )
         assert (a[:] == -np.ones((8, 8, 8))).all()
 
 
@@ -1754,14 +1781,14 @@ class TestLRUStoreCache(StoreTests):
 
 
 def test_getsize():
-    store = dict()
+    store = KVStore(dict())
     store['foo'] = b'aaa'
     store['bar'] = b'bbbb'
     store['baz/quux'] = b'ccccc'
     assert 7 == getsize(store)
     assert 5 == getsize(store, 'baz')
 
-    store = dict()
+    store = KVStore(dict())
     store['boo'] = None
     assert -1 == getsize(store)
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -68,11 +68,10 @@ def test_invalid_store():
 
 def test_capabilities():
     s = KVStore(dict())
-    s.is_readable()
-    s.is_listable()
-    s.is_erasable()
-    s.is_writeable()
-
+    assert s.is_readable()
+    assert s.is_listable()
+    assert s.is_erasable()
+    assert s.is_writeable()
 
 def test_getsize_non_implemented():
     assert getsize(object()) == -1
@@ -90,7 +89,7 @@ def test_coverage_rename():
 
 def test_deprecated_listdir_nosotre():
     store = dict()
-    with pytest.warns(UserWarning, match="has not `listdir`"):
+    with pytest.warns(UserWarning, match="has no `listdir`"):
         listdir(store)
 
 

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,11 +1,12 @@
 import collections
-from collections.abc import MutableMapping
 import os
+
+from zarr.storage import Store
 
 import pytest
 
 
-class CountingDict(MutableMapping):
+class CountingDict(Store):
 
     def __init__(self):
         self.wrapped = dict()


### PR DESCRIPTION
# Use a base Store class instead of just MutableMapping

I am resuming the work @Carreau started in #612 here. This is mostly just a rebase of that PR with a small new commit in 8136713. Matthias and I met earlier today and we decided that starting with this PR should make it easier to add zarr-v3 support without trying to implement an entirely independent set of classes. The goal is to reduce code duplication between v2 and v3 where possible (None of the changes in this PR are specific to v3 yet)

Note that I updated the version string text to `2.9.0` in a couple of places, but that may need to be updated again depending on when this is merged.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
