### PR TITLE
avoid NumPy 1.21.0 due to bug

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        numpy_version: ['', '==1.17.*']
+        numpy_version: ['!=1.21.0', '==1.17.*']
     services:
       redis:
         image: redis

--- a/requirements_rtfd.txt
+++ b/requirements_rtfd.txt
@@ -5,4 +5,4 @@ sphinx
 sphinx-issues
 sphinx-rtd-theme
 numpydoc
-numpy
+numpy!=1.21.0


### PR DESCRIPTION
This PR blocks NumPy 1.21.0 due to numpy/numpy#19325

I cherry-picked this commit from #789 where it resolved the observed segfault


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
