### PR TITLE
Fix build with Sphinx 4.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,9 +144,11 @@ html_theme_options = {'logo_only': True}
 # of the sidebar.
 html_logo = '_static/logo1.png'
 
+
 # Add custom css
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')
+
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
`add_stylesheet` was deprecated in 1.8 and removed in 4.0 [1]. The replacement, `add_css_file` was added in 1.0.

You don't have a minimum Sphinx version specified, so I'm not sure what is required, but 1.0 is pretty old.

[1] https://www.sphinx-doc.org/en/master/extdev/deprecated.html?highlight=add_stylesheet