### PR TITLE
add missing assert when comparing array checksums in TestArray

### DIFF
--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -578,7 +578,7 @@ class TestArray(unittest.TestCase):
         if hasattr(z.store, 'close'):
             z.store.close()
 
-        self.expected() == found
+        assert self.expected() == found
 
     def test_resize_1d(self):
 


### PR DESCRIPTION
I came across a missing assert in the `test_hexdigest` method of `TestArray` (needed to verify that the checksums match the expected values)

TODO:
~* [ ] Add unit tests and/or doctests in docstrings~
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in docs/tutorial.rst~
~* [ ] Changes documented in docs/release.rst~
* [ ] GitHub Actions have all passed
~* [ ] Test coverage is 100% (Codecov passes)~
