### PR TITLE
Zarr 2.9.1: fix conda release

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,14 @@ Release notes
 Unreleased
 ----------
 
+.. _release_2.9.1:
+
+Maintenance
+~~~~~~~~~~~
+
+* Correct conda-forge deployment of Zarr.
+  By :user:`Josh Moore <joshmoore>`; :issue:`XXX`.
+
 .. _release_2.9.0:
 
 

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -63,6 +63,7 @@ def test_open(dataset):
     verify(zarr.open(dataset))
 
 
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 def test_fsstore(dataset):
     verify(Array(store=FSStore(dataset)))
 


### PR DESCRIPTION
see:
 * https://github.com/conda-forge/zarr-feedstock/pull/48
 * #817

The conda-forge release failed since fsspec is not installed by default. In order to get Zarr deployed ASAP (re: https://github.com/DiamondLightSource/python-tristan/pull/62) this simply properly handles the test issue that @QuLogic brought up in #817.

It might be that moving forward, fsspec should be installed & tested for conda-forge releases. If not, then a minimal test workflow should be added here to show that the conda-forge requirements (below) suffice to run or skip all tests:

```
channels:
  - conda-forge
  - defaults
dependencies:
  - python < 3.9.0
  - wheel
  - numcodecs
  - numpy
  - pip
  - pip:
    - asciitree
    - fasteners
    - pytest
    - setuptools_scm
```