### PR TITLE
Be more robust in how regression data are discovered

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,15 @@ Release notes
 Unreleased
 ----------
 
+.. _release_2.9.2:
+
+Maintenance
+~~~~~~~~~~~
+
+* Correct conda-forge deployment of Zarr by fixing some Zarr tests.
+  By :user:`Ben Williams <benjaminhwilliams>`; :issue:`821`.
+
+
 .. _release_2.9.1:
 
 Maintenance

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -60,7 +60,7 @@ def verify(array):
 
 
 def test_open(dataset):
-    verify(zarr.open(dataset))
+    verify(zarr.open(dataset, "r"))
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -33,9 +33,9 @@ def dataset(tmpdir, request):
     if which.startswith("static"):
         project_root = pathlib.Path(zarr.__file__).resolve().parent.parent
         if which.endswith("nested"):
-            return project_root / "fixture/nested"
+            return str(project_root / "fixture/nested")
         else:
-            return project_root / "fixture/flat"
+            return str(project_root / "fixture/flat")
 
     if which.startswith("directory"):
         store_class = DirectoryStore

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 from numpy.testing import assert_array_equal
 
@@ -29,10 +31,11 @@ def dataset(tmpdir, request):
     kwargs = {}
 
     if which.startswith("static"):
+        project_root = pathlib.Path(zarr.__file__).resolve().parent.parent
         if which.endswith("nested"):
-            return "fixture/nested"
+            return project_root / "fixture/nested"
         else:
-            return "fixture/flat"
+            return project_root / "fixture/flat"
 
     if which.startswith("directory"):
         store_class = DirectoryStore


### PR DESCRIPTION
Be stricter about where and how regression data are discovered, during testing.  This fixes some tests that are failing during the Conda-forge release process.

As previously mentioned in https://github.com/zarr-developers/zarr-python/pull/819#discussion_r694717559:
- Ensure that, regardless of the test runner working directory, the regression data can be found.
- During `zarr.tests.test_dim_separator.test_open`, open an array in read-only mode, to prevent accidental creation of an empty array when the expected array does not exist, which would leave droppings in the test runner working directory.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
