### PR TITLE
Circumvent Codecov's legitimate complaint without resorting to pragma

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -9,7 +9,7 @@ Unreleased
 Maintenance
 ~~~~~~~~~~~
 
-* Mark the fact that some tests that require ``fsspec``, compromising the code coverage score.
+* Mark the fact that some tests that require ``fsspec``, without compromising the code coverage score.
   By :user:`Ben Williams <benjaminhwilliams>`; :issue:`823`.
 
 .. _release_2.9.2:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,12 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+
+* Mark the fact that some tests that require ``fsspec``, compromising the code coverage score.
+  By :user:`Ben Williams <benjaminhwilliams>`; :issue:`823`.
+
 .. _release_2.9.2:
 
 2.9.2

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -7,6 +7,9 @@ from zarr.storage import (DirectoryStore, NestedDirectoryStore, FSStore)
 from zarr.tests.util import have_fsspec
 
 
+needs_fsspec = pytest.mark.skipif(not have_fsspec, reason="needs fsspec")
+
+
 @pytest.fixture(params=("static_nested",
                         "static_flat",
                         "directory_nested",
@@ -14,9 +17,9 @@ from zarr.tests.util import have_fsspec
                         "directory_default",
                         "nesteddirectory_nested",
                         "nesteddirectory_default",
-                        "fs_nested",
-                        "fs_flat",
-                        "fs_default"))
+                        pytest.param("fs_nested", marks=needs_fsspec),
+                        pytest.param("fs_flat", marks=needs_fsspec),
+                        pytest.param("fs_default", marks=needs_fsspec)))
 def dataset(tmpdir, request):
     """
     Generate a variety of different Zarrs using
@@ -39,8 +42,6 @@ def dataset(tmpdir, request):
     elif which.startswith("nested"):
         store_class = NestedDirectoryStore
     else:
-        if have_fsspec is False:
-            pytest.skip("no fsspec")  # pragma: no cover
         store_class = FSStore
         kwargs["mode"] = "w"
         kwargs["auto_mkdir"] = True
@@ -63,7 +64,7 @@ def test_open(dataset):
     verify(zarr.open(dataset))
 
 
-@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+@needs_fsspec
 def test_fsstore(dataset):
     verify(Array(store=FSStore(dataset)))
 


### PR DESCRIPTION
Codecov recognises that we aren't testing with `fsspec`.  Perhaps it is less picky if we use `pytest.param` to parametrise the tests.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
