### PR TITLE
Ignore None dim_separators in save_array (fix #831)

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -126,11 +126,12 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     if dimension_separator is None:
         dimension_separator = getattr(store, "_dimension_separator", None)
     else:
-        if getattr(store, "_dimension_separator", None) != dimension_separator:
+        store_separator = getattr(store, "_dimension_separator", None)
+        if store_separator not in (None, dimension_separator):
             raise ValueError(
                 f"Specified dimension_separtor: {dimension_separator}"
                 f"conflicts with store's separator: "
-                f"{store._dimension_separator}")
+                f"{store_separator}")
     dimension_separator = normalize_dimension_separator(dimension_separator)
 
     # initialize array metadata

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -18,6 +18,7 @@ from zarr.convenience import (
     open_consolidated,
     save,
     save_group,
+    save_array,
     copy_all,
 )
 from zarr.core import Array
@@ -223,6 +224,17 @@ def test_consolidated_with_chunk_store():
     # make sure keyword arguments are passed through without error
     open_consolidated(store, cache_attrs=True, synchronizer=None,
                       chunk_store=chunk_store)
+
+
+@pytest.mark.parametrize("options", (
+    {"dimension_separator": "/"},
+    {"dimension_separator": "."},
+    {"dimension_separator": None},
+))
+def test_save_array_separator(tmpdir, options):
+    data = np.arange(6).reshape((3,2))
+    url = tmpdir.join("test.zarr")
+    zarr.save_array(url, data, **options)
 
 
 class TestCopyStore(unittest.TestCase):

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -232,9 +232,9 @@ def test_consolidated_with_chunk_store():
     {"dimension_separator": None},
 ))
 def test_save_array_separator(tmpdir, options):
-    data = np.arange(6).reshape((3,2))
+    data = np.arange(6).reshape((3, 2))
     url = tmpdir.join("test.zarr")
-    zarr.save_array(url, data, **options)
+    save_array(url, data, **options)
 
 
 class TestCopyStore(unittest.TestCase):


### PR DESCRIPTION
If a store does not have a `dimension_separator` set,
then requesting a non-`None` value should not be an
error.

[Description of PR]

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
