### PR TITLE
Fix versionadded tag in zarr.core.Array docstring

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -76,6 +76,9 @@ class Array:
         If True and while the chunk_store is a FSStore and the compresion used
         is Blosc, when getting data from the array chunks will be partially
         read and decompressed when possible.
+
+        .. versionadded:: 2.7
+
     write_empty_chunks : bool, optional
         If True (default), all chunks will be stored regardless of their
         contents. If False, each chunk is compared to the array's fill
@@ -85,7 +88,8 @@ class Array:
         as only chunks with non-fill-value data are stored, at the expense
         of overhead associated with checking the data of each chunk.
 
-        .. versionadded:: 2.7
+        .. versionadded:: 2.11
+
 
     Attributes
     ----------


### PR DESCRIPTION
In #738, we accidentally moved the 2.7 versionadded tag of partial_decompress to the new write_empty_chunks argument. This commit restores it to its rightful place and adds a 2.11 versionadded tag to write_empty_chunks.
