### PR TITLE
Fix: N5 keywords now emit UserWarning instead of raising a ValueError

### DIFF
--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -128,7 +128,7 @@ class N5Store(NestedDirectoryStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    print("Warning: attribute %s is a reserved N5 keyword" % k)
+                    warnings.warn("attribute %s is a reserved N5 keyword" % k, UserWarning)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):
@@ -424,7 +424,7 @@ class N5FSStore(FSStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    print("Warning: attribute %s is a reserved N5 keyword" % k)
+                    warnings.warn("attribute %s is a reserved N5 keyword" % k, UserWarning)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -128,7 +128,7 @@ class N5Store(NestedDirectoryStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    raise ValueError("Can not set attribute %s, this is a reserved N5 keyword" % k)
+                    print("Warning: you are setting attribute %s, this is a reserved N5 keyword" % k)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):
@@ -424,9 +424,7 @@ class N5FSStore(FSStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    raise ValueError(
-                        "Can not set attribute %s, this is a reserved N5 keyword" % k
-                    )
+                    print("Warning: you are setting attribute %s, this is a reserved N5 keyword" % k)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -128,7 +128,7 @@ class N5Store(NestedDirectoryStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    print("Warning: you are setting attribute %s, this is a reserved N5 keyword" % k)
+                    print("Warning: attribute %s is a reserved N5 keyword" % k)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):
@@ -424,7 +424,7 @@ class N5FSStore(FSStore):
 
             for k in n5_keywords:
                 if k in zarr_attrs.keys():
-                    print("Warning: you are setting attribute %s, this is a reserved N5 keyword" % k)
+                    print("Warning: attribute %s is a reserved N5 keyword" % k)
 
             # replace previous user attributes
             for k in list(n5_attrs.keys()):

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1699,10 +1699,6 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
 class TestArrayWithN5Store(TestArrayWithDirectoryStore):
 
-    @pytest.fixture(autouse=True)
-    def capsys(self, capsys):
-        self.capsys = capsys
-
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1964,9 +1960,8 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
     def test_attrs_n5_keywords(self):
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         for k in n5_keywords:
-            z.attrs[k] = ""
-            out, _ = self.capsys.readouterr()
-            assert "Warning: attribute" in out
+            with pytest.warns(UserWarning):
+                z.attrs[k] = ""
 
     def test_compressors(self):
         compressors = [

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1965,8 +1965,8 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         for k in n5_keywords:
             z.attrs[k] = ""
-            out, _  = self.capsys.readouterr()
-            assert "Warning: you are setting attribute" in out
+            out, _ = self.capsys.readouterr()
+            assert "Warning: attribute" in out
 
     def test_compressors(self):
         compressors = [

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1699,6 +1699,10 @@ class TestArrayWithNestedDirectoryStore(TestArrayWithDirectoryStore):
 
 class TestArrayWithN5Store(TestArrayWithDirectoryStore):
 
+    @pytest.fixture(autouse=True)
+    def capsys(self, capsys):
+        self.capsys = capsys
+
     @staticmethod
     def create_array(read_only=False, **kwargs):
         path = mkdtemp()
@@ -1960,8 +1964,9 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
     def test_attrs_n5_keywords(self):
         z = self.create_array(shape=(1050,), chunks=100, dtype='i4')
         for k in n5_keywords:
-            with pytest.raises(ValueError):
-                z.attrs[k] = ""
+            z.attrs[k] = ""
+            out, _  = self.capsys.readouterr()
+            assert "Warning: you are setting attribute" in out
 
     def test_compressors(self):
         compressors = [


### PR DESCRIPTION
Fix for #693  
Changed both N5 and N5FS
Added test fixture to capture stdout
Updated test making sure a warning is printed

Let me know if there are any docs changes I need to do.

Thanks!

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
