### PR TITLE
blocks_to_decompress not used in read_part function

### DIFF
--- a/zarr/util.py
+++ b/zarr/util.py
@@ -605,12 +605,6 @@ class PartialReadBuffer:
         assert self.buff is not None
         if self.nblocks == 1:
             return
-        blocks_to_decompress = nitems / self.n_per_block
-        blocks_to_decompress = (
-            blocks_to_decompress
-            if blocks_to_decompress == int(blocks_to_decompress)
-            else int(blocks_to_decompress + 1)
-        )
         start_block = int(start / self.n_per_block)
         wanted_decompressed = 0
         while wanted_decompressed < nitems:


### PR DESCRIPTION
Unused variable, as indicated by [lgtm.com](https://lgtm.com/projects/g/zarr-developers/zarr-python/snapshot/9546f2312c02be3e91a4a67c8631e21bbb9c73e9/files/zarr/util.py?sort=name&dir=ASC&mode=heatmap#xcd2184c787afdbd8:1)

TODO:
* [x] Add unit tests and/or doctests in docstrings (all tests passed locally)
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
