### PR TITLE
Pass dimension_separator on fixture generation (fix #858)

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -26,3 +26,10 @@ jobs:
         conda activate minimal
         python -m pip install .
         pytest -svx
+    - name: Fixture generation
+      shell: "bash -l {0}"
+      run: |
+        conda activate minimal
+        rm -rf fixture/
+        pytest -svx zarr/tests/test_dim_separator.py zarr/tests/test_storage.py
+        # This simulates fixture-less tests in conda and debian packaging

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -2,7 +2,6 @@ import pathlib
 
 import pytest
 from numpy.testing import assert_array_equal
-from functools import partial
 
 import zarr
 from zarr.core import Array
@@ -44,16 +43,9 @@ def dataset(tmpdir, request):
         if not static.exists():  # pragma: no cover
 
             if "nested" in which:
-                # No way to reproduce the nested_legacy file via code
                 generator = NestedDirectoryStore
             else:
-                if "legacy" in suffix:
-                    # No dimension_separator metadata included
-                    generator = DirectoryStore
-                else:
-                    # Explicit dimension_separator metadata included
-                    generator = partial(DirectoryStore,
-                                        dimension_separator=".")
+                generator = DirectoryStore
 
             # store the data - should be one-time operation
             s = generator(str(static))

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -2,6 +2,7 @@ import pathlib
 
 import pytest
 from numpy.testing import assert_array_equal
+from functools import partial
 
 import zarr
 from zarr.core import Array
@@ -43,9 +44,16 @@ def dataset(tmpdir, request):
         if not static.exists():  # pragma: no cover
 
             if "nested" in which:
+                # No way to reproduce the nested_legacy file via code
                 generator = NestedDirectoryStore
             else:
-                generator = DirectoryStore
+                if "legacy" in suffix:
+                    # No dimension_separator metadata included
+                    generator = DirectoryStore
+                else:
+                    # Explicit dimension_separator metadata included
+                    generator = partial(DirectoryStore,
+                                        dimension_separator=".")
 
             # store the data - should be one-time operation
             s = generator(str(static))


### PR DESCRIPTION
Under some test conditions (conda-forge, Debian builds), the
fixtures directory is not available and is then re-created.
When dimension_separator is not passed to DirectoryStore, then
no metadata is assigned to the file. For the "flat" (as opposed
to "flat_legacy") fixture, this meant that the NestedDirectoryStore
did not correct its behavior leading to a failure.

see:
 - https://github.com/conda-forge/zarr-feedstock/pull/56
 - https://github.com/zarr-developers/zarr-python/issues/858

TODO:
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)

fix #858
