### PR TITLE
add v3 store classes (zarr v3 support part 1)

### DIFF
--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from collections.abc import MutableMapping
 from string import ascii_letters, digits

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -1,7 +1,5 @@
 import base64
 import itertools
-import os
-from collections import namedtuple
 from collections.abc import Mapping
 
 import numpy as np
@@ -37,7 +35,10 @@ _v3_complex_types = set(
 # see: https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units
 _date_units = ["Y", "M", "W", "D"]
 _time_units = ["h", "m", "s", "ms", "us", "μs", "ns", "ps", "fs", "as"]
-_v3_datetime_types = set(f"{end}{kind}8[{unit}]" for end, unit, kind in itertools.product("<>", _date_units + _time_units, ('m', 'M')))
+_v3_datetime_types = set(
+    f"{end}{kind}8[{unit}]"
+    for end, unit, kind in itertools.product("<>", _date_units + _time_units, ('m', 'M'))
+)
 
 
 def get_extended_dtype_info(dtype):
@@ -322,7 +323,7 @@ class Metadata3(Metadata2):
         d = cls._decode_dtype_descr(d)
         dtype = np.dtype(d)
         if validate:
-            if dtype.str in (_v3_core_types  | {"|b1", "|u1", "|i1"}):
+            if dtype.str in (_v3_core_types | {"|b1", "|u1", "|i1"}):
                 # it is a core dtype of the v3 spec
                 pass
             else:

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -22,6 +22,12 @@ _v3_core_type = set(
 )
 _v3_core_type = {"bool", "i1", "u1"} | _v3_core_type
 
+# TODO: How do we want to handle dtypes not officially in the v3 spec?
+#       Those in _v3_core_type above are the only ones defined in the spec.
+#       However we currently support many other dtypes for v2. For now, I also
+#       allow all of these for v3 unless the user sets an environment variable
+#       ZARR_V3_CORE_DTYPES_ONLY=1, etc.
+
 ZARR_V3_CORE_DTYPES_ONLY = int(os.environ.get("ZARR_V3_CORE_DTYPES_ONLY", False))
 ZARR_V3_ALLOW_COMPLEX = int(os.environ.get("ZARR_V3_ALLOW_COMPLEX",
                                            not ZARR_V3_CORE_DTYPES_ONLY))

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -417,6 +417,12 @@ class Metadata3(Metadata2):
             uri = uri + "zlib/1.0"
         elif isinstance(codec, numcodecs.Blosc):
             uri = uri + "blosc/1.0"
+        elif isinstance(codec, numcodecs.BZ2):
+            uri = uri + "bz2/1.0"
+        elif isinstance(codec, numcodecs.LZ4):
+            uri = uri + "lz4/1.0"
+        elif isinstance(codec, numcodecs.LZMA):
+            uri = uri + "lzma/1.0"
         meta = {
             "codec": uri,
             "configuration": config,
@@ -433,12 +439,21 @@ class Metadata3(Metadata2):
         if meta['codec'].startswith(uri + 'gzip/'):
             codec = numcodecs.GZip(level=conf['level'])
         elif meta['codec'].startswith(uri + 'zlib/'):
-            codec = numcodecs.Zlib()
+            codec = numcodecs.Zlib(level=conf['level'])
         elif meta['codec'].startswith(uri + 'blosc/'):
             codec = numcodecs.Blosc(clevel=conf['clevel'],
                                     shuffle=conf['shuffle'],
                                     blocksize=conf['blocksize'],
                                     cname=conf['cname'])
+        elif meta['codec'].startswith(uri + 'bz2/'):
+            codec = numcodecs.BZ2(level=conf['level'])
+        elif meta['codec'].startswith(uri + 'lz4/'):
+            codec = numcodecs.LZ4(acceleration=conf['acceleration'])
+        elif meta['codec'].startswith(uri + 'lzma/'):
+            codec = numcodecs.LZMA(format=conf['format'],
+                                   check=conf['check'],
+                                   preset=conf['preset'],
+                                   filters=conf['filters'])
         else:
             raise NotImplementedError
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -476,6 +476,7 @@ class Metadata3(Metadata2):
             # TODO: remove dimension_separator?
 
             compressor = cls._decode_codec_metadata(meta.get("compressor", None))
+            extensions = meta.get("extensions", [])
             meta = dict(
                 shape=tuple(meta["shape"]),
                 chunk_grid=dict(
@@ -488,6 +489,7 @@ class Metadata3(Metadata2):
                 chunk_memory_layout=meta["chunk_memory_layout"],
                 dimension_separator=meta.get("dimension_separator", "/"),
                 attributes=meta["attributes"],
+                extensions=extensions,
             )
             # compressor field should be absent when there is no compression
             if compressor:
@@ -515,6 +517,7 @@ class Metadata3(Metadata2):
         else:
             object_codec = None
         compressor = cls._encode_codec_metadata(meta.get("compressor", None))
+        extensions = meta.get("extensions", [])
         meta = dict(
             shape=meta["shape"] + sdshape,
             chunk_grid=dict(
@@ -526,6 +529,7 @@ class Metadata3(Metadata2):
             fill_value=encode_fill_value(meta["fill_value"], dtype, object_codec),
             chunk_memory_layout=meta["chunk_memory_layout"],
             attributes=meta.get("attributes", {}),
+            extensions=extensions,
         )
         if compressor:
             meta["compressor"] = compressor

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -169,9 +169,6 @@ class Metadata2:
         if dimension_separator:
             meta["dimension_separator"] = dimension_separator
 
-        if dimension_separator:
-            meta["dimension_separator"] = dimension_separator
-
         return json_dumps(meta)
 
     @classmethod

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -487,7 +487,6 @@ class Metadata3(Metadata2):
                 data_type=dtype,
                 fill_value=fill_value,
                 chunk_memory_layout=meta["chunk_memory_layout"],
-                dimension_separator=meta.get("dimension_separator", "/"),
                 attributes=meta["attributes"],
                 extensions=extensions,
             )
@@ -495,9 +494,6 @@ class Metadata3(Metadata2):
             if compressor:
                 meta['compressor'] = compressor
 
-            # dimension_separator = meta.get("dimension_separator", None)
-            # if dimension_separator:
-            #     meta["dimension_separator"] = dimension_separator
         except Exception as e:
             raise MetadataError("error decoding metadata: %s" % e)
         else:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -562,7 +562,7 @@ def _init_array_metadata(
 
     # obtain compressor config
     compressor_config = None
-    if compressor:
+    if store_version == 2 and compressor:
         try:
             compressor_config = compressor.get_config()
         except AttributeError as e:
@@ -598,7 +598,8 @@ def _init_array_metadata(
 
     # initialize metadata
     # TODO: don't store redundant dimension_separator for v3?
-    meta = dict(shape=shape, compressor=compressor_config,
+    _compressor = compressor_config if store_version == 2 else compressor
+    meta = dict(shape=shape, compressor=_compressor,
                 fill_value=fill_value,
                 dimension_separator=dimension_separator)
     if store_version < 3:

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -18,9 +18,9 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from numcodecs.compat import ensure_bytes
 
 from zarr.codecs import BZ2, AsType, Blosc, Zlib
-from zarr.errors import MetadataError
+from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataError
 from zarr.hierarchy import group
-from zarr.meta import ZARR_FORMAT, decode_array_metadata
+from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3, decode_array_metadata
 from zarr.n5 import N5Store, N5FSStore
 from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           DictStore, DirectoryStore, KVStore, LMDBStore,
@@ -31,7 +31,12 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore, rename, listdir
+from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
+                          DirectoryStoreV3, NestedDirectoryStoreV3,
+                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
+                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
 from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container
+from zarr.tests.util import CountingDictV3
 
 
 @contextmanager
@@ -45,6 +50,15 @@ def does_not_raise():
     ("/", "/"),
 ])
 def dimension_separator_fixture(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    (None, "/"),
+    (".", "."),
+    ("/", "/"),
+])
+def dimension_separator_fixture_v3(request):
     return request.param
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -18,9 +18,9 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from numcodecs.compat import ensure_bytes
 
 from zarr.codecs import BZ2, AsType, Blosc, Zlib
-from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataError
+from zarr.errors import MetadataError
 from zarr.hierarchy import group
-from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3, decode_array_metadata
+from zarr.meta import ZARR_FORMAT, decode_array_metadata
 from zarr.n5 import N5Store, N5FSStore
 from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           DictStore, DirectoryStore, KVStore, LMDBStore,
@@ -31,12 +31,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore, rename, listdir
-from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
-                          DirectoryStoreV3, NestedDirectoryStoreV3,
-                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
-                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
 from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container
-from zarr.tests.util import CountingDictV3
 
 
 @contextmanager

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -95,7 +95,7 @@ class StoreV3Tests(StoreTests):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
-        assert default_compressor.get_config() == meta['compressor']
+        assert default_compressor == meta['compressor']
         assert meta['fill_value'] is None
         # Missing MUST be assumed to be "/"
         assert meta.get('dimension_separator', "/") is want_dim_sep
@@ -118,7 +118,7 @@ class StoreV3Tests(StoreTests):
                                  chunk_shape=(200,),
                                  separator=('/')),
                  data_type=np.dtype('u1'),
-                 compressor=Zlib(1).get_config(),
+                 compressor=Zlib(1),
                  fill_value=0,
                  chunk_memory_layout=order,
                  filters=None)
@@ -165,7 +165,7 @@ class StoreV3Tests(StoreTests):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
-        assert default_compressor.get_config() == meta['compressor']
+        assert default_compressor == meta['compressor']
         assert meta['fill_value'] is None
 
         store.close()
@@ -179,7 +179,7 @@ class StoreV3Tests(StoreTests):
                                     chunk_shape=(200,),
                                     separator=('/')),
                     data_type=np.dtype('u1'),
-                    compressor=Zlib(1).get_config(),
+                    compressor=Zlib(1),
                     fill_value=0,
                     chunk_memory_layout=order,
                     filters=None)

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -6,8 +6,6 @@ import tempfile
 import numpy as np
 import pytest
 
-from numcodecs.compat import ensure_bytes
-
 from zarr.codecs import Zlib
 from zarr.errors import ContainsArrayError, ContainsGroupError
 from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
@@ -25,8 +23,10 @@ from .test_storage import (StoreTests, TestMemoryStore, TestDirectoryStore,
                            TestDBMStoreNDBM, TestDBMStoreBerkeleyDB,
                            TestLMDBStore, TestSQLiteStore,
                            TestSQLiteStoreInMemory, TestLRUStoreCache,
-                           dimension_separator_fixture, s3,
                            skip_if_nested_chunks)
+
+# pytest will fail to run if the following fixtures aren't imported here
+from .test_storage import dimension_separator_fixture, s3  # noqa
 
 
 @pytest.fixture(params=[

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -17,13 +17,23 @@ from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
                           LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
 from zarr.tests.util import CountingDictV3, have_fsspec, skip_test_env_var
 
-from .test_storage import (StoreTests, TestMemoryStore, TestDirectoryStore,
-                           TestFSStore, TestNestedDirectoryStore, TestZipStore,
-                           TestDBMStore, TestDBMStoreDumb, TestDBMStoreGnu,
-                           TestDBMStoreNDBM, TestDBMStoreBerkeleyDB,
-                           TestLMDBStore, TestSQLiteStore,
-                           TestSQLiteStoreInMemory, TestLRUStoreCache,
-                           skip_if_nested_chunks)
+from .test_storage import (
+    StoreTests,
+    TestMemoryStore as _TestMemoryStore,
+    TestDirectoryStore as _TestDirectoryStore,
+    TestFSStore as _TestFSStore,
+    TestNestedDirectoryStore as _TestNestedDirectoryStore,
+    TestZipStore as _TestZipStore,
+    TestDBMStore as _TestDBMStore,
+    TestDBMStoreDumb as _TestDBMStoreDumb,
+    TestDBMStoreGnu as _TestDBMStoreGnu,
+    TestDBMStoreNDBM as _TestDBMStoreNDBM,
+    TestDBMStoreBerkeleyDB as _TestDBMStoreBerkeleyDB,
+    TestLMDBStore as _TestLMDBStore,
+    TestSQLiteStore as _TestSQLiteStore,
+    TestSQLiteStoreInMemory as _TestSQLiteStoreInMemory,
+    TestLRUStoreCache as _TestLRUStoreCache,
+    skip_if_nested_chunks)
 
 # pytest will fail to run if the following fixtures aren't imported here
 from .test_storage import dimension_separator_fixture, s3  # noqa
@@ -363,14 +373,14 @@ class TestMappingStoreV3(StoreV3Tests):
         pass
 
 
-class TestMemoryStoreV3(TestMemoryStore, StoreV3Tests):
+class TestMemoryStoreV3(_TestMemoryStore, StoreV3Tests):
 
     def create_store(self, **kwargs):
         skip_if_nested_chunks(**kwargs)
         return MemoryStoreV3(**kwargs)
 
 
-class TestDirectoryStoreV3(TestDirectoryStore, StoreV3Tests):
+class TestDirectoryStoreV3(_TestDirectoryStore, StoreV3Tests):
 
     def create_store(self, normalize_keys=False, **kwargs):
         # For v3, don't have to skip if nested.
@@ -383,7 +393,7 @@ class TestDirectoryStoreV3(TestDirectoryStore, StoreV3Tests):
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
-class TestFSStoreV3(TestFSStore, StoreV3Tests):
+class TestFSStoreV3(_TestFSStore, StoreV3Tests):
 
     def create_store(self, normalize_keys=False,
                      dimension_separator=".",
@@ -451,7 +461,7 @@ class TestFSStoreV3WithKeySeparator(StoreV3Tests):
 
 
 # TODO: remove NestedDirectoryStoreV3?
-class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
+class TestNestedDirectoryStoreV3(_TestNestedDirectoryStore,
                                  TestDirectoryStoreV3):
 
     def create_store(self, normalize_keys=False, **kwargs):
@@ -478,10 +488,10 @@ class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
 
 # TODO: enable once N5StoreV3 has been implemented
 # @pytest.mark.skipif(True, reason="N5StoreV3 not yet fully implemented")
-# class TestN5StoreV3(TestN5Store, TestNestedDirectoryStoreV3, StoreV3Tests):
+# class TestN5StoreV3(_TestN5Store, TestNestedDirectoryStoreV3, StoreV3Tests):
 
 
-class TestZipStoreV3(TestZipStore, StoreV3Tests):
+class TestZipStoreV3(_TestZipStore, StoreV3Tests):
 
     def create_store(self, **kwargs):
         path = tempfile.mktemp(suffix='.zip')
@@ -499,7 +509,7 @@ class TestZipStoreV3(TestZipStore, StoreV3Tests):
             store.clear()
 
 
-class TestDBMStoreV3(TestDBMStore, StoreV3Tests):
+class TestDBMStoreV3(_TestDBMStore, StoreV3Tests):
 
     def create_store(self, dimension_separator=None):
         path = tempfile.mktemp(suffix='.anydbm')
@@ -509,7 +519,7 @@ class TestDBMStoreV3(TestDBMStore, StoreV3Tests):
         return store
 
 
-class TestDBMStoreV3Dumb(TestDBMStoreDumb, StoreV3Tests):
+class TestDBMStoreV3Dumb(_TestDBMStoreDumb, StoreV3Tests):
 
     def create_store(self, **kwargs):
         path = tempfile.mktemp(suffix='.dumbdbm')
@@ -520,7 +530,7 @@ class TestDBMStoreV3Dumb(TestDBMStoreDumb, StoreV3Tests):
         return store
 
 
-class TestDBMStoreV3Gnu(TestDBMStoreGnu, StoreV3Tests):
+class TestDBMStoreV3Gnu(_TestDBMStoreGnu, StoreV3Tests):
 
     def create_store(self, **kwargs):
         gdbm = pytest.importorskip("dbm.gnu")
@@ -532,7 +542,7 @@ class TestDBMStoreV3Gnu(TestDBMStoreGnu, StoreV3Tests):
         return store  # pragma: no cover
 
 
-class TestDBMStoreV3NDBM(TestDBMStoreNDBM, StoreV3Tests):
+class TestDBMStoreV3NDBM(_TestDBMStoreNDBM, StoreV3Tests):
 
     def create_store(self, **kwargs):
         ndbm = pytest.importorskip("dbm.ndbm")
@@ -542,7 +552,7 @@ class TestDBMStoreV3NDBM(TestDBMStoreNDBM, StoreV3Tests):
         return store  # pragma: no cover
 
 
-class TestDBMStoreV3BerkeleyDB(TestDBMStoreBerkeleyDB, StoreV3Tests):
+class TestDBMStoreV3BerkeleyDB(_TestDBMStoreBerkeleyDB, StoreV3Tests):
 
     def create_store(self, **kwargs):
         bsddb3 = pytest.importorskip("bsddb3")
@@ -552,7 +562,7 @@ class TestDBMStoreV3BerkeleyDB(TestDBMStoreBerkeleyDB, StoreV3Tests):
         return store
 
 
-class TestLMDBStoreV3(TestLMDBStore, StoreV3Tests):
+class TestLMDBStoreV3(_TestLMDBStore, StoreV3Tests):
 
     def create_store(self, **kwargs):
         pytest.importorskip("lmdb")
@@ -563,7 +573,7 @@ class TestLMDBStoreV3(TestLMDBStore, StoreV3Tests):
         return store
 
 
-class TestSQLiteStoreV3(TestSQLiteStore, StoreV3Tests):
+class TestSQLiteStoreV3(_TestSQLiteStore, StoreV3Tests):
 
     def create_store(self, **kwargs):
         pytest.importorskip("sqlite3")
@@ -573,7 +583,7 @@ class TestSQLiteStoreV3(TestSQLiteStore, StoreV3Tests):
         return store
 
 
-class TestSQLiteStoreV3InMemory(TestSQLiteStoreInMemory, StoreV3Tests):
+class TestSQLiteStoreV3InMemory(_TestSQLiteStoreInMemory, StoreV3Tests):
 
     def create_store(self, **kwargs):
         pytest.importorskip("sqlite3")
@@ -606,7 +616,7 @@ class TestRedisStoreV3(StoreV3Tests):
         return store
 
 
-class TestLRUStoreCacheV3(TestLRUStoreCache, StoreV3Tests):
+class TestLRUStoreCacheV3(_TestLRUStoreCache, StoreV3Tests):
 
     def create_store(self, **kwargs):
         # wrapper therefore no dimension_separator argument
@@ -834,4 +844,4 @@ class TestLRUStoreCacheV3(TestLRUStoreCache, StoreV3Tests):
 
 # TODO: implement ABSStoreV3
 # @skip_test_env_var("ZARR_TEST_ABS")
-# class TestABSStoreV3(TestABSStore, StoreV3Tests):
+# class TestABSStoreV3(_TestABSStore, StoreV3Tests):

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -1,0 +1,847 @@
+import array
+import atexit
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from numcodecs.compat import ensure_bytes
+
+from zarr.codecs import Zlib
+from zarr.errors import ContainsArrayError, ContainsGroupError
+from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
+from zarr.storage import (array_meta_key, atexit_rmglob, atexit_rmtree,
+                          default_compressor, getsize, init_array, init_group)
+from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
+                          DirectoryStoreV3, NestedDirectoryStoreV3,
+                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
+                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
+from zarr.tests.util import CountingDictV3, have_fsspec, skip_test_env_var
+
+from .test_storage import (StoreTests, TestMemoryStore, TestDirectoryStore,
+                           TestFSStore, TestNestedDirectoryStore, TestZipStore,
+                           TestDBMStore, TestDBMStoreDumb, TestDBMStoreGnu,
+                           TestDBMStoreNDBM, TestDBMStoreBerkeleyDB,
+                           TestLMDBStore, TestSQLiteStore,
+                           TestSQLiteStoreInMemory, TestLRUStoreCache,
+                           dimension_separator_fixture, s3,
+                           skip_if_nested_chunks)
+
+
+@pytest.fixture(params=[
+    (None, "/"),
+    (".", "."),
+    ("/", "/"),
+])
+def dimension_separator_fixture_v3(request):
+    return request.param
+
+
+class StoreV3Tests(StoreTests):
+
+    def test_getsize(self):
+        # TODO: determine proper getsize() behavior for v3
+
+        # Currently returns the combined size of entries under
+        # meta/root/path and data/root/path.
+        # Any path not under meta/root/ or data/root/ (including zarr.json)
+        # returns size 0.
+
+        store = self.create_store()
+        if isinstance(store, dict) or hasattr(store, 'getsize'):
+            assert 0 == getsize(store, 'zarr.json')
+            store['meta/root/foo/a'] = b'x'
+            assert 1 == getsize(store)
+            assert 1 == getsize(store, 'foo')
+            store['meta/root/foo/b'] = b'x'
+            assert 2 == getsize(store, 'foo')
+            assert 1 == getsize(store, 'foo/b')
+            store['meta/root/bar/a'] = b'yy'
+            assert 2 == getsize(store, 'bar')
+            store['data/root/bar/a'] = b'zzz'
+            assert 5 == getsize(store, 'bar')
+            store['data/root/baz/a'] = b'zzz'
+            assert 3 == getsize(store, 'baz')
+            assert 10 == getsize(store)
+            store['data/root/quux'] = array.array('B', b'zzzz')
+            assert 14 == getsize(store)
+            assert 4 == getsize(store, 'quux')
+            store['data/root/spong'] = np.frombuffer(b'zzzzz', dtype='u1')
+            assert 19 == getsize(store)
+            assert 5 == getsize(store, 'spong')
+
+        store.close()
+
+    # noinspection PyStatementEffect
+    def test_hierarchy(self):
+        pytest.skip("TODO: adapt v2 test_hierarchy tests to v3")
+
+    def test_init_array(self, dimension_separator_fixture_v3):
+
+        pass_dim_sep, want_dim_sep = dimension_separator_fixture_v3
+
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100,
+                   dimension_separator=pass_dim_sep)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.array.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_array_metadata(store[mkey])
+        # TODO: zarr_format already stored at the heirarchy level should we
+        #       also keep it in the .array.json?
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
+        # Missing MUST be assumed to be "/"
+        assert meta.get('dimension_separator', "/") is want_dim_sep
+        assert meta['chunk_grid']['separator'] is want_dim_sep
+        store.close()
+
+    def _test_init_array_overwrite(self, order):
+        # setup
+        store = self.create_store()
+
+        if store._store_version < 3:
+            path = None
+            mkey = array_meta_key
+        else:
+            path = 'arr1'  # no default, have to specify for v3
+            mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(
+            dict(shape=(2000,),
+                 chunk_grid=dict(type='regular',
+                                 chunk_shape=(200,),
+                                 separator=('/')),
+                 data_type=np.dtype('u1'),
+                 compressor=Zlib(1).get_config(),
+                 fill_value=0,
+                 chunk_memory_layout=order,
+                 filters=None)
+        )
+
+        # don't overwrite (default)
+        with pytest.raises(ContainsArrayError):
+            init_array(store, path=path, shape=1000, chunks=100)
+
+        # do overwrite
+        try:
+            init_array(store, path=path, shape=1000, chunks=100,
+                       dtype='i4', overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            meta = store._metadata_class.decode_array_metadata(
+                store[mkey]
+            )
+            assert (1000,) == meta['shape']
+            if store._store_version == 2:
+                assert ZARR_FORMAT == meta['zarr_format']
+                assert (100,) == meta['chunks']
+                assert np.dtype('i4') == meta['dtype']
+            elif store._store_version == 3:
+                assert ZARR_FORMAT_v3 == meta['zarr_format']
+                assert (100,) == meta['chunk_grid']['chunk_shape']
+                assert np.dtype('i4') == meta['data_type']
+            else:
+                raise ValueError(
+                    "unexpected store version: {store._store_version}"
+                )
+        store.close()
+
+    def test_init_array_path(self):
+        path = 'foo/bar'
+        store = self.create_store()
+        init_array(store, shape=1000, chunks=100, path=path)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.array.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_array_metadata(store[mkey])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
+
+        store.close()
+
+    def _test_init_array_overwrite_path(self, order):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        meta = dict(shape=(2000,),
+                    chunk_grid=dict(type='regular',
+                                    chunk_shape=(200,),
+                                    separator=('/')),
+                    data_type=np.dtype('u1'),
+                    compressor=Zlib(1).get_config(),
+                    fill_value=0,
+                    chunk_memory_layout=order,
+                    filters=None)
+        mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(meta)
+
+        # don't overwrite
+        with pytest.raises(ContainsArrayError):
+            init_array(store, shape=1000, chunks=100, path=path)
+
+        # do overwrite
+        try:
+            init_array(store, shape=1000, chunks=100, dtype='i4', path=path,
+                       overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            # should have been overwritten
+            meta = store._metadata_class.decode_array_metadata(store[mkey])
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+
+        store.close()
+
+    def test_init_array_overwrite_group(self):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        array_key = 'meta/root/' + path + '.array.json'
+        group_key = 'meta/root/' + path + '.group.json'
+        store[group_key] = store._metadata_class.encode_group_metadata()
+
+        with pytest.raises(ContainsGroupError):
+            init_array(store, shape=1000, chunks=100, path=path)
+
+        # do overwrite
+        try:
+            init_array(store, shape=1000, chunks=100, dtype='i4', path=path,
+                       overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert group_key not in store
+            assert array_key in store
+            meta = store._metadata_class.decode_array_metadata(
+                store[array_key]
+            )
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+
+        store.close()
+
+    def _test_init_array_overwrite_chunk_store(self, order):
+        # setup
+        store = self.create_store()
+        chunk_store = self.create_store()
+        path = 'arr1'
+        mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(
+            dict(shape=(2000,),
+                 chunk_grid=dict(type='regular',
+                                 chunk_shape=(200,),
+                                 separator=('/')),
+                 data_type=np.dtype('u1'),
+                 compressor=None,
+                 fill_value=0,
+                 filters=None,
+                 chunk_memory_layout=order)
+        )
+
+        chunk_store['data/root/arr1/0'] = b'aaa'
+        chunk_store['data/root/arr1/1'] = b'bbb'
+
+        assert 'data/root/arr1/0' in chunk_store
+        assert 'data/root/arr1/1' in chunk_store
+
+        # don't overwrite (default)
+        with pytest.raises(ValueError):
+            init_array(store, path=path, shape=1000, chunks=100, chunk_store=chunk_store)
+
+        # do overwrite
+        try:
+            init_array(store, path=path, shape=1000, chunks=100, dtype='i4',
+                       overwrite=True, chunk_store=chunk_store)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            meta = store._metadata_class.decode_array_metadata(store[mkey])
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+            assert 'data/root/arr1/0' not in chunk_store
+            assert 'data/root/arr1/1' not in chunk_store
+
+        store.close()
+        chunk_store.close()
+
+    def test_init_array_compat(self):
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100, compressor='none')
+        mkey = 'meta/root/' + path + '.array.json'
+        meta = store._metadata_class.decode_array_metadata(
+            store[mkey]
+        )
+        assert meta['compressor'] is None
+
+        store.close()
+
+    def test_init_group(self):
+        store = self.create_store()
+        path = "meta/root/foo"
+        init_group(store, path=path)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.group.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_group_metadata(store[mkey])
+        assert meta == {'attributes': {}}
+
+        store.close()
+
+    def _test_init_group_overwrite(self, order):
+        pytest.skip(
+            "In v3 array and group names cannot overlap"
+        )
+
+    def _test_init_group_overwrite_path(self, order):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        meta = dict(
+            shape=(2000,),
+            chunk_grid=dict(type='regular',
+                            chunk_shape=(200,),
+                            separator=('/')),
+            data_type=np.dtype('u1'),
+            compressor=None,
+            fill_value=0,
+            filters=None,
+            chunk_memory_layout=order,
+        )
+        array_key = 'meta/root/' + path + '.array.json'
+        group_key = 'meta/root/' + path + '.group.json'
+        store[array_key] = store._metadata_class.encode_array_metadata(meta)
+
+        # don't overwrite
+        with pytest.raises(ContainsArrayError):
+            init_group(store, path=path)
+
+        # do overwrite
+        try:
+            init_group(store, overwrite=True, path=path)
+        except NotImplementedError:
+            pass
+        else:
+            assert array_key not in store
+            assert group_key in store
+            # should have been overwritten
+            meta = store._metadata_class.decode_group_metadata(store[group_key])
+            # assert ZARR_FORMAT == meta['zarr_format']
+            assert meta == {'attributes': {}}
+
+        store.close()
+
+    def _test_init_group_overwrite_chunk_store(self, order):
+        pytest.skip(
+            "In v3 array and group names cannot overlap"
+        )
+
+
+class TestMappingStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        return KVStoreV3(dict())
+
+    def test_set_invalid_content(self):
+        # Generic mappings support non-buffer types
+        pass
+
+
+class TestMemoryStoreV3(TestMemoryStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+        return MemoryStoreV3(**kwargs)
+
+
+class TestDirectoryStoreV3(TestDirectoryStore, StoreV3Tests):
+
+    def create_store(self, normalize_keys=False, **kwargs):
+        # For v3, don't have to skip if nested.
+        # skip_if_nested_chunks(**kwargs)
+
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = DirectoryStoreV3(path, normalize_keys=normalize_keys, **kwargs)
+        return store
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestFSStoreV3(TestFSStore, StoreV3Tests):
+
+    def create_store(self, normalize_keys=False,
+                     dimension_separator=".",
+                     path=None,
+                     **kwargs):
+
+        if path is None:
+            path = tempfile.mkdtemp()
+            atexit.register(atexit_rmtree, path)
+
+        store = FSStoreV3(
+            path,
+            normalize_keys=normalize_keys,
+            dimension_separator=dimension_separator,
+            **kwargs)
+        return store
+
+    def test_init_array(self):
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100)
+
+        # check metadata
+        array_meta_key = 'meta/root/' + path + '.array.json'
+        assert array_meta_key in store
+        meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert meta['chunk_grid']['separator'] == "/"
+
+    # TODO: remove this skip once v3 support is added to hierarchy.Group
+    @pytest.mark.skipif(True, reason="need v3 support in zarr.hierarchy.Group")
+    def test_deep_ndim(self):
+        import zarr
+
+        store = self.create_store()
+        foo = zarr.open_group(store=store, path='group1')
+        bar = foo.create_group("bar")
+        baz = bar.create_dataset("baz",
+                                 shape=(4, 4, 4),
+                                 chunks=(2, 2, 2),
+                                 dtype="i8")
+        baz[:] = 1
+        assert set(store.listdir()) == set(["data", "meta", "zarr.json"])
+        assert set(store.listdir("meta/root/group1")) == set(["bar", "bar.group.json"])
+        assert set(store.listdir("data/root/group1")) == set(["bar"])
+        assert foo["bar"]["baz"][(0, 0, 0)] == 1
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestFSStoreV3WithKeySeparator(StoreV3Tests):
+
+    def create_store(self, normalize_keys=False, key_separator=".", **kwargs):
+
+        # Since the user is passing key_separator, that will take priority.
+        skip_if_nested_chunks(**kwargs)
+
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        return FSStoreV3(
+            path,
+            normalize_keys=normalize_keys,
+            key_separator=key_separator)
+
+
+# TODO: remove NestedDirectoryStoreV3?
+class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
+                                 TestDirectoryStoreV3):
+
+    def create_store(self, normalize_keys=False, **kwargs):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = NestedDirectoryStoreV3(path, normalize_keys=normalize_keys, **kwargs)
+        return store
+
+    def test_init_array(self):
+        store = self.create_store()
+        # assert store._dimension_separator == "/"
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100)
+
+        # check metadata
+        array_meta_key = 'meta/root/' + path + '.array.json'
+        assert array_meta_key in store
+        meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        # assert meta['dimension_separator'] == "/"
+        assert meta['chunk_grid']['separator'] == "/"
+
+# TODO: enable once N5StoreV3 has been implemented
+# @pytest.mark.skipif(True, reason="N5StoreV3 not yet fully implemented")
+# class TestN5StoreV3(TestN5Store, TestNestedDirectoryStoreV3, StoreV3Tests):
+
+
+class TestZipStoreV3(TestZipStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        path = tempfile.mktemp(suffix='.zip')
+        atexit.register(os.remove, path)
+        store = ZipStoreV3(path, mode='w', **kwargs)
+        return store
+
+    def test_mode(self):
+        with ZipStoreV3('data/store.zip', mode='w') as store:
+            store['foo'] = b'bar'
+        store = ZipStoreV3('data/store.zip', mode='r')
+        with pytest.raises(PermissionError):
+            store['foo'] = b'bar'
+        with pytest.raises(PermissionError):
+            store.clear()
+
+
+class TestDBMStoreV3(TestDBMStore, StoreV3Tests):
+
+    def create_store(self, dimension_separator=None):
+        path = tempfile.mktemp(suffix='.anydbm')
+        atexit.register(atexit_rmglob, path + '*')
+        # create store using default dbm implementation
+        store = DBMStoreV3(path, flag='n', dimension_separator=dimension_separator)
+        return store
+
+
+class TestDBMStoreV3Dumb(TestDBMStoreDumb, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        path = tempfile.mktemp(suffix='.dumbdbm')
+        atexit.register(atexit_rmglob, path + '*')
+
+        import dbm.dumb as dumbdbm
+        store = DBMStoreV3(path, flag='n', open=dumbdbm.open, **kwargs)
+        return store
+
+
+class TestDBMStoreV3Gnu(TestDBMStoreGnu, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        gdbm = pytest.importorskip("dbm.gnu")
+        path = tempfile.mktemp(suffix=".gdbm")  # pragma: no cover
+        atexit.register(os.remove, path)  # pragma: no cover
+        store = DBMStoreV3(
+            path, flag="n", open=gdbm.open, write_lock=False, **kwargs
+        )  # pragma: no cover
+        return store  # pragma: no cover
+
+
+class TestDBMStoreV3NDBM(TestDBMStoreNDBM, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        ndbm = pytest.importorskip("dbm.ndbm")
+        path = tempfile.mktemp(suffix=".ndbm")  # pragma: no cover
+        atexit.register(atexit_rmglob, path + "*")  # pragma: no cover
+        store = DBMStoreV3(path, flag="n", open=ndbm.open, **kwargs)  # pragma: no cover
+        return store  # pragma: no cover
+
+
+class TestDBMStoreV3BerkeleyDB(TestDBMStoreBerkeleyDB, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        bsddb3 = pytest.importorskip("bsddb3")
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStoreV3(path, flag='n', open=bsddb3.btopen, write_lock=False, **kwargs)
+        return store
+
+
+class TestLMDBStoreV3(TestLMDBStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("lmdb")
+        path = tempfile.mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        buffers = True
+        store = LMDBStoreV3(path, buffers=buffers, **kwargs)
+        return store
+
+
+class TestSQLiteStoreV3(TestSQLiteStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("sqlite3")
+        path = tempfile.mktemp(suffix='.db')
+        atexit.register(atexit_rmtree, path)
+        store = SQLiteStoreV3(path, **kwargs)
+        return store
+
+
+class TestSQLiteStoreV3InMemory(TestSQLiteStoreInMemory, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("sqlite3")
+        store = SQLiteStoreV3(':memory:', **kwargs)
+        return store
+
+
+@skip_test_env_var("ZARR_TEST_MONGO")
+class TestMongoDBStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("pymongo")
+        store = MongoDBStoreV3(host='127.0.0.1', database='zarr_tests',
+                               collection='zarr_tests', **kwargs)
+        # start with an empty store
+        store.clear()
+        return store
+
+
+@skip_test_env_var("ZARR_TEST_REDIS")
+class TestRedisStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        # TODO: this is the default host for Redis on Travis,
+        # we probably want to generalize this though
+        pytest.importorskip("redis")
+        store = RedisStoreV3(host='localhost', port=6379, **kwargs)
+        # start with an empty store
+        store.clear()
+        return store
+
+
+class TestLRUStoreCacheV3(TestLRUStoreCache, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        # wrapper therefore no dimension_separator argument
+        skip_if_nested_chunks(**kwargs)
+        return LRUStoreCacheV3(dict(), max_size=2**27)
+
+    def test_cache_values_no_max_size(self):
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        assert 1 == store.counter['__setitem__', 'bar']
+
+        # setup cache
+        cache = LRUStoreCacheV3(store, max_size=None)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test __setitem__, __getitem__
+        cache['foo'] = b'zzz'
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        # should be a cache hit
+        assert b'zzz' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        assert 2 == cache.hits
+        assert 1 == cache.misses
+
+        # manually invalidate all cached values
+        cache.invalidate_values()
+        assert b'zzz' == cache['foo']
+        assert 2 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        cache.invalidate()
+        assert b'zzz' == cache['foo']
+        assert 3 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+
+        # test __delitem__
+        del cache['foo']
+        with pytest.raises(KeyError):
+            # noinspection PyStatementEffect
+            cache['foo']
+        with pytest.raises(KeyError):
+            # noinspection PyStatementEffect
+            store['foo']
+
+        # verify other keys untouched
+        assert 0 == store.counter['__getitem__', 'bar']
+        assert 1 == store.counter['__setitem__', 'bar']
+
+    def test_cache_values_with_max_size(self):
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        # setup cache - can only hold one item
+        cache = LRUStoreCacheV3(store, max_size=5)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first 'foo' __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second 'foo' __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test first 'bar' __getitem__, cache miss
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 1 == cache.hits
+        assert 2 == cache.misses
+
+        # test second 'bar' __getitem__, cache hit
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'foo' __getitem__, should have been evicted, cache miss
+        assert b'xxx' == cache['foo']
+        assert 2 == store.counter['__getitem__', 'foo']
+        assert 2 == cache.hits
+        assert 3 == cache.misses
+
+        # test 'bar' __getitem__, should have been evicted, cache miss
+        assert b'yyy' == cache['bar']
+        assert 2 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 4 == cache.misses
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        # setup cache - can hold two items
+        cache = LRUStoreCacheV3(store, max_size=6)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first 'foo' __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second 'foo' __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test first 'bar' __getitem__, cache miss
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 1 == cache.hits
+        assert 2 == cache.misses
+
+        # test second 'bar' __getitem__, cache hit
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'foo' __getitem__, should still be cached
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 3 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'bar' __getitem__, should still be cached
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 4 == cache.hits
+        assert 2 == cache.misses
+
+    def test_cache_keys(self):
+
+        # setup
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        assert 0 == store.counter['keys']
+        cache = LRUStoreCacheV3(store, max_size=None)
+
+        # keys should be cached on first call
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'foo']
+        assert 1 == store.counter['keys']
+        # keys should now be cached
+        assert keys == sorted(cache.keys())
+        assert 1 == store.counter['keys']
+        assert 'foo' in cache
+        assert 0 == store.counter['__contains__', 'foo']
+        assert keys == sorted(cache)
+        assert 0 == store.counter['__iter__']
+        assert 1 == store.counter['keys']
+
+        # cache should be cleared if store is modified - crude but simple for now
+        cache['baz'] = b'zzz'
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'baz', 'foo']
+        assert 2 == store.counter['keys']
+        # keys should now be cached
+        assert keys == sorted(cache.keys())
+        assert 2 == store.counter['keys']
+
+        # manually invalidate keys
+        cache.invalidate_keys()
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'baz', 'foo']
+        assert 3 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        cache.invalidate_keys()
+        keys = sorted(cache)
+        assert keys == ['bar', 'baz', 'foo']
+        assert 4 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        cache.invalidate_keys()
+        assert 'foo' in cache
+        assert 5 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+
+        # check these would get counted if called directly
+        assert 'foo' in store
+        assert 1 == store.counter['__contains__', 'foo']
+        assert keys == sorted(store)
+        assert 1 == store.counter['__iter__']
+
+
+# TODO: implement ABSStoreV3
+# @skip_test_env_var("ZARR_TEST_ABS")
+# class TestABSStoreV3(TestABSStore, StoreV3Tests):

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -98,7 +98,6 @@ class StoreV3Tests(StoreTests):
         assert default_compressor == meta['compressor']
         assert meta['fill_value'] is None
         # Missing MUST be assumed to be "/"
-        assert meta.get('dimension_separator', "/") is want_dim_sep
         assert meta['chunk_grid']['separator'] is want_dim_sep
         store.close()
 

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -8,7 +8,7 @@ import pytest
 
 from zarr.codecs import Zlib
 from zarr.errors import ContainsArrayError, ContainsGroupError
-from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
+from zarr.meta import ZARR_FORMAT
 from zarr.storage import (array_meta_key, atexit_rmglob, atexit_rmtree,
                           default_compressor, getsize, init_array, init_group)
 from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
@@ -92,7 +92,6 @@ class StoreV3Tests(StoreTests):
         meta = store._metadata_class.decode_array_metadata(store[mkey])
         # TODO: zarr_format already stored at the heirarchy level should we
         #       also keep it in the .array.json?
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -146,7 +145,6 @@ class StoreV3Tests(StoreTests):
                 assert (100,) == meta['chunks']
                 assert np.dtype('i4') == meta['dtype']
             elif store._store_version == 3:
-                assert ZARR_FORMAT_v3 == meta['zarr_format']
                 assert (100,) == meta['chunk_grid']['chunk_shape']
                 assert np.dtype('i4') == meta['data_type']
             else:
@@ -164,7 +162,6 @@ class StoreV3Tests(StoreTests):
         mkey = 'meta/root/' + path + '.array.json'
         assert mkey in store
         meta = store._metadata_class.decode_array_metadata(store[mkey])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -203,7 +200,6 @@ class StoreV3Tests(StoreTests):
             assert mkey in store
             # should have been overwritten
             meta = store._metadata_class.decode_array_metadata(store[mkey])
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -233,7 +229,6 @@ class StoreV3Tests(StoreTests):
             meta = store._metadata_class.decode_array_metadata(
                 store[array_key]
             )
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -277,7 +272,6 @@ class StoreV3Tests(StoreTests):
         else:
             assert mkey in store
             meta = store._metadata_class.decode_array_metadata(store[mkey])
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -295,7 +289,7 @@ class StoreV3Tests(StoreTests):
         meta = store._metadata_class.decode_array_metadata(
             store[mkey]
         )
-        assert meta['compressor'] is None
+        assert 'compressor' not in meta
 
         store.close()
 
@@ -350,7 +344,6 @@ class StoreV3Tests(StoreTests):
             assert group_key in store
             # should have been overwritten
             meta = store._metadata_class.decode_group_metadata(store[group_key])
-            # assert ZARR_FORMAT == meta['zarr_format']
             assert meta == {'attributes': {}}
 
         store.close()
@@ -418,7 +411,6 @@ class TestFSStoreV3(TestFSStore, StoreV3Tests):
         array_meta_key = 'meta/root/' + path + '.array.json'
         assert array_meta_key in store
         meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -479,7 +471,6 @@ class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
         array_meta_key = 'meta/root/' + path + '.array.json'
         assert array_meta_key in store
         meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,7 +1,7 @@
 import collections
 import os
 
-from zarr.storage import Store
+from zarr.storage import Store, StoreV3
 
 import pytest
 
@@ -39,6 +39,10 @@ class CountingDict(Store):
     def __delitem__(self, key):
         self.counter['__delitem__', key] += 1
         del self.wrapped[key]
+
+
+class CountingDictV3(CountingDict, StoreV3):
+    pass
 
 
 def skip_test_env_var(name):


### PR DESCRIPTION
This PR contains changes to `storage.py` and `meta.py` for v3 support. I split this out from the full v3 branch and will have follow up PRs adding v3 support to the `Array` and `Group` classes as well as the higher level routines.

This PR defines StoreV3 versions of most existing Store types (no N5Store or ABSStore, currently). This will need some rounds of revision/feedback and there are a number of "TODO" comments in code where I was unsure about desired behavior of some aspect.

For the test cases, I tried to avoid a lot of the duplication by subclassing the v2 test classes, just overriding methods where it was necessary to make changes. These v3 classes are currently in a separate file, but could instead just be appended to the existing file if that is preferred. Another possible approach is to try keeping just the existing classes, but add parameterization based on the Zarr version.

For test coverage, there are a handful of functions like `rmdir` that support `StoreLike` inputs that only have test coverage via higher-level functions which are not yet included in this PR, so there will currently be some reduction in test coverage unless that code is removed or we add test cases.


[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
