### PR TITLE
Sharding Prototype I: implementation as translating Store

### DIFF
--- a/chunking_test.py
+++ b/chunking_test.py
@@ -44,7 +44,7 @@ print("CHUNKSTORE (SHARDED)", sorted(z.chunk_store))
 # CHUNKSTORE (SHARDED) ['.zarray', '0.0', '0.1', '1.0', '1.1', '2.0', '2.1', '3.0', '3.1', '5.0', '6.1']
 
 index_bytes = z.store["0.0"][-2*2*16:]
-print("INDEX 0.0", [int.from_bytes(index_bytes[i:i+8], byteorder="big") for i in range(0, len(index_bytes), 8)])
+print("INDEX 0.0", [int.from_bytes(index_bytes[i:i+8], byteorder="little") for i in range(0, len(index_bytes), 8)])
 # INDEX 0.0 [0, 48, 48, 48, 96, 48, 144, 48]
 
 z_reopened = zarr.open("data/chunking_test.zarr")

--- a/chunking_test.py
+++ b/chunking_test.py
@@ -11,11 +11,37 @@ z[19, 2] = 1
 z[0, 1] = -4.2
 
 print(store[".zarray"].decode())
-print("ONDISK", sorted(os.listdir("data/chunking_test.zarr")))
+# {
+#     "chunks": [
+#         3,
+#         2
+#     ],
+#     "compressor": null,
+#     "dtype": "<f8",
+#     "fill_value": 0.0,
+#     "filters": null,
+#     "order": "C",
+#     "shape": [
+#         20,
+#         3
+#     ],
+#     "shard_format": "morton_order",
+#     "shards": [
+#         2,
+#         2
+#     ],
+#     "zarr_format": 2
+# }
+
 assert json.loads(store[".zarray"].decode()) ["shards"] == [2, 2]
 
+print("ONDISK", sorted(os.listdir("data/chunking_test.zarr")))
 print("STORE", sorted(store))
 print("CHUNKSTORE (SHARDED)", sorted(z.chunk_store))
+
+# ONDISK ['.zarray', '0.0', '1.0', '2.0', '3.0']
+# STORE ['.zarray', '0.0', '1.0', '2.0', '3.0']
+# CHUNKSTORE (SHARDED) ['.zarray', '0.0', '0.1', '1.0', '1.1', '2.0', '2.1', '3.0', '3.1', '5.0', '6.1']
 
 z_reopened = zarr.open("data/chunking_test.zarr")
 assert z_reopened.shards == (2, 2)

--- a/chunking_test.py
+++ b/chunking_test.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+import zarr
+
+store = zarr.DirectoryStore("data/chunking_test.zarr")
+z = zarr.zeros((20, 3), chunks=(3, 3), shards=(2, 2), store=store, overwrite=True, compressor=None)
+z[...] = 42
+z[15, 1] = 389
+z[19, 2] = 1
+z[0, 1] = -4.2
+
+print("ONDISK", sorted(os.listdir("data/chunking_test.zarr")))
+assert json.loads(store[".zarray"].decode()) ["shards"] == [2, 2]
+
+print("STORE", list(store))
+print("CHUNKSTORE (SHARDED)", list(z.chunk_store))
+
+z_reopened = zarr.open("data/chunking_test.zarr")
+assert z_reopened.shards == (2, 2)
+assert z_reopened[15, 1] == 389
+assert z_reopened[19, 2] == 1
+assert z_reopened[0, 1] == -4.2
+assert z_reopened[0, 0] == 42

--- a/chunking_test.py
+++ b/chunking_test.py
@@ -25,7 +25,7 @@ print(store[".zarray"].decode())
 #         20,
 #         3
 #     ],
-#     "shard_format": "morton_order",
+#     "shard_format": "indexed",
 #     "shards": [
 #         2,
 #         2
@@ -42,6 +42,10 @@ print("CHUNKSTORE (SHARDED)", sorted(z.chunk_store))
 # ONDISK ['.zarray', '0.0', '1.0', '2.0', '3.0']
 # STORE ['.zarray', '0.0', '1.0', '2.0', '3.0']
 # CHUNKSTORE (SHARDED) ['.zarray', '0.0', '0.1', '1.0', '1.1', '2.0', '2.1', '3.0', '3.1', '5.0', '6.1']
+
+index_bytes = z.store["0.0"][-2*2*16:]
+print("INDEX 0.0", [int.from_bytes(index_bytes[i:i+8], byteorder="big") for i in range(0, len(index_bytes), 8)])
+# INDEX 0.0 [0, 48, 48, 48, 96, 48, 144, 48]
 
 z_reopened = zarr.open("data/chunking_test.zarr")
 assert z_reopened.shards == (2, 2)

--- a/chunking_test.py
+++ b/chunking_test.py
@@ -4,17 +4,18 @@ import os
 import zarr
 
 store = zarr.DirectoryStore("data/chunking_test.zarr")
-z = zarr.zeros((20, 3), chunks=(3, 3), shards=(2, 2), store=store, overwrite=True, compressor=None)
-z[...] = 42
+z = zarr.zeros((20, 3), chunks=(3, 2), shards=(2, 2), store=store, overwrite=True, compressor=None)
+z[:10, :] = 42
 z[15, 1] = 389
 z[19, 2] = 1
 z[0, 1] = -4.2
 
+print(store[".zarray"].decode())
 print("ONDISK", sorted(os.listdir("data/chunking_test.zarr")))
 assert json.loads(store[".zarray"].decode()) ["shards"] == [2, 2]
 
-print("STORE", list(store))
-print("CHUNKSTORE (SHARDED)", list(z.chunk_store))
+print("STORE", sorted(store))
+print("CHUNKSTORE (SHARDED)", sorted(z.chunk_store))
 
 z_reopened = zarr.open("data/chunking_test.zarr")
 assert z_reopened.shards == (2, 2)

--- a/zarr/_storage/sharded_store.py
+++ b/zarr/_storage/sharded_store.py
@@ -1,0 +1,102 @@
+from functools import reduce
+from itertools import product
+from typing import Any, Iterable, Iterator, Optional, Tuple
+
+from zarr._storage.store import BaseStore, Store
+from zarr.storage import StoreLike, array_meta_key, attrs_key, group_meta_key
+
+
+def _cum_prod(x: Iterable[int]) -> Iterable[int]:
+    prod = 1
+    yield prod
+    for i in x[:-1]:
+        prod *= i
+        yield prod
+
+
+class ShardedStore(Store):
+    """This class should not be used directly,
+    but is added to an Array as a wrapper when needed automatically."""
+
+    def __init__(
+        self, store:
+        StoreLike,
+        shards: Tuple[int, ...],
+        dimension_separator: str,
+        chunk_has_constant_size: bool,
+        fill_value: bytes,
+        value_len: Optional[int],
+    ) -> None:
+        self._store: BaseStore = BaseStore._ensure_store(store)
+        self._shards = shards
+        # This defines C/F-order
+        self._shards_cumprod = tuple(_cum_prod(shards))
+        self._num_chunks_per_shard = reduce(lambda x, y: x*y, shards, 1)
+        self._dimension_separator = dimension_separator
+        # TODO: add jumptable for compressed data
+        assert not chunk_has_constant_size, "Currently only uncompressed data can be used."
+        self._chunk_has_constant_size = chunk_has_constant_size
+        if not chunk_has_constant_size:
+            assert value_len is not None
+            self._fill_chunk = fill_value * value_len
+        else:
+            self._fill_chunk = None
+
+        # TODO: add warnings for ineffective reads/writes:
+        # * warn if partial reads are not available
+        # * optionally warn on unaligned writes if no partial writes are available
+  
+    def __key_to_sharded__(self, key: str) -> Tuple[str, int]:
+        # TODO: allow to be in a group (aka only use last parts for dimensions)
+        subkeys = map(int, key.split(self._dimension_separator))
+
+        shard_tuple, index_tuple = zip(*((subkey // shard_i, subkey % shard_i) for subkey, shard_i in zip(subkeys, self._shards)))
+        shard_key = self._dimension_separator.join(map(str, shard_tuple))
+        index = sum(i * j for i, j in zip(index_tuple, self._shards_cumprod))
+        return shard_key, index
+
+    def __get_chunk_slice__(self, shard_key: str, shard_index: int) -> Tuple[int, int]:
+        # TODO: here we would use the jumptable for compression
+        start = shard_index * len(self._fill_chunk)
+        return slice(start, start + len(self._fill_chunk))
+
+    def __getitem__(self, key: str) -> bytes:
+        shard_key, shard_index = self.__key_to_sharded__(key)
+        chunk_slice = self.__get_chunk_slice__(shard_key, shard_index)
+        # TODO use partial reads if available
+        full_shard_value = self._store[shard_key]
+        return full_shard_value[chunk_slice]
+
+    def __setitem__(self, key: str, value: bytes) -> None:
+        shard_key, shard_index = self.__key_to_sharded__(key)
+        if shard_key in self._store:
+            full_shard_value = bytearray(self._store[shard_key])
+        else:
+            full_shard_value = bytearray(self._fill_chunk * self._num_chunks_per_shard)
+        chunk_slice = self.__get_chunk_slice__(shard_key, shard_index)
+        # TODO use partial writes if available
+        full_shard_value[chunk_slice] = value
+        self._store[shard_key] = full_shard_value
+
+    def __delitem__(self, key) -> None:
+        # TODO not implemented yet
+        # For uncompressed chunks, deleting the "last" chunk might need to be detected.
+        raise NotImplementedError("Deletion is not yet implemented")
+
+    def __iter__(self) -> Iterator[str]:
+        for shard_key in self._store.__iter__():
+            if any(shard_key.endswith(i) for i in (array_meta_key, group_meta_key, attrs_key)):
+                yield shard_key
+            else:
+                # TODO: allow to be in a group (aka only use last parts for dimensions)
+                subkeys = tuple(map(int, shard_key.split(self._dimension_separator)))
+                for offset in product(*(range(i) for i in self._shards)):
+                    original_key = (subkeys_i * shards_i + offset_i for subkeys_i, offset_i, shards_i in zip(subkeys, offset, self._shards))
+                    yield self._dimension_separator.join(map(str, original_key))
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self.keys())
+
+    # TODO: For efficient reads and writes, we need to implement
+    # getitems, setitems & delitems
+    # and combine writes/reads/deletions to the same shard.

--- a/zarr/_storage/sharded_store.py
+++ b/zarr/_storage/sharded_store.py
@@ -1,6 +1,7 @@
+from collections import defaultdict
 from functools import reduce
-from itertools import product
-from typing import Any, Iterable, Iterator, Optional, Tuple
+import math
+from typing import Any, Dict, Iterable, Iterator, List, Tuple, Union
 
 import numpy as np
 
@@ -16,7 +17,7 @@ def _cum_prod(x: Iterable[int]) -> Iterable[int]:
         yield prod
 
 
-class ShardedStore(Store):
+class MortonOrderShardedStore(Store):
     """This class should not be used directly,
     but is added to an Array as a wrapper when needed automatically."""
 
@@ -32,59 +33,97 @@ class ShardedStore(Store):
     ) -> None:
         self._store: BaseStore = BaseStore._ensure_store(store)
         self._shards = shards
-        # This defines C/F-order
-        self._shard_strides = tuple(_cum_prod(shards))
         self._num_chunks_per_shard = reduce(lambda x, y: x*y, shards, 1)
         self._dimension_separator = dimension_separator
-        # TODO: add jumptable for compressed data
+
         chunk_has_constant_size = not are_chunks_compressed and not dtype == object
         assert chunk_has_constant_size, "Currently only uncompressed, fixed-length data can be used."
         self._chunk_has_constant_size = chunk_has_constant_size
         if chunk_has_constant_size:
             binary_fill_value = np.full(1, fill_value=fill_value or 0, dtype=dtype).tobytes()
             self._fill_chunk = binary_fill_value * chunk_size
-        else:
-            self._fill_chunk = None
+            self._emtpy_meta = b"\x00" * math.ceil(self._num_chunks_per_shard / 8)
+
+        # unused when using Morton order
+        self._shard_strides = tuple(_cum_prod(shards))
 
         # TODO: add warnings for ineffective reads/writes:
         # * warn if partial reads are not available
         # * optionally warn on unaligned writes if no partial writes are available
-  
-    def __key_to_sharded__(self, key: str) -> Tuple[str, int]:
-        # TODO: allow to be in a group (aka only use last parts for dimensions)
-        subkeys = map(int, key.split(self._dimension_separator))
 
-        shard_tuple, index_tuple = zip(*((subkey // shard_i, subkey % shard_i) for subkey, shard_i in zip(subkeys, self._shards)))
+    def __get_meta__(self, shard_content: Union[bytes, bytearray]) -> int:
+        return int.from_bytes(shard_content[-len(self._emtpy_meta):], byteorder="big")
+
+    def __set_meta__(self, shard_content: bytearray, meta: int) -> None:
+        shard_content[-len(self._emtpy_meta):] = meta.to_bytes(len(self._emtpy_meta), byteorder="big")
+
+    # The following two methods define the order of the chunks in a shard
+    # TODO use morton order
+    def __chunk_key_to_shard_key_and_index__(self, chunk_key: str) -> Tuple[str, int]:
+        # TODO: allow to be in a group (aka only use last parts for dimensions)
+        chunk_subkeys = map(int, chunk_key.split(self._dimension_separator))
+
+        shard_tuple, index_tuple = zip(*((subkey // shard_i, subkey % shard_i) for subkey, shard_i in zip(chunk_subkeys, self._shards)))
         shard_key = self._dimension_separator.join(map(str, shard_tuple))
         index = sum(i * j for i, j in zip(index_tuple, self._shard_strides))
         return shard_key, index
 
-    def __get_chunk_slice__(self, shard_key: str, shard_index: int) -> Tuple[int, int]:
-        # TODO: here we would use the jumptable for compression, which uses shard_key
+    def __shard_key_and_index_to_chunk_key__(self, shard_key_tuple: Tuple[int, ...], shard_index: int) -> str:
+        offset = tuple(shard_index % s2 // s1 for s1, s2 in zip(self._shard_strides, self._shard_strides[1:] + (self._num_chunks_per_shard,)))
+        original_key = (shard_key_i * shards_i + offset_i for shard_key_i, offset_i, shards_i in zip(shard_key_tuple, offset, self._shards))
+        return self._dimension_separator.join(map(str, original_key))
+
+    def __keys_to_shard_groups__(self, keys: Iterable[str]) -> Dict[str, List[Tuple[str, str]]]:
+        shard_indices_per_shard_key = defaultdict(list)
+        for chunk_key in keys:
+            shard_key, shard_index = self.__chunk_key_to_shard_key_and_index__(chunk_key)
+            shard_indices_per_shard_key[shard_key].append((shard_index, chunk_key))
+        return shard_indices_per_shard_key
+
+    def __get_chunk_slice__(self, shard_index: int) -> Tuple[int, int]:
         start = shard_index * len(self._fill_chunk)
         return slice(start, start + len(self._fill_chunk))
 
     def __getitem__(self, key: str) -> bytes:
-        shard_key, shard_index = self.__key_to_sharded__(key)
-        chunk_slice = self.__get_chunk_slice__(shard_key, shard_index)
-        # TODO use partial reads if available
-        full_shard_value = self._store[shard_key]
-        return full_shard_value[chunk_slice]
+        return self.getitems([key])[key]
+
+    def getitems(self, keys: Iterable[str], **kwargs) -> Dict[str, bytes]:
+        result = {}
+        for shard_key, chunks_in_shard in self.__keys_to_shard_groups__(keys).items():
+            # TODO use partial reads if available
+            full_shard_value = self._store[shard_key]
+            # TODO omit items if they don't exist
+            for shard_index, chunk_key in chunks_in_shard:
+                result[chunk_key] = full_shard_value[self.__get_chunk_slice__(shard_index)]
+        return result
 
     def __setitem__(self, key: str, value: bytes) -> None:
-        shard_key, shard_index = self.__key_to_sharded__(key)
-        if shard_key in self._store:
-            full_shard_value = bytearray(self._store[shard_key])
-        else:
-            full_shard_value = bytearray(self._fill_chunk * self._num_chunks_per_shard)
-        chunk_slice = self.__get_chunk_slice__(shard_key, shard_index)
-        # TODO use partial writes if available
-        full_shard_value[chunk_slice] = value
-        self._store[shard_key] = full_shard_value
+        self.setitems({key: value})
+
+    def setitems(self, values: Dict[str, bytes]) -> None:
+        for shard_key, chunks_in_shard in self.__keys_to_shard_groups__(values.keys()).items():
+            if len(chunks_in_shard) == self._num_chunks_per_shard:
+                # TODO shards at a non-dataset-size aligned surface are not captured here yet
+                full_shard_value = b"".join(
+                    values[chunk_key] for _, chunk_key in sorted(chunks_in_shard)
+                ) + b"\xff" * len(self._emtpy_meta)
+                self._store[shard_key] = full_shard_value
+            else:
+                # TODO use partial writes if available
+                try:
+                    full_shard_value = bytearray(self._store[shard_key])
+                except KeyError:
+                    full_shard_value = bytearray(self._fill_chunk * self._num_chunks_per_shard + self._emtpy_meta)
+                chunk_mask = self.__get_meta__(full_shard_value)
+                for shard_index, chunk_key in chunks_in_shard:
+                    chunk_mask |= 1 << shard_index
+                    full_shard_value[self.__get_chunk_slice__(shard_index)] = values[chunk_key]
+                self.__set_meta__(full_shard_value, chunk_mask)
+                self._store[shard_key] = full_shard_value
 
     def __delitem__(self, key) -> None:
-        # TODO not implemented yet
-        # For uncompressed chunks, deleting the "last" chunk might need to be detected.
+        # TODO not implemented yet, also delitems
+        # Deleting the "last" chunk in a shard needs to remove the whole shard
         raise NotImplementedError("Deletion is not yet implemented")
 
     def __iter__(self) -> Iterator[str]:
@@ -94,16 +133,20 @@ class ShardedStore(Store):
                 yield shard_key
             else:
                 # For each shard key in the wrapped store, all corresponding chunks are yielded.
-                # TODO: For compressed chunks we might yield only the actualy contained chunks by reading the jumptables.
                 # TODO: allow to be in a group (aka only use last parts for dimensions)
-                subkeys = tuple(map(int, shard_key.split(self._dimension_separator)))
-                for offset in product(*(range(i) for i in self._shards)):
-                    original_key = (subkeys_i * shards_i + offset_i for subkeys_i, offset_i, shards_i in zip(subkeys, offset, self._shards))
-                    yield self._dimension_separator.join(map(str, original_key))
+                shard_key_tuple = tuple(map(int, shard_key.split(self._dimension_separator)))
+                mask = self.__get_meta__(self._store[shard_key])
+                for i in range(self._num_chunks_per_shard):
+                    if mask == 0:
+                        break
+                    if mask & 1:
+                        yield self.__shard_key_and_index_to_chunk_key__(shard_key_tuple, i)
+                    mask >>= 1
 
     def __len__(self) -> int:
         return sum(1 for _ in self.keys())
 
-    # TODO: For efficient reads and writes, we need to implement
-    # getitems, setitems & delitems
-    # and combine writes/reads/deletions to the same shard.
+
+SHARDED_STORES = {
+    "morton_order": MortonOrderShardedStore,
+}

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -110,6 +110,7 @@ class BaseStore(MutableMapping):
 
 
 class Store(BaseStore):
+    # TODO: document methods which allow optimizations, e.g. delitems, setitems, getitems, listdir, …
     """Abstract store class used by implementations following the Zarr v2 spec.
 
     Adds public `listdir`, `rename`, and `rmdir` methods on top of BaseStore.

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -110,7 +110,8 @@ class BaseStore(MutableMapping):
 
 
 class Store(BaseStore):
-    # TODO: document methods which allow optimizations, e.g. delitems, setitems, getitems, listdir, …
+    # TODO: document methods which allow optimizations,
+    # e.g. delitems, setitems, getitems, listdir, …
     """Abstract store class used by implementations following the Zarr v2 spec.
 
     Adds public `listdir`, `rename`, and `rmdir` methods on top of BaseStore.

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -330,10 +330,6 @@ class Array:
                     chunk_store,
                     shards=self._shards,
                     dimension_separator=self._dimension_separator,
-                    are_chunks_compressed=self._compressor is not None,
-                    dtype=self._dtype,
-                    fill_value=self._fill_value or 0,
-                    chunk_size=reduce(operator.mul, self._chunks, 1),
                 )
             return self._cached_sharded_store
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1930,7 +1930,8 @@ class Array:
             and hasattr(self._compressor, "decode_partial")
             and not fields
             and self.dtype != object
-            and hasattr(self.chunk_store, "getitems")  # TODO: this should rather check for read_block or similar
+            # TODO: this should rather check for read_block or similar
+            and hasattr(self.chunk_store, "getitems")
         ):
             partial_read_decode = True
             cdatas = {

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -21,7 +21,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
            object_codec=None, dimension_separator=None, write_empty_chunks=True,
-           shards: Union[int, Tuple[int, ...], None]=None, shard_format: str="morton_order", **kwargs):
+           shards: Union[int, Tuple[int, ...], None]=None, shard_format: str="indexed", **kwargs):
     """Create an array.
 
     Parameters

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -1,3 +1,4 @@
+from typing import Optional, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -19,7 +20,8 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            fill_value=0, order='C', store=None, synchronizer=None,
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
-           object_codec=None, dimension_separator=None, write_empty_chunks=True, **kwargs):
+           object_codec=None, dimension_separator=None, write_empty_chunks=True,
+           shards: Union[int, Tuple[int, ...], None]=None, **kwargs):
     """Create an array.
 
     Parameters
@@ -145,7 +147,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
                fill_value=fill_value, order=order, overwrite=overwrite, path=path,
                chunk_store=chunk_store, filters=filters, object_codec=object_codec,
-               dimension_separator=dimension_separator)
+               dimension_separator=dimension_separator, shards=shards)
 
     # instantiate array
     z = Array(store, path=path, chunk_store=chunk_store, synchronizer=synchronizer,

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -21,7 +21,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
            object_codec=None, dimension_separator=None, write_empty_chunks=True,
-           shards: Union[int, Tuple[int, ...], None]=None, **kwargs):
+           shards: Union[int, Tuple[int, ...], None]=None, shard_format: str="morton_order", **kwargs):
     """Create an array.
 
     Parameters
@@ -147,7 +147,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
                fill_value=fill_value, order=order, overwrite=overwrite, path=path,
                chunk_store=chunk_store, filters=filters, object_codec=object_codec,
-               dimension_separator=dimension_separator, shards=shards)
+               dimension_separator=dimension_separator, shards=shards, shard_format=shard_format)
 
     # instantiate array
     z = Array(store, path=path, chunk_store=chunk_store, synchronizer=synchronizer,

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -21,7 +21,8 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
            object_codec=None, dimension_separator=None, write_empty_chunks=True,
-           shards: Union[int, Tuple[int, ...], None]=None, shard_format: str="indexed", **kwargs):
+           shards: Union[int, Tuple[int, ...], None] = None,
+           shard_format: str = "indexed", **kwargs):
     """Create an array.
 
     Parameters

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -52,6 +52,7 @@ class Metadata2:
 
             dimension_separator = meta.get("dimension_separator", None)
             shards = meta.get("shards", None)
+            shard_format = meta.get("shard_format", None)
             fill_value = cls.decode_fill_value(meta['fill_value'], dtype, object_codec)
             meta = dict(
                 zarr_format=meta["zarr_format"],
@@ -67,6 +68,8 @@ class Metadata2:
                 meta['dimension_separator'] = dimension_separator
             if shards:
                 meta['shards'] = tuple(shards)
+                assert shard_format is not None
+                meta['shard_format'] = shard_format
         except Exception as e:
             raise MetadataError("error decoding metadata") from e
         else:
@@ -81,6 +84,7 @@ class Metadata2:
 
         dimension_separator = meta.get("dimension_separator")
         shards = meta.get("shards")
+        shard_format = meta.get("shard_format")
         if dtype.hasobject:
             import numcodecs
             object_codec = numcodecs.get_codec(meta['filters'][0])
@@ -99,9 +103,10 @@ class Metadata2:
         )
         if dimension_separator:
             meta['dimension_separator'] = dimension_separator
-
         if shards:
             meta['shards'] = shards
+            assert shard_format is not None
+            meta['shard_format'] = shard_format
 
         return json_dumps(meta)
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -51,6 +51,7 @@ class Metadata2:
                 object_codec = None
 
             dimension_separator = meta.get("dimension_separator", None)
+            shards = meta.get("shards", None)
             fill_value = cls.decode_fill_value(meta['fill_value'], dtype, object_codec)
             meta = dict(
                 zarr_format=meta["zarr_format"],
@@ -64,6 +65,8 @@ class Metadata2:
             )
             if dimension_separator:
                 meta['dimension_separator'] = dimension_separator
+            if shards:
+                meta['shards'] = tuple(shards)
         except Exception as e:
             raise MetadataError("error decoding metadata") from e
         else:
@@ -77,6 +80,7 @@ class Metadata2:
             dtype, sdshape = dtype.subdtype
 
         dimension_separator = meta.get("dimension_separator")
+        shards = meta.get("shards")
         if dtype.hasobject:
             import numcodecs
             object_codec = numcodecs.get_codec(meta['filters'][0])
@@ -96,8 +100,8 @@ class Metadata2:
         if dimension_separator:
             meta['dimension_separator'] = dimension_separator
 
-        if dimension_separator:
-            meta["dimension_separator"] = dimension_separator
+        if shards:
+            meta['shards'] = shards
 
         return json_dumps(meta)
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -236,8 +236,8 @@ def init_array(
     filters=None,
     object_codec=None,
     dimension_separator=None,
-    shards: Union[int, Tuple[int, ...], None]=None,
-    shard_format: Optional[str]=None,
+    shards: Union[int, Tuple[int, ...], None] = None,
+    shard_format: Optional[str] = None,
 ):
     """Initialize an array store with the given configuration. Note that this is a low-level
     function and there should be no need to call this directly from user code.
@@ -373,8 +373,8 @@ def _init_array_metadata(
     filters=None,
     object_codec=None,
     dimension_separator=None,
-    shards:Union[int, Tuple[int, ...], None] = None,
-    shard_format: Optional[str]=None,
+    shards: Union[int, Tuple[int, ...], None] = None,
+    shard_format: Optional[str] = None,
 ):
 
     # guard conditions

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -237,6 +237,7 @@ def init_array(
     object_codec=None,
     dimension_separator=None,
     shards: Union[int, Tuple[int, ...], None]=None,
+    shard_format: Optional[str]=None,
 ):
     """Initialize an array store with the given configuration. Note that this is a low-level
     function and there should be no need to call this directly from user code.
@@ -355,7 +356,7 @@ def init_array(
                          chunk_store=chunk_store, filters=filters,
                          object_codec=object_codec,
                          dimension_separator=dimension_separator,
-                         shards=shards)
+                         shards=shards, shard_format=shard_format)
 
 
 def _init_array_metadata(
@@ -373,6 +374,7 @@ def _init_array_metadata(
     object_codec=None,
     dimension_separator=None,
     shards:Union[int, Tuple[int, ...], None] = None,
+    shard_format: Optional[str]=None,
 ):
 
     # guard conditions
@@ -392,6 +394,7 @@ def _init_array_metadata(
     dtype = dtype.base
     chunks = normalize_chunks(chunks, shape, dtype.itemsize)
     shards = normalize_shards(shards, shape)
+    shard_format = shard_format or "morton_order"
     order = normalize_order(order)
     fill_value = normalize_fill_value(fill_value, dtype)
 
@@ -451,6 +454,7 @@ def _init_array_metadata(
                 dimension_separator=dimension_separator)
     if shards is not None:
         meta["shards"] = shards
+        meta["shard_format"] = shard_format
     key = _path_to_prefix(path) + array_meta_key
     if hasattr(store, '_metadata_class'):
         store[key] = store._metadata_class.encode_array_metadata(meta)  # type: ignore

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -14,7 +14,7 @@ from numcodecs.compat import ensure_ndarray, ensure_text
 from numcodecs.registry import codec_registry
 from numcodecs.blosc import cbuffer_sizes, cbuffer_metainfo
 
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
 
 
 def flatten(arg: Iterable) -> Iterable:
@@ -150,7 +150,7 @@ def normalize_chunks(
 
 
 def normalize_shards(
-    shards: Optional[Tuple[Optional[int], ...]], shape: Tuple[int, ...],
+    shards: Union[int, Tuple[Optional[int], ...], None], shape: Tuple[int, ...],
 ) -> Optional[Tuple[int, ...]]:
     """Convenience function to normalize the `shards` argument for an array
     with the given `shape`."""
@@ -163,6 +163,7 @@ def normalize_shards(
     # handle 1D convenience form
     if isinstance(shards, numbers.Integral):
         shards = tuple(int(shards) for _ in shape)
+    shards = cast(Tuple[Optional[int]], shards)
 
     # handle bad dimensionality
     if len(shards) > len(shape):
@@ -171,13 +172,14 @@ def normalize_shards(
     # handle underspecified shards
     if len(shards) < len(shape):
         # assume single shards across remaining dimensions
-        shards += (1, ) * len(shape) - len(shards)
+        shards += (1, ) * (len(shape) - len(shards))
 
     # handle None or -1 in shards
     if -1 in shards or None in shards:
         shards = tuple(s if c == -1 or c is None else int(c)
                        for s, c in zip(shape, shards))
 
+    shards = cast(Tuple[int], shards)
     return tuple(shards)
 
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -592,7 +592,7 @@ class PartialReadBuffer:
         # is it fsstore or an actual fsspec map object
         assert hasattr(self.chunk_store, "map")
         self.map = self.chunk_store.map
-        # maybe use partial_read here also
+        # TODO maybe use partial_read here also
         self.fs = self.chunk_store.fs
         self.store_key = store_key
         self.buff = None

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -150,8 +150,8 @@ def normalize_chunks(
 
 
 def normalize_shards(
-    shards: Optional[Tuple[int, ...]], shape: Tuple[int, ...],
-) -> Tuple[int, ...]:
+    shards: Optional[Tuple[Optional[int], ...]], shape: Tuple[int, ...],
+) -> Optional[Tuple[int, ...]]:
     """Convenience function to normalize the `shards` argument for an array
     with the given `shape`."""
 


### PR DESCRIPTION
This PR is for an early prototype of sharding support, as described in the corresponding issue #877. It serves mainly to discuss the overall implementation approach for sharding. This PR is not (yet) meant to be merged.

This prototype
* allows to specify shards as the number of chunks that should be contained in a shard (e.g. using `arr.zeros((20, 3), chunks=(3, 3), shards=(2, 2), …)`).
   One shard corresponds to one storage key, but can contain multiple chunks:
  ![sharding](https://user-images.githubusercontent.com/7216331/142209119-c1c179e1-e132-463c-a64f-80cb70d62f22.png)
* ensures that this setting is persisted in the `.zarray` config and loaded when opening an array again, adding two entries:
    * `"shard_format": "indexed"` specifies the binary format of the shards and allows to extend sharding with other formats later
    * `"shards": [2, 2]` specifies how many chunks are contained in a shard,
* adds a `IndexedShardedStore` class that is used to wrap the chunk-store when sharding is enabled. This store handles the grouping of multiple chunks to one shard and transparently reads and writes them via the inner store in a binary format which is specified below. The original store API does not need to be adapted, it just stores shards instead of chunks, which are translated back to chunks by the `IndexedShardedStore`.
* adds a small script `chunking_test.py` for demonstration purposes, this is not meant to be merged but servers to illustrate the changes.

-----------------

The currently implemented file format is still up for discussion. It implements "Format 2" @jbms describes in https://github.com/zarr-developers/zarr-python/pull/876#issuecomment-973462279.

Chunks are written successively in a shard (unused space between them is allowed), followed by an index referencing them.
The index holding an `offset, length` pair of little-endian uint64 per chunk, the chunks-order in the index is row-major (C) order,
e.g. for (2, 2) chunks per shard an index would look like:

```
| chunk (0, 0)    | chunk (0, 1)    | chunk (1, 0)    | chunk (1, 1)    |
| offset | length | offset | length | offset | length | offset | length |
| uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 |
```

Empty chunks are denoted by setting both offset and length to `2^64 - 1`. All the index always has the full shape of all possible chunks per shard, even if they are outside of the array size.

For the default order of the actual chunk-content in a shard I'd propose to use Morton order, but this can easily be changed and customized, since any order can be read.

-----------------

If the overall direction of this PR is pursued, the following steps (and possibly more) are missing:
* Functionality
  * [ ] Use a default write-order (Morton) of chunks in a shard and allow customization
  * [ ] Support deletion in the `ShardedStore`
  * [ ] Group chunk-wise operations in `Array` where possible (e.g. in `digest` & `_resize_nosync`)
  * [ ] Consider locking mechanisms to guard against concurrency issues within a shard
  * [ ] Allow partial reads and writes when the wrapped store supports them
  * [ ] Add support for prefixes before the chunk-dimensions in the storage key, e.g. for arrays that are contained in a group
  * [ ] Add warnings for inefficient reads/writes (might be configured)
  * [ ] Maybe use the new partial read method on the Store also for the current PartialReadBuffer usage (to detect if this is possible and reading via it)
* Tests
  * [ ] Add unit tests and/or doctests in docstrings
  * [ ] Test coverage is 100% (Codecov passes)
* Documentation
  * [ ] also document optional optimization possibilities on the `Store` or `BaseStore` class, such as `getitems` or partial reads
  * [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
  * [ ] New/modified features documented in docs/tutorial.rst
  * [ ] Changes documented in docs/release.rst

*changed 2021-12-07: added file format description and updated TODOs*