### PR TITLE
Fix typos found by codespell

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -152,7 +152,7 @@ the tests will be skipped. To install all optional dependencies, run::
     $ pip install -r requirements_dev_optional.txt
 
 To also run the doctests within docstrings (requires optional
-depencies to be installed), run::
+dependencies to be installed), run::
 
     $ pytest -v --doctest-plus zarr
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -344,7 +344,7 @@ See `this link <https://github.com/zarr-developers/zarr-python/milestone/11?clos
 merged PR tagged with the 2.6 milestone.
 
 * Add ability to partially read and decompress arrays, see :issue:`667`. It is
-  only available to chunks stored using fs-spec and using bloc as a compressor.
+  only available to chunks stored using fsspec and using Blosc as a compressor.
 
   For certain analysis case when only a small portion of chunks is needed it can
   be advantageous to only access and decompress part of the chunks. Doing
@@ -375,7 +375,7 @@ This release will be the last to support Python 3.5, next version of Zarr will b
   without ``ipytree`` installed.
   By :user:`Zain Patel <mzjp2>`; :issue:`537`
 
-* Add typing informations to many of the core functions :issue:`589`
+* Add typing information to many of the core functions :issue:`589`
 
 * Explicitly close stores during testing.
   By :user:`Elliott Sales de Andrade <QuLogic>`; :issue:`442`

--- a/docs/spec/v1.rst
+++ b/docs/spec/v1.rst
@@ -150,7 +150,7 @@ and columns 4000-5000 and is stored under the key '2.4'; etc.
 
 There is no need for all chunks to be present within an array
 store. If a chunk is not present then it is considered to be in an
-uninitialized state.  An unitialized chunk MUST be treated as if it
+uninitialized state.  An uninitialized chunk MUST be treated as if it
 was uniformly filled with the value of the 'fill_value' field in the
 array metadata. If the 'fill_value' field is ``null`` then the
 contents of the chunk are undefined.

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -81,7 +81,7 @@ filters
 The following keys MAY be present within the object:
 
 dimension_separator
-    If present, either the string ``"."`` or ``"/""`` definining the separator placed
+    If present, either the string ``"."`` or ``"/""`` defining the separator placed
     between the dimensions of a chunk. If the value is not set, then the
     default MUST be assumed to be ``"."``, leading to chunk keys of the form "0.0".
     Arrays defined with ``"/"`` as the dimension separator can be considered to have
@@ -222,7 +222,7 @@ columns 4000-5000 and is stored under the key "2.4"; etc.
 
 There is no need for all chunks to be present within an array store. If a chunk
 is not present then it is considered to be in an uninitialized state.  An
-unitialized chunk MUST be treated as if it was uniformly filled with the value
+uninitialized chunk MUST be treated as if it was uniformly filled with the value
 of the "fill_value" field in the array metadata. If the "fill_value" field is
 ``null`` then the contents of the chunk are undefined.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1297,7 +1297,7 @@ ratios, depending on the correlation structure within the data. E.g.::
     Chunks initialized : 100/100
 
 In the above example, Fortran order gives a better compression ratio. This is an
-artifical example but illustrates the general point that changing the order of
+artificial example but illustrates the general point that changing the order of
 bytes within chunks of an array may improve the compression ratio, depending on
 the structure of the data, the compression algorithm used, and which compression
 filters (e.g., byte-shuffle) have been applied.

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -74,7 +74,7 @@ class Array:
         operations. If False, user attributes are reloaded from the store prior
         to all attribute read operations.
     partial_decompress : bool, optional
-        If True and while the chunk_store is a FSStore and the compresion used
+        If True and while the chunk_store is a FSStore and the compression used
         is Blosc, when getting data from the array chunks will be partially
         read and decompressed when possible.
 
@@ -459,7 +459,7 @@ class Array:
         # count chunk keys
         return sum(1 for k in listdir(self.chunk_store, self._path) if prog.match(k))
 
-    # backwards compability
+    # backwards compatibility
     initialized = nchunks_initialized
 
     @property
@@ -1108,7 +1108,7 @@ class Array:
             >>> import numpy as np
             >>> z = zarr.array(np.arange(100).reshape(10, 10))
 
-        Retrieve items by specifying a maks::
+        Retrieve items by specifying a mask::
 
             >>> sel = np.zeros_like(z, dtype=bool)
             >>> sel[1, 1] = True

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -136,7 +136,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
         store_separator = getattr(store, "_dimension_separator", None)
         if store_separator not in (None, dimension_separator):
             raise ValueError(
-                f"Specified dimension_separtor: {dimension_separator}"
+                f"Specified dimension_separator: {dimension_separator}"
                 f"conflicts with store's separator: "
                 f"{store_separator}")
     dimension_separator = normalize_dimension_separator(dimension_separator)
@@ -439,7 +439,7 @@ def open_array(
         If using an fsspec URL to create the store, these will be passed to
         the backend implementation. Ignored otherwise.
     partial_decompress : bool, optional
-        If True and while the chunk_store is a FSStore and the compresion used
+        If True and while the chunk_store is a FSStore and the compression used
         is Blosc, when getting data from the array chunks will be partially
         read and decompressed when possible.
     write_empty_chunks : bool, optional

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -38,7 +38,7 @@ class N5Store(NestedDirectoryStore):
     normalize_keys : bool, optional
         If True, all store keys will be normalized to use lower case characters
         (e.g. 'foo' and 'FOO' will be treated as equivalent). This can be
-        useful to avoid potential discrepancies between case-senstive and
+        useful to avoid potential discrepancies between case-sensitive and
         case-insensitive file system. Default value is False.
 
     Examples
@@ -283,8 +283,9 @@ class N5Store(NestedDirectoryStore):
 
 
 class N5FSStore(FSStore):
-    """Implentation of the N5 format (https://github.com/saalfeldlab/n5) using `fsspec`,
-    which allows storage on a variety of filesystems. Based on `zarr.N5Store`.
+    """Implementation of the N5 format (https://github.com/saalfeldlab/n5)
+    using `fsspec`, which allows storage on a variety of filesystems. Based
+    on `zarr.N5Store`.
     Parameters
     ----------
     path : string
@@ -292,7 +293,7 @@ class N5FSStore(FSStore):
     normalize_keys : bool, optional
         If True, all store keys will be normalized to use lower case characters
         (e.g. 'foo' and 'FOO' will be treated as equivalent). This can be
-        useful to avoid potential discrepancies between case-senstive and
+        useful to avoid potential discrepancies between case-sensitive and
         case-insensitive file system. Default value is False.
 
     Examples

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -787,7 +787,7 @@ class DirectoryStore(Store):
     normalize_keys : bool, optional
         If True, all store keys will be normalized to use lower case characters
         (e.g. 'foo' and 'FOO' will be treated as equivalent). This can be
-        useful to avoid potential discrepancies between case-senstive and
+        useful to avoid potential discrepancies between case-sensitive and
         case-insensitive file system. Default value is False.
     dimension_separator : {'.', '/'}, optional
         Separator placed between the dimensions of a chunk.
@@ -1291,7 +1291,7 @@ class TempStore(DirectoryStore):
     normalize_keys : bool, optional
         If True, all store keys will be normalized to use lower case characters
         (e.g. 'foo' and 'FOO' will be treated as equivalent). This can be
-        useful to avoid potential discrepancies between case-senstive and
+        useful to avoid potential discrepancies between case-sensitive and
         case-insensitive file system. Default value is False.
     dimension_separator : {'.', '/'}, optional
         Separator placed between the dimensions of a chunk.
@@ -1321,7 +1321,7 @@ class NestedDirectoryStore(DirectoryStore):
     normalize_keys : bool, optional
         If True, all store keys will be normalized to use lower case characters
         (e.g. 'foo' and 'FOO' will be treated as equivalent). This can be
-        useful to avoid potential discrepancies between case-senstive and
+        useful to avoid potential discrepancies between case-sensitive and
         case-insensitive file system. Default value is False.
     dimension_separator : {'/'}, optional
         Separator placed between the dimensions of a chunk.

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -93,7 +93,7 @@ def verify(array, expect_failure=False):
 
 def test_open(dataset):
     """
-    Use zarr.open to open the dataset fixture. Legacy nested datatsets
+    Use zarr.open to open the dataset fixture. Legacy nested datasets
     without the dimension_separator metadata are not expected to be
     openable.
     """
@@ -104,7 +104,7 @@ def test_open(dataset):
 @needs_fsspec
 def test_fsstore(dataset):
     """
-    Use FSStore to open the dataset fixture. Legacy nested datatsets
+    Use FSStore to open the dataset fixture. Legacy nested datasets
     without the dimension_separator metadata are not expected to be
     openable.
     """
@@ -114,7 +114,7 @@ def test_fsstore(dataset):
 
 def test_directory(dataset):
     """
-    Use DirectoryStore to open the dataset fixture. Legacy nested datatsets
+    Use DirectoryStore to open the dataset fixture. Legacy nested datasets
     without the dimension_separator metadata are not expected to be
     openable.
     """

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -751,7 +751,7 @@ class TestMappingStore(StoreTests):
 
 def setdel_hierarchy_checks(store):
     # these tests are for stores that are aware of hierarchy levels; this
-    # behaviour is not stricly required by Zarr but these tests are included
+    # behaviour is not strictly required by Zarr but these tests are included
     # to define behaviour of MemoryStore and DirectoryStore classes
 
     # check __setitem__ and __delitem__ blocked by leaf
@@ -903,7 +903,7 @@ class TestDirectoryStore(StoreTests):
 
         def mock_walker_no_slash(_path):
             yield from [
-                # no trainling slash in first key
+                # no trailing slash in first key
                 ('root_with_no_slash', ['d1', 'g1'], ['.zgroup']),
                 ('root_with_no_slash/d1', [], ['.zarray']),
                 ('root_with_no_slash/g1', [], ['.zgroup'])
@@ -2149,7 +2149,7 @@ class TestConsolidatedMetadataStore:
 
     def test_bad_format(self):
 
-        # setup store with consolidated metdata
+        # setup store with consolidated metadata
         store = dict()
         consolidated = {
             # bad format version
@@ -2163,7 +2163,7 @@ class TestConsolidatedMetadataStore:
 
     def test_read_write(self):
 
-        # setup store with consolidated metdata
+        # setup store with consolidated metadata
         store = dict()
         consolidated = {
             'zarr_consolidated_format': 1,


### PR DESCRIPTION
Started looking into Zarr, just fixing a few typos, mostly in docs.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)