### PR TITLE
Unnecessary comprehension

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2070,7 +2070,7 @@ class Array:
         if self._compressor:
             # only decode requested items
             if (
-                all([x is not None for x in [start, nitems]])
+                all(x is not None for x in [start, nitems])
                 and self._compressor.codec_id == "blosc"
             ) and hasattr(self._compressor, "decode_partial"):
                 chunk = self._compressor.decode_partial(cdata, start, nitems)

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -308,15 +308,15 @@ def is_positive_slice(s):
 
 def is_contiguous_selection(selection):
     selection = ensure_tuple(selection)
-    return all([
+    return all(
         (is_integer_array(s) or is_contiguous_slice(s) or s == Ellipsis)
         for s in selection
-    ])
+    )
 
 
 def is_basic_selection(selection):
     selection = ensure_tuple(selection)
-    return all([is_integer(s) or is_positive_slice(s) for s in selection])
+    return all(is_integer(s) or is_positive_slice(s) for s in selection)
 
 
 # noinspection PyProtectedMember
@@ -671,8 +671,8 @@ class OIndex(object):
 def is_coordinate_selection(selection, array):
     return (
         (len(selection) == len(array._shape)) and
-        all([is_integer(dim_sel) or is_integer_array(dim_sel)
-             for dim_sel in selection])
+        all(is_integer(dim_sel) or is_integer_array(dim_sel)
+            for dim_sel in selection)
     )
 
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -132,7 +132,7 @@ class TestArray(unittest.TestCase):
         z[:] = np.random.random(z.shape)
 
         # Check in-memory array only contains `bytes`
-        assert all([isinstance(v, bytes) for v in z.chunk_store.values()])
+        assert all(isinstance(v, bytes) for v in z.chunk_store.values())
 
         z.store.close()
 

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -146,7 +146,7 @@ def test_guess_chunks():
         assert isinstance(chunks, tuple)
         assert len(chunks) == len(shape)
         # doesn't make any sense to allow chunks to have zero length dimension
-        assert all([0 < c <= max(s, 1) for c, s in zip(chunks, shape)])
+        assert all(0 < c <= max(s, 1) for c, s in zip(chunks, shape))
 
     # ludicrous itemsize
     chunks = guess_chunks((1000000,), 40000000000)

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -330,7 +330,7 @@ def normalize_storage_path(path: Union[str, bytes, None]) -> str:
 
         # don't allow path segments with just '.' or '..'
         segments = path.split('/')
-        if any([s in {'.', '..'} for s in segments]):
+        if any(s in {'.', '..'} for s in segments):
             raise ValueError("path containing '.' or '..' segment not allowed")
 
     else:


### PR DESCRIPTION
Built-in functions [all()](https://docs.python.org/3/library/functions.html#all) and [any()](https://docs.python.org/3/library/functions.html#any) do not require a comprehension, they operate directly on a generator expression.

This fixes these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PTC-W0016/occurrences

I suppose there is no need to document such a minor commit in `docs/tutorial.rst`, is there?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
