### PR TITLE
Useless `return`

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1958,7 +1958,6 @@ class Array:
             # that will trigger this condition, but it's possible that they
             # will be developed in the future.
             tuple(map(self._chunk_delitem, ckeys))
-        return None
 
     def _chunk_delitem(self, ckey):
         """
@@ -1966,9 +1965,8 @@ class Array:
         """
         try:
             del self.chunk_store[ckey]
-            return
         except KeyError:
-            return
+            pass
 
     def _chunk_setitem(self, chunk_coords, chunk_selection, value, fields=None):
         """Replace part or whole of a chunk.


### PR DESCRIPTION
Python implicitly returns `None` anyway.

This fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PYL-R1711/occurrences

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
