### PR TITLE
Decorate a few method with `@staticmethod`

### DIFF
--- a/zarr/_storage/absstore.py
+++ b/zarr/_storage/absstore.py
@@ -76,7 +76,8 @@ class ABSStore(Store):
         self._account_name = account_name
         self._account_key = account_key
 
-    def _warn_deprecated(self, property_):
+    @staticmethod
+    def _warn_deprecated(property_):
         msg = ("The {} property is deprecated and will be removed in a future "
                "version. Get the property from 'ABSStore.client' instead.")
         warnings.warn(msg.format(property_), FutureWarning, stacklevel=3)

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -343,7 +343,8 @@ class N5FSStore(FSStore):
         dimension_separator = "."
         super().__init__(*args, dimension_separator=dimension_separator, **kwargs)
 
-    def _swap_separator(self, key):
+    @staticmethod
+    def _swap_separator(key):
         segments = list(key.split('/'))
         if segments:
             last_segment = segments[-1]
@@ -898,7 +899,8 @@ class N5ChunkWrapper(Codec):
 
             return chunk
 
-    def _create_header(self, chunk):
+    @staticmethod
+    def _create_header(chunk):
 
         mode = struct.pack('>H', 0)
         num_dims = struct.pack('>H', len(chunk.shape))
@@ -909,7 +911,8 @@ class N5ChunkWrapper(Codec):
 
         return mode + num_dims + shape
 
-    def _read_header(self, chunk):
+    @staticmethod
+    def _read_header(chunk):
 
         num_dims = struct.unpack('>H', chunk[2:4])[0]
         shape = tuple(

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -851,7 +851,8 @@ class DirectoryStore(Store):
     def _normalize_key(self, key):
         return key.lower() if self.normalize_keys else key
 
-    def _fromfile(self, fn):
+    @staticmethod
+    def _fromfile(fn):
         """ Read data from a file
 
         Parameters
@@ -867,7 +868,8 @@ class DirectoryStore(Store):
         with open(fn, 'rb') as f:
             return f.read()
 
-    def _tofile(self, a, fn):
+    @staticmethod
+    def _tofile(a, fn):
         """ Write data to a file
 
         Parameters


### PR DESCRIPTION
These methods don't use `self`.

This fixes a few of these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PYL-R0201/occurrences
I have not changed the multiple occurrences under `zarr/test_*.py`.

[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
