### PR TITLE
No need to inherit from `object`

### DIFF
--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -428,7 +428,7 @@ def tree(grp, expand=False, level=None):
     return TreeViewer(grp, expand=expand, level=level)
 
 
-class _LogWriter(object):
+class _LogWriter:
 
     def __init__(self, log):
         self.log_func = None

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -132,7 +132,7 @@ dim_out_sel
 """
 
 
-class IntDimIndexer(object):
+class IntDimIndexer:
 
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
 
@@ -157,7 +157,7 @@ def ceildiv(a, b):
     return math.ceil(a / b)
 
 
-class SliceDimIndexer(object):
+class SliceDimIndexer:
 
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
 
@@ -320,7 +320,7 @@ def is_basic_selection(selection):
 
 
 # noinspection PyProtectedMember
-class BasicIndexer(object):
+class BasicIndexer:
 
     def __init__(self, selection, array):
 
@@ -361,7 +361,7 @@ class BasicIndexer(object):
             yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
 
 
-class BoolArrayDimIndexer(object):
+class BoolArrayDimIndexer:
 
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
 
@@ -451,7 +451,7 @@ def boundscheck_indices(x, dim_len):
         raise BoundsCheckError(dim_len)
 
 
-class IntArrayDimIndexer(object):
+class IntArrayDimIndexer:
     """Integer array selection against a single dimension."""
 
     def __init__(self, dim_sel, dim_len, dim_chunk_len, wraparound=True, boundscheck=True,
@@ -579,7 +579,7 @@ def oindex_set(a, selection, value):
 
 
 # noinspection PyProtectedMember
-class OrthogonalIndexer(object):
+class OrthogonalIndexer:
 
     def __init__(self, selection, array):
 
@@ -649,7 +649,7 @@ class OrthogonalIndexer(object):
             yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
 
 
-class OIndex(object):
+class OIndex:
 
     def __init__(self, array):
         self.array = array
@@ -686,7 +686,7 @@ def is_mask_selection(selection, array):
 
 
 # noinspection PyProtectedMember
-class CoordinateIndexer(object):
+class CoordinateIndexer:
 
     def __init__(self, selection, array):
 
@@ -805,7 +805,7 @@ class MaskIndexer(CoordinateIndexer):
         super().__init__(selection, array)
 
 
-class VIndex(object):
+class VIndex:
 
     def __init__(self, array):
         self.array = array
@@ -905,7 +905,7 @@ def make_slice_selection(selection):
     return ls
 
 
-class PartialChunkIterator(object):
+class PartialChunkIterator:
     """Iterator to retrieve the specific coordinates of requested data
     from within a compressed chunk.
 

--- a/zarr/sync.py
+++ b/zarr/sync.py
@@ -5,7 +5,7 @@ from threading import Lock
 import fasteners
 
 
-class ThreadSynchronizer(object):
+class ThreadSynchronizer:
     """Provides synchronization using thread locks."""
 
     def __init__(self):
@@ -24,7 +24,7 @@ class ThreadSynchronizer(object):
         self.__init__()
 
 
-class ProcessSynchronizer(object):
+class ProcessSynchronizer:
     """Provides synchronization using file locks via the
     `fasteners <http://fasteners.readthedocs.io/en/latest/api/process_lock.html>`_
     package.

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2423,7 +2423,7 @@ class TestArrayWithFilters(TestArray):
 
 
 # custom store, does not support getsize()
-class CustomMapping(object):
+class CustomMapping:
 
     def __init__(self):
         self.inner = KVStore(dict())

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -20,7 +20,7 @@ from zarr.sync import ThreadSynchronizer
 
 
 # something bcolz-like
-class MockBcolzArray(object):
+class MockBcolzArray:
 
     def __init__(self, data, chunklen):
         self.data = data
@@ -34,7 +34,7 @@ class MockBcolzArray(object):
 
 
 # something h5py-like
-class MockH5pyDataset(object):
+class MockH5pyDataset:
 
     def __init__(self, data, chunks):
         self.data = data

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -128,7 +128,7 @@ class TestGroup(unittest.TestCase):
         assert '/a/b/c' == g5.name
 
         # test non-str keys
-        class Foo(object):
+        class Foo:
 
             def __init__(self, s):
                 self.s = s

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -94,7 +94,7 @@ def test_deprecated_listdir_nosotre():
         listdir(store)
 
 
-class StoreTests(object):
+class StoreTests:
     """Abstract store tests."""
 
     def create_store(self, **kwargs):  # pragma: no cover

--- a/zarr/tests/test_sync.py
+++ b/zarr/tests/test_sync.py
@@ -57,7 +57,7 @@ def _set_arange(arg):
     return i
 
 
-class MixinArraySyncTests(object):
+class MixinArraySyncTests:
 
     def test_parallel_setitem(self):
         n = 100
@@ -197,7 +197,7 @@ def _require_group(arg):
     return h.name
 
 
-class MixinGroupSyncTests(object):
+class MixinGroupSyncTests:
 
     def test_parallel_create_group(self):
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -370,7 +370,7 @@ def info_html_report(items) -> str:
     return report
 
 
-class InfoReporter(object):
+class InfoReporter:
 
     def __init__(self, obj):
         self.obj = obj
@@ -384,7 +384,7 @@ class InfoReporter(object):
         return info_html_report(items)
 
 
-class TreeNode(object):
+class TreeNode:
 
     def __init__(self, obj, depth=0, level=None):
         self.obj = obj
@@ -468,7 +468,7 @@ def tree_widget(group, expand, level):
     return result
 
 
-class TreeViewer(object):
+class TreeViewer:
 
     def __init__(self, group, expand=False, level=None):
 
@@ -541,7 +541,7 @@ def is_valid_python_name(name):
     return name.isidentifier() and not iskeyword(name)
 
 
-class NoLock(object):
+class NoLock:
     """A lock that doesn't lock."""
 
     def __enter__(self):


### PR DESCRIPTION
In Python 3, all classes implicitly inherit from `object`.

This fixes these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PYL-R0205/occurrences

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
