### PR TITLE
use an if `expression` instead of `and`/`or`

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -997,8 +997,8 @@ class DirectoryStore(Store):
         return dir_path
 
     def listdir(self, path=None):
-        return self._dimension_separator == "/" and \
-            self._nested_listdir(path) or self._flat_listdir(path)
+        return self._nested_listdir(path) if self._dimension_separator == "/" else \
+            self._flat_listdir(path)
 
     def _flat_listdir(self, path=None):
         dir_path = self.dir_path(path)


### PR DESCRIPTION
Fix this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PYL-R1706/occurrences

An instance of the pre-Python 2.5 ternary syntax is being used. It is recommended to use an `if` expression such as: `foo if condition else bar`. Using `[condition] and [on_true] or [on_false]` may also give wrong results when `on_true` has a false boolean value.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
