### PR TITLE
Unguarded next inside generator

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -966,12 +966,14 @@ class DirectoryStore(Store):
     @staticmethod
     def _keys_fast(path, walker=os.walk):
         for dirpath, _, filenames in walker(path):
-            dirpath = os.path.relpath(dirpath, path).replace("\\", "/")
-            for f in filenames:
-                if dirpath == os.curdir:
+            dirpath = os.path.relpath(dirpath, path)
+            if dirpath == os.curdir:
+                for f in filenames:
                     yield f
-                else:
-                    yield dirpath + "/" + f
+            else:
+                dirpath = dirpath.replace("\\", "/")
+                for f in filenames:
+                    yield "/".join((dirpath, f))
 
     def __iter__(self):
         return self.keys()

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -965,23 +965,13 @@ class DirectoryStore(Store):
 
     @staticmethod
     def _keys_fast(path, walker=os.walk):
-        """
-
-        Faster logic on platform where the separator is `/` and using
-        `os.walk()` to decrease the number of stats.call.
-
-        """
-        it = iter(walker(path))
-        d0, dirnames, filenames = next(it)
-        if d0.endswith('/'):
-            root_len = len(d0)
-        else:
-            root_len = len(d0)+1
-        for f in filenames:
-            yield f
-        for dirpath, _, filenames in it:
+        for dirpath, _, filenames in walker(path):
+            dirpath = os.path.relpath(dirpath, path).replace("\\", "/")
             for f in filenames:
-                yield dirpath[root_len:].replace('\\', '/')+'/'+f
+                if dirpath == ".":
+                    yield f
+                else:
+                    yield dirpath + "/" + f
 
     def __iter__(self):
         return self.keys()

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -968,7 +968,7 @@ class DirectoryStore(Store):
         for dirpath, _, filenames in walker(path):
             dirpath = os.path.relpath(dirpath, path).replace("\\", "/")
             for f in filenames:
-                if dirpath == ".":
+                if dirpath == os.curdir:
                     yield f
                 else:
                     yield dirpath + "/" + f


### PR DESCRIPTION
Fixes #881.

Fix this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PTC-W0063/occurrences

> Calls to `next()` should be inside `try-except` block.
> 
> When the iterator is exhausted, `StopIteration` exception is raised. When used inside a generator, this can cause unexpected behavior. If not handled, it will propagate out of the generator causing termination. [PEP-479](https://www.python.org/dev/peps/pep-0479/) has been accepted to fix this problem. It will modify the behavior of `StopIteration` in generators.
> 
> Each call to `next()` should be wrapped in a `try-except` block to explicitly handle `StopIteration` exceptions.


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
