### PR TITLE
Remove unnecessary literal

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -986,7 +986,7 @@ class TestFSStore(StoreTests):
                                  chunks=(2, 2, 2),
                                  dtype="i8")
         baz[:] = 1
-        assert set(store.listdir()) == set([".zgroup", "bar"])
+        assert set(store.listdir()) == {".zgroup", "bar"}
         assert foo["bar"]["baz"][(0, 0, 0)] == 1
 
     def test_not_fsspec(self):


### PR DESCRIPTION
Fix this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PTC-W0018/occurrences

> It is unnecessary to use a `list` or `tuple` literal within a call to `tuple`, [list](url), [set](url), or [dict](url) since there is a literal syntax for these types.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
