### PR TITLE
Add StoreV3 support to creation.py (zarr v3 support part 5)

### DIFF
--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from collections.abc import MutableMapping
 from string import ascii_letters, digits

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -1,6 +1,6 @@
 from collections.abc import MutableMapping
 
-from zarr._storage.store import Store
+from zarr._storage.store import Store, StoreV3
 from zarr.util import json_dumps
 
 
@@ -26,7 +26,15 @@ class Attributes(MutableMapping):
 
     def __init__(self, store, key='.zattrs', read_only=False, cache=True,
                  synchronizer=None):
-        self.store = Store._ensure_store(store)
+
+        self._version = getattr(store, '_store_version', 2)
+        assert key
+
+        if self._version == 3 and '.z' in key:
+            raise ValueError('invalid v3 key')
+
+        _Store = Store if self._version == 2 else StoreV3
+        self.store = _Store._ensure_store(store)
         self.key = key
         self.read_only = read_only
         self.cache = cache
@@ -38,6 +46,8 @@ class Attributes(MutableMapping):
             data = self.store[self.key]
         except KeyError:
             d = dict()
+            if self._version > 2:
+                d['attributes'] = {}
         else:
             d = self.store._metadata_class.parse_metadata(data)
         return d
@@ -47,6 +57,8 @@ class Attributes(MutableMapping):
         if self.cache and self._cached_asdict is not None:
             return self._cached_asdict
         d = self._get_nosync()
+        if self._version == 3:
+            d = d['attributes']
         if self.cache:
             self._cached_asdict = d
         return d
@@ -54,7 +66,10 @@ class Attributes(MutableMapping):
     def refresh(self):
         """Refresh cached attributes from the store."""
         if self.cache:
-            self._cached_asdict = self._get_nosync()
+            if self._version == 3:
+                self._cached_asdict = self._get_nosync()['attributes']
+            else:
+                self._cached_asdict = self._get_nosync()
 
     def __contains__(self, x):
         return x in self.asdict()
@@ -84,7 +99,10 @@ class Attributes(MutableMapping):
         d = self._get_nosync()
 
         # set key value
-        d[item] = value
+        if self._version == 2:
+            d[item] = value
+        else:
+            d['attributes'][item] = value
 
         # _put modified data
         self._put_nosync(d)
@@ -98,7 +116,10 @@ class Attributes(MutableMapping):
         d = self._get_nosync()
 
         # delete key value
-        del d[key]
+        if self._version == 2:
+            del d[key]
+        else:
+            del d['attributes'][key]
 
         # _put modified data
         self._put_nosync(d)
@@ -106,12 +127,34 @@ class Attributes(MutableMapping):
     def put(self, d):
         """Overwrite all attributes with the key/value pairs in the provided dictionary
         `d` in a single operation."""
-        self._write_op(self._put_nosync, d)
+        if self._version == 2:
+            self._write_op(self._put_nosync, d)
+        else:
+            self._write_op(self._put_nosync, dict(attributes=d))
 
     def _put_nosync(self, d):
-        self.store[self.key] = json_dumps(d)
-        if self.cache:
-            self._cached_asdict = d
+        if self._version == 2:
+            self.store[self.key] = json_dumps(d)
+            if self.cache:
+                self._cached_asdict = d
+        else:
+            if self.key in self.store:
+                # Cannot write the attributes directly to JSON, but have to
+                # store it within the pre-existing attributes key of the v3
+                # metadata.
+
+                # Note: this changes the store.counter result in test_caching_on!
+
+                meta = self.store._metadata_class.parse_metadata(self.store[self.key])
+                if 'attributes' in meta and 'filters' in meta['attributes']:
+                    # need to preserve any existing "filters" attribute
+                    d['attributes']['filters'] = meta['attributes']['filters']
+                meta['attributes'] = d['attributes']
+            else:
+                meta = d
+            self.store[self.key] = json_dumps(meta)
+            if self.cache:
+                self._cached_asdict = d['attributes']
 
     # noinspection PyMethodOverriding
     def update(self, *args, **kwargs):
@@ -124,7 +167,12 @@ class Attributes(MutableMapping):
         d = self._get_nosync()
 
         # update
-        d.update(*args, **kwargs)
+        if self._version == 2:
+            d.update(*args, **kwargs)
+        else:
+            if 'attributes' not in d:
+                d['attributes'] = {}
+            d['attributes'].update(*args, **kwargs)
 
         # _put modified data
         self._put_nosync(d)

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -255,11 +255,12 @@ class Array:
                 self._chunks = meta['chunk_grid']['chunk_shape']
                 self._dtype = meta['data_type']
                 self._order = meta['chunk_memory_layout']
+                chunk_separator = meta['chunk_grid']['separator']
                 if dimension_separator is None:
                     # TODO: omit attribute in v3?
-                    dimension_separator = meta.get('dimension_separator', '/')
-                chunk_separator = meta['chunk_grid']['separator']
-                assert chunk_separator == dimension_separator
+                    dimension_separator = meta.get('dimension_separator', chunk_separator)
+                else:
+                    assert chunk_separator == dimension_separator
 
             self._dimension_separator = dimension_separator
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -264,11 +264,13 @@ class Array:
             self._dimension_separator = dimension_separator
 
             # setup compressor
-            config = meta.get('compressor', None)
-            if config is None:
+            compressor = meta.get('compressor', None)
+            if compressor is None:
                 self._compressor = None
+            elif self._version == 2:
+                    self._compressor = get_codec(compressor)
             else:
-                self._compressor = get_codec(config)
+                self._compressor = compressor
 
             # setup filters
             if self._version == 2:
@@ -301,7 +303,8 @@ class Array:
             filters_config = [f.get_config() for f in self._filters]
         else:
             filters_config = None
-        meta = dict(shape=self._shape, compressor=compressor_config,
+        _compressor = compressor_config if self._version == 2 else self._compressor
+        meta = dict(shape=self._shape, compressor=_compressor,
                     fill_value=self._fill_value, filters=filters_config)
         if getattr(self._store, '_store_version', 2) == 2:
             meta.update(

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -269,7 +269,7 @@ class Array:
             if compressor is None:
                 self._compressor = None
             elif self._version == 2:
-                    self._compressor = get_codec(compressor)
+                self._compressor = get_codec(compressor)
             else:
                 self._compressor = compressor
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -264,7 +264,7 @@ class Array:
             self._dimension_separator = dimension_separator
 
             # setup compressor
-            config = meta['compressor']
+            config = meta.get('compressor', None)
             if config is None:
                 self._compressor = None
             else:

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -4,13 +4,14 @@ import itertools
 import math
 import operator
 import re
+from collections.abc import MutableMapping
 from functools import reduce
+from typing import Any
 
 import numpy as np
 from numcodecs.compat import ensure_bytes, ensure_ndarray
 
-from collections.abc import MutableMapping
-
+from zarr._storage.store import _prefix_to_attrs_key
 from zarr.attrs import Attributes
 from zarr.codecs import AsType, get_codec
 from zarr.errors import ArrayNotFoundError, ReadOnlyError, ArrayIndexError
@@ -31,7 +32,13 @@ from zarr.indexing import (
     is_scalar,
     pop_fields,
 )
-from zarr.storage import array_meta_key, attrs_key, getsize, listdir, BaseStore
+from zarr.storage import (
+    _get_hierarchy_metadata,
+    _prefix_to_array_key,
+    getsize,
+    listdir,
+    normalize_store_arg,
+)
 from zarr.util import (
     all_equal,
     InfoReporter,
@@ -146,7 +153,7 @@ class Array:
 
     def __init__(
         self,
-        store: BaseStore,
+        store: Any,  # BaseStore not stricly required due to normalize_store_arg
         path=None,
         read_only=False,
         chunk_store=None,
@@ -155,12 +162,22 @@ class Array:
         cache_attrs=True,
         partial_decompress=False,
         write_empty_chunks=True,
+        zarr_version=None,
     ):
         # N.B., expect at this point store is fully initialized with all
         # configuration metadata fully specified and normalized
 
-        store = BaseStore._ensure_store(store)
-        chunk_store = BaseStore._ensure_store(chunk_store)
+        store = normalize_store_arg(store, zarr_version=zarr_version)
+        if zarr_version is None:
+            zarr_version = getattr(store, '_store_version', 2)
+
+        if chunk_store is not None:
+            chunk_store = normalize_store_arg(chunk_store,
+                                              zarr_version=zarr_version)
+            if not getattr(chunk_store, '_store_version', 2) == zarr_version:
+                raise ValueError(
+                    "zarr_version of store and chunk_store must match"
+                )
 
         self._store = store
         self._chunk_store = chunk_store
@@ -175,12 +192,19 @@ class Array:
         self._is_view = False
         self._partial_decompress = partial_decompress
         self._write_empty_chunks = write_empty_chunks
+        self._version = zarr_version
+
+        if self._version == 3:
+            self._data_key_prefix = 'data/root/' + self._key_prefix
+            self._data_path = 'data/root/' + self._path
+            self._hierarchy_metadata = _get_hierarchy_metadata(store=None)
+            self._metadata_key_suffix = self._hierarchy_metadata['metadata_key_suffix']
 
         # initialize metadata
         self._load_metadata()
 
         # initialize attributes
-        akey = self._key_prefix + attrs_key
+        akey = _prefix_to_attrs_key(self._store, self._key_prefix)
         self._attrs = Attributes(store, key=akey, read_only=read_only,
                                  synchronizer=synchronizer, cache=cache_attrs)
 
@@ -196,13 +220,13 @@ class Array:
         if self._synchronizer is None:
             self._load_metadata_nosync()
         else:
-            mkey = self._key_prefix + array_meta_key
+            mkey = _prefix_to_array_key(self._store, self._key_prefix)
             with self._synchronizer[mkey]:
                 self._load_metadata_nosync()
 
     def _load_metadata_nosync(self):
         try:
-            mkey = self._key_prefix + array_meta_key
+            mkey = _prefix_to_array_key(self._store, self._key_prefix)
             meta_bytes = self._store[mkey]
         except KeyError:
             raise ArrayNotFoundError(self._path)
@@ -212,21 +236,31 @@ class Array:
             meta = self._store._metadata_class.decode_array_metadata(meta_bytes)
             self._meta = meta
             self._shape = meta['shape']
-            self._chunks = meta['chunks']
-            self._dtype = meta['dtype']
             self._fill_value = meta['fill_value']
-            self._order = meta['order']
-
             dimension_separator = meta.get('dimension_separator', None)
-            if dimension_separator is None:
-                try:
-                    dimension_separator = self._store._dimension_separator
-                except (AttributeError, KeyError):
-                    pass
-
-                # Fallback for any stores which do not choose a default
+            if self._version == 2:
+                self._chunks = meta['chunks']
+                self._dtype = meta['dtype']
+                self._order = meta['order']
                 if dimension_separator is None:
-                    dimension_separator = "."
+                    try:
+                        dimension_separator = self._store._dimension_separator
+                    except (AttributeError, KeyError):
+                        pass
+
+                    # Fallback for any stores which do not choose a default
+                    if dimension_separator is None:
+                        dimension_separator = "."
+            else:
+                self._chunks = meta['chunk_grid']['chunk_shape']
+                self._dtype = meta['data_type']
+                self._order = meta['chunk_memory_layout']
+                if dimension_separator is None:
+                    # TODO: omit attribute in v3?
+                    dimension_separator = meta.get('dimension_separator', '/')
+                chunk_separator = meta['chunk_grid']['separator']
+                assert chunk_separator == dimension_separator
+
             self._dimension_separator = dimension_separator
 
             # setup compressor
@@ -237,7 +271,12 @@ class Array:
                 self._compressor = get_codec(config)
 
             # setup filters
-            filters = meta['filters']
+            if self._version == 2:
+                filters = meta.get('filters', [])
+            else:
+                # TODO: storing filters under attributes for now since the v3
+                #       array metadata does not have a 'filters' attribute.
+                filters = meta['attributes'].get('filters', [])
             if filters:
                 filters = [get_codec(config) for config in filters]
             self._filters = filters
@@ -262,10 +301,22 @@ class Array:
             filters_config = [f.get_config() for f in self._filters]
         else:
             filters_config = None
-        meta = dict(shape=self._shape, chunks=self._chunks, dtype=self._dtype,
-                    compressor=compressor_config, fill_value=self._fill_value,
-                    order=self._order, filters=filters_config)
-        mkey = self._key_prefix + array_meta_key
+        meta = dict(shape=self._shape, compressor=compressor_config,
+                    fill_value=self._fill_value, filters=filters_config)
+        if getattr(self._store, '_store_version', 2) == 2:
+            meta.update(
+                dict(chunks=self._chunks, dtype=self._dtype, order=self._order)
+            )
+        else:
+            meta.update(
+                dict(chunk_grid=dict(type='regular',
+                                     chunk_shape=self._chunks,
+                                     separator=self._dimension_separator),
+                     data_type=self._dtype,
+                     chunk_memory_layout=self._order,
+                     attributes=self.attrs.asdict())
+            )
+        mkey = _prefix_to_array_key(self._store, self._key_prefix)
         self._store[mkey] = self._store._metadata_class.encode_array_metadata(meta)
 
     @property
@@ -453,11 +504,28 @@ class Array:
     def nchunks_initialized(self):
         """The number of chunks that have been initialized with some data."""
 
-        # key pattern for chunk keys
-        prog = re.compile(r'\.'.join([r'\d+'] * min(1, self.ndim)))
-
         # count chunk keys
-        return sum(1 for k in listdir(self.chunk_store, self._path) if prog.match(k))
+        if self._version == 3:
+            # # key pattern for chunk keys
+            # prog = re.compile(r'\.'.join([r'c\d+'] * min(1, self.ndim)))
+            # # get chunk keys, excluding the prefix
+            # members = self.chunk_store.list_prefix(self._data_path)
+            # members = [k.split(self._data_key_prefix)[1] for k in members]
+            # # count the chunk keys
+            # return sum(1 for k in members if prog.match(k))
+
+            # key pattern for chunk keys
+            prog = re.compile(self._data_key_prefix + r'c\d+')  # TODO: ndim == 0 case?
+            # get chunk keys, excluding the prefix
+            members = self.chunk_store.list_prefix(self._data_path)
+            # count the chunk keys
+            return sum(1 for k in members if prog.match(k))
+        else:
+            # key pattern for chunk keys
+            prog = re.compile(r'\.'.join([r'\d+'] * min(1, self.ndim)))
+
+            # count chunk keys
+            return sum(1 for k in listdir(self.chunk_store, self._path) if prog.match(k))
 
     # backwards compatibility
     initialized = nchunks_initialized
@@ -2061,7 +2129,15 @@ class Array:
         return chunk
 
     def _chunk_key(self, chunk_coords):
-        return self._key_prefix + self._dimension_separator.join(map(str, chunk_coords))
+        if self._version == 3:
+            # _chunk_key() corresponds to data_key(P, i, j, ...) example in the spec
+            # where P = self._key_prefix,  i, j, ... = chunk_coords
+            # e.g. c0/2/3 for 3d array with chunk index (0, 2, 3)
+            # https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/protocol/core/v3.0.html#regular-grids
+            return ("data/root/" + self._key_prefix +
+                    "c" + self._dimension_separator.join(map(str, chunk_coords)))
+        else:
+            return self._key_prefix + self._dimension_separator.join(map(str, chunk_coords))
 
     def _decode_chunk(self, cdata, start=None, nitems=None, expected_shape=None):
         # decompress
@@ -2242,7 +2318,8 @@ class Array:
         for i in itertools.product(*[range(s) for s in self.cdata_shape]):
             h.update(self.chunk_store.get(self._chunk_key(i), b""))
 
-        h.update(self.store.get(self._key_prefix + array_meta_key, b""))
+        mkey = _prefix_to_array_key(self._store, self._key_prefix)
+        h.update(self.store.get(mkey, b""))
 
         h.update(self.store.get(self.attrs.key, b""))
 
@@ -2279,7 +2356,7 @@ class Array:
     def __getstate__(self):
         return (self._store, self._path, self._read_only, self._chunk_store,
                 self._synchronizer, self._cache_metadata, self._attrs.cache,
-                self._partial_decompress, self._write_empty_chunks)
+                self._partial_decompress, self._write_empty_chunks, self._version)
 
     def __setstate__(self, state):
         self.__init__(*state)
@@ -2292,7 +2369,7 @@ class Array:
 
         else:
             # synchronize on the array
-            mkey = self._key_prefix + array_meta_key
+            mkey = _prefix_to_array_key(self._store, self._key_prefix)
             lock = self._synchronizer[mkey]
 
         with lock:
@@ -2559,7 +2636,7 @@ class Array:
         if synchronizer is None:
             synchronizer = self._synchronizer
         a = Array(store=store, path=path, chunk_store=chunk_store, read_only=read_only,
-                  synchronizer=synchronizer, cache_metadata=True)
+                  synchronizer=synchronizer, cache_metadata=True, zarr_version=self._version)
         a._is_view = True
 
         # allow override of some properties

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -6,8 +6,7 @@ import numpy as np
 from zarr.attrs import Attributes
 from zarr.core import Array
 from zarr.creation import (array, create, empty, empty_like, full, full_like,
-                           normalize_store_arg, ones, ones_like, zeros,
-                           zeros_like)
+                           ones, ones_like, zeros, zeros_like)
 from zarr.errors import (
     ContainsArrayError,
     ContainsGroupError,
@@ -15,14 +14,18 @@ from zarr.errors import (
     ReadOnlyError,
 )
 from zarr.storage import (
+    _get_hierarchy_metadata,
+    _prefix_to_group_key,
     BaseStore,
     MemoryStore,
+    MemoryStoreV3,
     attrs_key,
     contains_array,
     contains_group,
     group_meta_key,
     init_group,
     listdir,
+    normalize_store_arg,
     rename,
     rmdir,
 )
@@ -109,9 +112,17 @@ class Group(MutableMapping):
     """
 
     def __init__(self, store, path=None, read_only=False, chunk_store=None,
-                 cache_attrs=True, synchronizer=None):
-        store: BaseStore = BaseStore._ensure_store(store)
-        chunk_store: BaseStore = BaseStore._ensure_store(chunk_store)
+                 cache_attrs=True, synchronizer=None, zarr_version=None):
+        store: BaseStore = _normalize_store_arg(store, zarr_version=zarr_version)
+        if zarr_version is None:
+            zarr_version = getattr(store, '_store_version', 2)
+        if zarr_version > 2 and path:
+            if path.startswith(("meta/", "data/")):
+                raise ValueError("path must note start with 'meta/' or 'data/'")
+        if chunk_store is not None:
+            chunk_store: BaseStore = _normalize_store_arg(chunk_store, zarr_version=zarr_version)
+            if not getattr(chunk_store, '_store_version', 2) == zarr_version:
+                raise ValueError("zarr_version of store and chunk_store must match")
         self._store = store
         self._chunk_store = chunk_store
         self._path = normalize_storage_path(path)
@@ -121,6 +132,13 @@ class Group(MutableMapping):
             self._key_prefix = ''
         self._read_only = read_only
         self._synchronizer = synchronizer
+        self._version = zarr_version
+
+        if self._version == 3:
+            self._data_key_prefix = 'data/root/' + self._key_prefix
+            self._data_path = 'data/root/' + self._path
+            self._hierarchy_metadata = _get_hierarchy_metadata(store=None)
+            self._metadata_key_suffix = self._hierarchy_metadata['metadata_key_suffix']
 
         # guard conditions
         if contains_array(store, path=self._path):
@@ -128,15 +146,31 @@ class Group(MutableMapping):
 
         # initialize metadata
         try:
-            mkey = self._key_prefix + group_meta_key
+            mkey = _prefix_to_group_key(self._store, self._key_prefix)
+            assert not mkey.endswith("root/.group")
             meta_bytes = store[mkey]
         except KeyError:
-            raise GroupNotFoundError(path)
+            if self._version == 2:
+                raise GroupNotFoundError(path)
+            else:
+                implicit_prefix = 'meta/root/' + self._key_prefix
+                if not implicit_prefix.endswith('/'):
+                    implicit_prefix += '/'
+                if self._store.list_prefix(implicit_prefix):
+                    # implicit group does not have any metadata
+                    self._meta = None
+                else:
+                    raise GroupNotFoundError(path)
         else:
             self._meta = self._store._metadata_class.decode_group_metadata(meta_bytes)
 
         # setup attributes
-        akey = self._key_prefix + attrs_key
+        if self._version == 2:
+            akey = self._key_prefix + attrs_key
+        else:
+            # Note: mkey doesn't actually exist for implicit groups, but the
+            # object can still be created.
+            akey = mkey
         self._attrs = Attributes(store, key=akey, read_only=read_only,
                                  cache=cache_attrs, synchronizer=synchronizer)
 
@@ -227,11 +261,36 @@ class Group(MutableMapping):
         quux
 
         """
-        for key in sorted(listdir(self._store, self._path)):
-            path = self._key_prefix + key
-            if (contains_array(self._store, path) or
-                    contains_group(self._store, path)):
-                yield key
+        if getattr(self._store, '_store_version', 2) == 2:
+            for key in sorted(listdir(self._store, self._path)):
+                path = self._key_prefix + key
+                if (contains_array(self._store, path) or
+                        contains_group(self._store, path)):
+                    yield key
+        else:
+            # TODO: Should this iterate over data folders and/or metadata
+            #       folders and/or metadata files
+
+            dir_path = 'meta/root/' + self._key_prefix
+            name_start = len(dir_path)
+            keys, prefixes = self._store.list_dir(dir_path)
+
+            # yield any groups or arrays
+            sfx = self._metadata_key_suffix
+            for key in keys:
+                len_suffix = len('.group') + len(sfx)  # same for .array
+                if key.endswith(('.group' + sfx, '.array' + sfx)):
+                    yield key[name_start:-len_suffix]
+
+            # also yield any implicit groups
+            for prefix in prefixes:
+                prefix = prefix.rstrip('/')
+                # only implicit if there is no .group.sfx file
+                if not prefix + '.group' + sfx in self._store:
+                    yield prefix[name_start:]
+
+            # Note: omit data/root/ to avoid duplicate listings
+            #       any group in data/root/ must has an entry in meta/root/
 
     def __len__(self):
         """Number of members."""
@@ -323,9 +382,11 @@ class Group(MutableMapping):
         False
 
         """
+        if self._version > 2 and item.startswith('meta/'):
+            raise ValueError("meta/ must not be in item")
         path = self._item_path(item)
         return contains_array(self._store, path) or \
-            contains_group(self._store, path)
+            contains_group(self._store, path, explicit_only=False)
 
     def __getitem__(self, item):
         """Obtain a group member.
@@ -352,11 +413,21 @@ class Group(MutableMapping):
         if contains_array(self._store, path):
             return Array(self._store, read_only=self._read_only, path=path,
                          chunk_store=self._chunk_store,
-                         synchronizer=self._synchronizer, cache_attrs=self.attrs.cache)
-        elif contains_group(self._store, path):
+                         synchronizer=self._synchronizer, cache_attrs=self.attrs.cache,
+                         zarr_version=self._version)
+        elif contains_group(self._store, path, explicit_only=True):
             return Group(self._store, read_only=self._read_only, path=path,
                          chunk_store=self._chunk_store, cache_attrs=self.attrs.cache,
-                         synchronizer=self._synchronizer)
+                         synchronizer=self._synchronizer, zarr_version=self._version)
+        elif self._version == 3:
+            implicit_group = 'meta/root/' + path + '/'
+            # non-empty folder in the metadata path implies an implicit group
+            if self._store.list_prefix(implicit_group):
+                return Group(self._store, read_only=self._read_only, path=path,
+                             chunk_store=self._chunk_store, cache_attrs=self.attrs.cache,
+                             synchronizer=self._synchronizer, zarr_version=self._version)
+            else:
+                raise KeyError(item)
         else:
             raise KeyError(item)
 
@@ -369,7 +440,7 @@ class Group(MutableMapping):
     def _delitem_nosync(self, item):
         path = self._item_path(item)
         if contains_array(self._store, path) or \
-                contains_group(self._store, path):
+                contains_group(self._store, path, explicit_only=False):
             rmdir(self._store, path)
         else:
             raise KeyError(item)
@@ -406,10 +477,24 @@ class Group(MutableMapping):
         ['bar', 'foo']
 
         """
-        for key in sorted(listdir(self._store, self._path)):
-            path = self._key_prefix + key
-            if contains_group(self._store, path):
-                yield key
+        if self._version == 2:
+            for key in sorted(listdir(self._store, self._path)):
+                path = self._key_prefix + key
+                if contains_group(self._store, path):
+                    yield key
+        else:
+            dir_name = 'meta/root/' + self._path
+            sfx = _get_hierarchy_metadata(self._store)['metadata_key_suffix']
+            group_sfx = '.group' + sfx
+            for key in sorted(listdir(self._store, dir_name)):
+                if key.endswith(group_sfx):
+                    key = key[:-len(group_sfx)]
+                path = self._key_prefix + key
+                if path.endswith(".array" + sfx):
+                    # skip array keys
+                    continue
+                if contains_group(self._store, path, explicit_only=False):
+                    yield key
 
     def groups(self):
         """Return an iterator over (name, value) pairs for groups only.
@@ -428,13 +513,39 @@ class Group(MutableMapping):
         foo <class 'zarr.hierarchy.Group'>
 
         """
-        for key in sorted(listdir(self._store, self._path)):
-            path = self._key_prefix + key
-            if contains_group(self._store, path):
-                yield key, Group(self._store, path=path, read_only=self._read_only,
-                                 chunk_store=self._chunk_store,
-                                 cache_attrs=self.attrs.cache,
-                                 synchronizer=self._synchronizer)
+        if self._version == 2:
+            for key in sorted(listdir(self._store, self._path)):
+                path = self._key_prefix + key
+                if contains_group(self._store, path, explicit_only=False):
+                    yield key, Group(
+                        self._store,
+                        path=path,
+                        read_only=self._read_only,
+                        chunk_store=self._chunk_store,
+                        cache_attrs=self.attrs.cache,
+                        synchronizer=self._synchronizer,
+                        zarr_version=self._version)
+
+        else:
+            dir_name = 'meta/root/' + self._path
+            sfx = _get_hierarchy_metadata(self._store)['metadata_key_suffix']
+            group_sfx = '.group' + sfx
+            for key in sorted(listdir(self._store, dir_name)):
+                if key.endswith(group_sfx):
+                    key = key[:-len(group_sfx)]
+                path = self._key_prefix + key
+                if path.endswith(".array" + sfx):
+                    # skip array keys
+                    continue
+                if contains_group(self._store, path, explicit_only=False):
+                    yield key, Group(
+                        self._store,
+                        path=path,
+                        read_only=self._read_only,
+                        chunk_store=self._chunk_store,
+                        cache_attrs=self.attrs.cache,
+                        synchronizer=self._synchronizer,
+                        zarr_version=self._version)
 
     def array_keys(self, recurse=False):
         """Return an iterator over member names for arrays only.
@@ -491,14 +602,36 @@ class Group(MutableMapping):
                                 recurse=recurse)
 
     def _array_iter(self, keys_only, method, recurse):
-        for key in sorted(listdir(self._store, self._path)):
-            path = self._key_prefix + key
-            if contains_array(self._store, path):
-                yield key if keys_only else (key, self[key])
-            elif recurse and contains_group(self._store, path):
-                group = self[key]
-                for i in getattr(group, method)(recurse=recurse):
-                    yield i
+        if self._version == 2:
+            for key in sorted(listdir(self._store, self._path)):
+                path = self._key_prefix + key
+                assert not path.startswith("meta")
+                if contains_array(self._store, path):
+                    _key = key.rstrip("/")
+                    yield _key if keys_only else (_key, self[key])
+                elif recurse and contains_group(self._store, path):
+                    group = self[key]
+                    for i in getattr(group, method)(recurse=recurse):
+                        yield i
+        else:
+            dir_name = 'meta/root/' + self._path
+            sfx = _get_hierarchy_metadata(self._store)['metadata_key_suffix']
+            array_sfx = '.array' + sfx
+            for key in sorted(listdir(self._store, dir_name)):
+                if key.endswith(array_sfx):
+                    key = key[:-len(array_sfx)]
+                path = self._key_prefix + key
+                assert not path.startswith("meta")
+                if key.endswith('.group' + sfx):
+                    # skip group metadata keys
+                    continue
+                if contains_array(self._store, path):
+                    _key = key.rstrip("/")
+                    yield _key if keys_only else (_key, self[key])
+                elif recurse and contains_group(self._store, path):
+                    group = self[key]
+                    for i in getattr(group, method)(recurse=recurse):
+                        yield i
 
     def visitvalues(self, func):
         """Run ``func`` on each object.
@@ -707,7 +840,7 @@ class Group(MutableMapping):
 
         return Group(self._store, path=path, read_only=self._read_only,
                      chunk_store=self._chunk_store, cache_attrs=self.attrs.cache,
-                     synchronizer=self._synchronizer)
+                     synchronizer=self._synchronizer, zarr_version=self._version)
 
     def create_groups(self, *names, **kwargs):
         """Convenience method to create multiple groups in a single call."""
@@ -751,7 +884,7 @@ class Group(MutableMapping):
 
         return Group(self._store, path=path, read_only=self._read_only,
                      chunk_store=self._chunk_store, cache_attrs=self.attrs.cache,
-                     synchronizer=self._synchronizer)
+                     synchronizer=self._synchronizer, zarr_version=self._version)
 
     def require_groups(self, *names):
         """Convenience method to require multiple groups in a single call."""
@@ -1039,9 +1172,10 @@ class Group(MutableMapping):
 
         # Check that source exists.
         if not (contains_array(self._store, source) or
-                contains_group(self._store, source)):
+                contains_group(self._store, source, explicit_only=False)):
             raise ValueError('The source, "%s", does not exist.' % source)
-        if contains_array(self._store, dest) or contains_group(self._store, dest):
+        if (contains_array(self._store, dest) or
+                contains_group(self._store, dest, explicit_only=False)):
             raise ValueError('The dest, "%s", already exists.' % dest)
 
         # Ensure groups needed for `dest` exist.
@@ -1051,15 +1185,19 @@ class Group(MutableMapping):
         self._write_op(self._move_nosync, source, dest)
 
 
-def _normalize_store_arg(store, *, clobber=False, storage_options=None, mode=None):
+def _normalize_store_arg(store, *, clobber=False, storage_options=None, mode=None,
+                         zarr_version=None):
+    if zarr_version is None:
+        zarr_version = getattr(store, '_store_version', 2)
     if store is None:
-        return MemoryStore()
+        return MemoryStore() if zarr_version == 2 else MemoryStoreV3()
     return normalize_store_arg(store, clobber=clobber,
-                               storage_options=storage_options, mode=mode)
+                               storage_options=storage_options, mode=mode,
+                               zarr_version=zarr_version)
 
 
 def group(store=None, overwrite=False, chunk_store=None,
-          cache_attrs=True, synchronizer=None, path=None):
+          cache_attrs=True, synchronizer=None, path=None, *, zarr_version=None):
     """Create a group.
 
     Parameters
@@ -1104,20 +1242,29 @@ def group(store=None, overwrite=False, chunk_store=None,
     """
 
     # handle polymorphic store arg
-    store = _normalize_store_arg(store)
+    store = _normalize_store_arg(store, zarr_version=zarr_version)
+    if zarr_version is None:
+        zarr_version = getattr(store, '_store_version', 2)
+    if zarr_version == 3 and path is None:
+        raise ValueError(f"path must be provided for a v{zarr_version} group")
     path = normalize_storage_path(path)
 
-    # require group
-    if overwrite or not contains_group(store):
+    if zarr_version == 2:
+        requires_init = overwrite or not contains_group(store)
+    elif zarr_version == 3:
+        requires_init = overwrite or not contains_group(store, path)
+
+    if requires_init:
         init_group(store, overwrite=overwrite, chunk_store=chunk_store,
                    path=path)
 
     return Group(store, read_only=False, chunk_store=chunk_store,
-                 cache_attrs=cache_attrs, synchronizer=synchronizer, path=path)
+                 cache_attrs=cache_attrs, synchronizer=synchronizer, path=path,
+                 zarr_version=zarr_version)
 
 
 def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=None,
-               chunk_store=None, storage_options=None):
+               chunk_store=None, storage_options=None, *, zarr_version=None):
     """Open a group using file-mode-like semantics.
 
     Parameters
@@ -1166,11 +1313,22 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     # handle polymorphic store arg
     clobber = mode != "r"
     store = _normalize_store_arg(
-        store, clobber=clobber, storage_options=storage_options, mode=mode
-    )
+        store, clobber=clobber, storage_options=storage_options, mode=mode,
+        zarr_version=zarr_version)
+    if zarr_version is None:
+        zarr_version = getattr(store, '_store_version', 2)
     if chunk_store is not None:
         chunk_store = _normalize_store_arg(chunk_store, clobber=clobber,
                                            storage_options=storage_options)
+        if not getattr(chunk_store, '_store_version', 2) == zarr_version:
+            raise ValueError(
+                "zarr_version of store and chunk_store must match"
+            )
+
+    store_version = getattr(store, '_store_version', 2)
+    if store_version == 3 and path is None:
+        raise ValueError("path must be supplied to initialize a zarr v3 group")
+
     path = normalize_storage_path(path)
 
     # ensure store is initialized
@@ -1202,4 +1360,5 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
     read_only = mode == 'r'
 
     return Group(store, read_only=read_only, cache_attrs=cache_attrs,
-                 synchronizer=synchronizer, path=path, chunk_store=chunk_store)
+                 synchronizer=synchronizer, path=path, chunk_store=chunk_store,
+                 zarr_version=zarr_version)

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -1,7 +1,5 @@
 import base64
 import itertools
-import os
-from collections import namedtuple
 from collections.abc import Mapping
 
 import numpy as np
@@ -37,7 +35,10 @@ _v3_complex_types = set(
 # see: https://numpy.org/doc/stable/reference/arrays.datetime.html#datetime-units
 _date_units = ["Y", "M", "W", "D"]
 _time_units = ["h", "m", "s", "ms", "us", "μs", "ns", "ps", "fs", "as"]
-_v3_datetime_types = set(f"{end}{kind}8[{unit}]" for end, unit, kind in itertools.product("<>", _date_units + _time_units, ('m', 'M')))
+_v3_datetime_types = set(
+    f"{end}{kind}8[{unit}]"
+    for end, unit, kind in itertools.product("<>", _date_units + _time_units, ('m', 'M'))
+)
 
 
 def get_extended_dtype_info(dtype):
@@ -322,7 +323,7 @@ class Metadata3(Metadata2):
         d = cls._decode_dtype_descr(d)
         dtype = np.dtype(d)
         if validate:
-            if dtype.str in (_v3_core_types  | {"|b1", "|u1", "|i1"}):
+            if dtype.str in (_v3_core_types | {"|b1", "|u1", "|i1"}):
                 # it is a core dtype of the v3 spec
                 pass
             else:

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -22,6 +22,12 @@ _v3_core_type = set(
 )
 _v3_core_type = {"bool", "i1", "u1"} | _v3_core_type
 
+# TODO: How do we want to handle dtypes not officially in the v3 spec?
+#       Those in _v3_core_type above are the only ones defined in the spec.
+#       However we currently support many other dtypes for v2. For now, I also
+#       allow all of these for v3 unless the user sets an environment variable
+#       ZARR_V3_CORE_DTYPES_ONLY=1, etc.
+
 ZARR_V3_CORE_DTYPES_ONLY = int(os.environ.get("ZARR_V3_CORE_DTYPES_ONLY", False))
 ZARR_V3_ALLOW_COMPLEX = int(os.environ.get("ZARR_V3_ALLOW_COMPLEX",
                                            not ZARR_V3_CORE_DTYPES_ONLY))

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -512,6 +512,7 @@ class Metadata3(Metadata2):
             object_codec = numcodecs.get_codec(meta["attributes"]["filters"][0])
         else:
             object_codec = None
+
         compressor = cls._encode_codec_metadata(meta.get("compressor", None))
         extensions = meta.get("extensions", [])
         meta = dict(

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -417,6 +417,12 @@ class Metadata3(Metadata2):
             uri = uri + "zlib/1.0"
         elif isinstance(codec, numcodecs.Blosc):
             uri = uri + "blosc/1.0"
+        elif isinstance(codec, numcodecs.BZ2):
+            uri = uri + "bz2/1.0"
+        elif isinstance(codec, numcodecs.LZ4):
+            uri = uri + "lz4/1.0"
+        elif isinstance(codec, numcodecs.LZMA):
+            uri = uri + "lzma/1.0"
         meta = {
             "codec": uri,
             "configuration": config,
@@ -433,12 +439,21 @@ class Metadata3(Metadata2):
         if meta['codec'].startswith(uri + 'gzip/'):
             codec = numcodecs.GZip(level=conf['level'])
         elif meta['codec'].startswith(uri + 'zlib/'):
-            codec = numcodecs.Zlib()
+            codec = numcodecs.Zlib(level=conf['level'])
         elif meta['codec'].startswith(uri + 'blosc/'):
             codec = numcodecs.Blosc(clevel=conf['clevel'],
                                     shuffle=conf['shuffle'],
                                     blocksize=conf['blocksize'],
                                     cname=conf['cname'])
+        elif meta['codec'].startswith(uri + 'bz2/'):
+            codec = numcodecs.BZ2(level=conf['level'])
+        elif meta['codec'].startswith(uri + 'lz4/'):
+            codec = numcodecs.LZ4(acceleration=conf['acceleration'])
+        elif meta['codec'].startswith(uri + 'lzma/'):
+            codec = numcodecs.LZMA(format=conf['format'],
+                                   check=conf['check'],
+                                   preset=conf['preset'],
+                                   filters=conf['filters'])
         else:
             raise NotImplementedError
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -476,6 +476,7 @@ class Metadata3(Metadata2):
             # TODO: remove dimension_separator?
 
             compressor = cls._decode_codec_metadata(meta.get("compressor", None))
+            extensions = meta.get("extensions", [])
             meta = dict(
                 shape=tuple(meta["shape"]),
                 chunk_grid=dict(
@@ -488,6 +489,7 @@ class Metadata3(Metadata2):
                 chunk_memory_layout=meta["chunk_memory_layout"],
                 dimension_separator=meta.get("dimension_separator", "/"),
                 attributes=meta["attributes"],
+                extensions=extensions,
             )
             # compressor field should be absent when there is no compression
             if compressor:
@@ -515,6 +517,7 @@ class Metadata3(Metadata2):
         else:
             object_codec = None
         compressor = cls._encode_codec_metadata(meta.get("compressor", None))
+        extensions = meta.get("extensions", [])
         meta = dict(
             shape=meta["shape"] + sdshape,
             chunk_grid=dict(
@@ -526,6 +529,7 @@ class Metadata3(Metadata2):
             fill_value=encode_fill_value(meta["fill_value"], dtype, object_codec),
             chunk_memory_layout=meta["chunk_memory_layout"],
             attributes=meta.get("attributes", {}),
+            extensions=extensions,
         )
         if compressor:
             meta["compressor"] = compressor

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -169,9 +169,6 @@ class Metadata2:
         if dimension_separator:
             meta["dimension_separator"] = dimension_separator
 
-        if dimension_separator:
-            meta["dimension_separator"] = dimension_separator
-
         return json_dumps(meta)
 
     @classmethod

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -487,7 +487,6 @@ class Metadata3(Metadata2):
                 data_type=dtype,
                 fill_value=fill_value,
                 chunk_memory_layout=meta["chunk_memory_layout"],
-                dimension_separator=meta.get("dimension_separator", "/"),
                 attributes=meta["attributes"],
                 extensions=extensions,
             )
@@ -495,9 +494,6 @@ class Metadata3(Metadata2):
             if compressor:
                 meta['compressor'] = compressor
 
-            # dimension_separator = meta.get("dimension_separator", None)
-            # if dimension_separator:
-            #     meta["dimension_separator"] = dimension_separator
         except Exception as e:
             raise MetadataError("error decoding metadata: %s" % e)
         else:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -562,7 +562,7 @@ def _init_array_metadata(
 
     # obtain compressor config
     compressor_config = None
-    if compressor:
+    if store_version == 2 and compressor:
         try:
             compressor_config = compressor.get_config()
         except AttributeError as e:
@@ -598,7 +598,8 @@ def _init_array_metadata(
 
     # initialize metadata
     # TODO: don't store redundant dimension_separator for v3?
-    meta = dict(shape=shape, compressor=compressor_config,
+    _compressor = compressor_config if store_version == 2 else compressor
+    meta = dict(shape=shape, compressor=_compressor,
                 fill_value=fill_value,
                 dimension_separator=dimension_separator)
     if store_version < 3:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -468,6 +468,9 @@ def init_array(
         # initialize with default zarr.json entry level metadata
         store['zarr.json'] = store._metadata_class.encode_hierarchy_metadata(None)  # type: ignore
 
+    if not compressor:
+        # compatibility with legacy tests using compressor=[]
+        compressor = None
     _init_array_metadata(store, shape=shape, chunks=chunks, dtype=dtype,
                          compressor=compressor, fill_value=fill_value,
                          order=order, overwrite=overwrite, path=path,

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -43,6 +43,8 @@ from zarr.tests.util import abs_container, skip_test_env_var, have_fsspec
 
 class TestArray(unittest.TestCase):
 
+    _version = 2
+
     def test_array_init(self):
 
         # normal initialization
@@ -1180,7 +1182,6 @@ class TestArray(unittest.TestCase):
     def test_object_arrays_vlen_text(self):
 
         data = np.array(greetings * 1000, dtype=object)
-
         z = self.create_array(shape=data.shape, dtype=object, object_codec=VLenUTF8())
         z[0] = 'foo'
         assert z[0] == 'foo'

--- a/zarr/tests/test_core_v3.py
+++ b/zarr/tests/test_core_v3.py
@@ -1,0 +1,898 @@
+import atexit
+import os
+import shutil
+from tempfile import mkdtemp, mktemp
+
+import numpy as np
+import pytest
+from numcodecs import (Blosc, Zlib)
+from numcodecs.compat import ensure_bytes
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+
+from zarr.core import Array
+from zarr.errors import ArrayNotFoundError, ContainsGroupError
+from zarr.meta import json_loads
+from zarr.storage import (
+    # ABSStoreV3,
+    DBMStoreV3,
+    DirectoryStoreV3,
+    FSStoreV3,
+    KVStoreV3,
+    LMDBStoreV3,
+    LRUStoreCacheV3,
+    NestedDirectoryStoreV3,
+    SQLiteStoreV3,
+    StoreV3,
+    atexit_rmglob,
+    atexit_rmtree,
+    init_array,
+    init_group,
+)
+from zarr.tests.test_core import TestArrayWithPath
+from zarr.tests.util import have_fsspec
+from zarr.util import buffer_size
+
+
+# Start with TestArrayWithPathV3 not TestArrayV3 since path must be supplied
+
+class TestArrayWithPathV3(TestArrayWithPath):
+
+    _version = 3
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        store = KVStoreV3(dict())
+        kwargs.setdefault('compressor', Zlib(level=1))
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only,
+                     cache_metadata=cache_metadata, cache_attrs=cache_attrs,
+                     write_empty_chunks=write_empty_chunks)
+
+    def test_array_init(self):
+
+        # should not be able to initialize without a path in V3
+        store = KVStoreV3(dict())
+        with pytest.raises(ValueError):
+            init_array(store, shape=100, chunks=10, dtype="<f8")
+
+        # initialize at path
+        store = KVStoreV3(dict())
+        path = 'foo/bar'
+        init_array(store, shape=100, chunks=10, path=path, dtype='<f8')
+        a = Array(store, path=path)
+        assert isinstance(a, Array)
+        assert (100,) == a.shape
+        assert (10,) == a.chunks
+        assert path == a.path  # TODO: should this include meta/root?
+        assert '/' + path == a.name  # TODO: should this include meta/root?
+        assert 'bar' == a.basename
+        assert store is a.store
+        assert "402b6d5509c264ef9f0a881007300a39d27c4990" == a.hexdigest()
+
+        # store not initialized
+        store = KVStoreV3(dict())
+        with pytest.raises(ValueError):
+            Array(store)
+
+        # group is in the way
+        store = KVStoreV3(dict())
+        path = 'baz'
+        init_group(store, path=path)
+        # can't open with an uninitialized array
+        with pytest.raises(ArrayNotFoundError):
+            Array(store, path=path)
+        # can't open at same path as an existing group
+        with pytest.raises(ContainsGroupError):
+            init_array(store, shape=100, chunks=10, path=path, dtype='<f8')
+        group_key = 'meta/root/' + path + '.group.json'
+        assert group_key in store
+        del store[group_key]
+        init_array(store, shape=100, chunks=10, path=path, dtype='<f8')
+        Array(store, path=path)
+        assert group_key not in store
+        assert ('meta/root/' + path + '.array.json') in store
+
+    def test_nbytes_stored(self):
+
+        # dict as store
+        z = self.create_array(shape=1000, chunks=100)
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+        z[:] = 42
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+        assert z.nchunks_initialized == 10  # TODO: added temporarily for testing, can remove
+
+        # mess with store
+        try:
+            z.store['data/root/' + z._key_prefix + 'foo'] = list(range(10))
+            assert -1 == z.nbytes_stored
+        except TypeError:
+            pass
+
+        z.store.close()
+
+    def test_attributes(self):
+        a = self.create_array(shape=10, chunks=10, dtype='i8')
+        a.attrs['foo'] = 'bar'
+        assert a.attrs.key in a.store
+        assert 'foo' in a.attrs and a.attrs['foo'] == 'bar'
+        # in v3, attributes are in a sub-dictionary
+        attrs = json_loads(a.store[a.attrs.key])['attributes']
+        assert 'foo' in attrs and attrs['foo'] == 'bar'
+
+        a.attrs['bar'] = 'foo'
+        assert a.attrs.key in a.store
+        # in v3, attributes are in a sub-dictionary
+        attrs = json_loads(a.store[a.attrs.key])['attributes']
+        assert 'foo' in attrs and attrs['foo'] == 'bar'
+        assert 'bar' in attrs and attrs['bar'] == 'foo'
+        a.store.close()
+
+    def test_dtypes(self):
+
+        # integers
+        for dtype in 'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.arange(z.shape[0], dtype=dtype)
+            z[:] = a
+            assert_array_equal(a, z[:])
+            z.store.close()
+
+        # floats
+        for dtype in 'f2', 'f4', 'f8':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.linspace(0, 1, z.shape[0], dtype=dtype)
+            z[:] = a
+            assert_array_almost_equal(a, z[:])
+            z.store.close()
+
+        # TODO: should v3 spec be extended to include these complex and
+        #       datetime dtypes?
+
+        # complex
+        for dtype in 'c8', 'c16':
+            z = self.create_array(shape=10, chunks=3, dtype=dtype)
+            assert z.dtype == np.dtype(dtype)
+            a = np.linspace(0, 1, z.shape[0], dtype=dtype)
+            a -= 1j * a
+            z[:] = a
+            assert_array_almost_equal(a, z[:])
+            z.store.close()
+
+        # datetime, timedelta
+        for base_type in 'Mm':
+            for resolution in 'D', 'us', 'ns':
+                dtype = '{}8[{}]'.format(base_type, resolution)
+                z = self.create_array(shape=100, dtype=dtype, fill_value=0)
+                assert z.dtype == np.dtype(dtype)
+                a = np.random.randint(np.iinfo('i8').min, np.iinfo('i8').max,
+                                      size=z.shape[0],
+                                      dtype='i8').view(dtype)
+                z[:] = a
+                assert_array_equal(a, z[:])
+                z.store.close()
+
+        # check that datetime generic units are not allowed
+        with pytest.raises(ValueError):
+            self.create_array(shape=100, dtype='M8')
+        with pytest.raises(ValueError):
+            self.create_array(shape=100, dtype='m8')
+
+    def expected(self):
+        return [
+            "b3c57672933da371618596f48d87c2c1bdf76445",
+            "a71e05a0356c4c03418fb08b036238bad7c92a70",
+            "1d89bc519dbdbf8457569fc9f95f621da00294be",
+            "c5247a55edb89fe36105e2b46009d2a123de38a5",
+            "011965beb88874e928cfedcad9918418d9b37be5",
+        ]
+
+    def test_hexdigest(self):
+        found = []
+
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        found.append(z.hexdigest())
+        z.store.close()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
+        found.append(z.hexdigest())
+        z.store.close()
+
+        # Check basic 2-D array
+        z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
+        found.append(z.hexdigest())
+        z.store.close()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z[200:400] = np.arange(200, 400, dtype='i4')
+        found.append(z.hexdigest())
+        z.store.close()
+
+        # # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z.attrs['foo'] = 'bar'
+        found.append(z.hexdigest())
+        z.store.close()
+        print(f"found = {found}")
+        print(f"self.expected() = {self.expected()}")
+
+        assert self.expected() == found
+
+    def test_nchunks_initialized(self):
+        # copied from TestArray so the empty version from TestArrayWithPath is
+        # not used
+
+        z = self.create_array(shape=100, chunks=10)
+        assert 0 == z.nchunks_initialized
+        # manually put something into the store to confuse matters
+        z.store['foo'] = b'bar'
+        assert 0 == z.nchunks_initialized
+        z[:] = 42
+        assert 10 == z.nchunks_initialized
+
+        z.store.close()
+
+
+class TestArrayWithChunkStoreV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        store = KVStoreV3(dict())
+        # separate chunk store
+        chunk_store = KVStoreV3(dict())
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        init_array(store, path=array_path, chunk_store=chunk_store, **kwargs)
+        return Array(store, path=array_path, read_only=read_only,
+                     chunk_store=chunk_store, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_hexdigest(self):
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        assert '86004b83376cb08536689d53f29ae44a5a2d931f' == z.hexdigest()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
+        assert '2add13ba6be94522a3c6627a06556f0525c4b8bf' == z.hexdigest()
+
+        # Check basic 2-D array
+        z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
+        assert 'e2fea56c53fbdecc666d48ed1ef49d69538544d1' == z.hexdigest()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z[200:400] = np.arange(200, 400, dtype='i4')
+        assert '065de6123cbbfd46690b305ced6e4465cf5ff639' == z.hexdigest()
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z.attrs['foo'] = 'bar'
+        assert '62a467fd8ff6fed7c422cc5214c311af04437b8d' == z.hexdigest()
+
+    def test_nbytes_stored(self):
+
+        z = self.create_array(shape=1000, chunks=100)
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        expect_nbytes_stored += sum(buffer_size(v)
+                                    for k, v in z.chunk_store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+        z[:] = 42
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        expect_nbytes_stored += sum(buffer_size(v)
+                                    for k, v in z.chunk_store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+
+        # mess with store
+        z.chunk_store['data/root/' + z._key_prefix + 'foo'] = list(range(10))
+        assert -1 == z.nbytes_stored
+
+
+class TestArrayWithDirectoryStoreV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        store = DirectoryStoreV3(path)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only,
+                     cache_metadata=cache_metadata, cache_attrs=cache_attrs,
+                     write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        # dict as store
+        z = self.create_array(shape=1000, chunks=100)
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+        z[:] = 42
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+
+
+# TODO: TestArrayWithABSStoreV3
+# @skip_test_env_var("ZARR_TEST_ABS")
+# class TestArrayWithABSStoreV3(TestArrayWithPathV3):
+
+
+class TestArrayWithNestedDirectoryStoreV3(TestArrayWithDirectoryStoreV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        store = NestedDirectoryStoreV3(path)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def expected(self):
+        return [
+            "b3c57672933da371618596f48d87c2c1bdf76445",
+            "a71e05a0356c4c03418fb08b036238bad7c92a70",
+            "1d89bc519dbdbf8457569fc9f95f621da00294be",
+            "c5247a55edb89fe36105e2b46009d2a123de38a5",
+            "011965beb88874e928cfedcad9918418d9b37be5",
+        ]
+
+
+# TODO: TestArrayWithN5StoreV3
+# class TestArrayWithN5StoreV3(TestArrayWithDirectoryStoreV3):
+
+
+class TestArrayWithDBMStoreV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mktemp(suffix='.anydbm')
+        atexit.register(atexit_rmglob, path + '*')
+        store = DBMStoreV3(path, flag='n')
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_attrs=cache_attrs,
+                     cache_metadata=cache_metadata, write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+class TestArrayWithDBMStoreV3BerkeleyDB(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        bsddb3 = pytest.importorskip("bsddb3")
+        path = mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStoreV3(path, flag='n', open=bsddb3.btopen)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+class TestArrayWithLMDBStoreV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        pytest.importorskip("lmdb")
+        path = mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        store = LMDBStoreV3(path, buffers=True)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_store_has_bytes_values(self):
+        pass  # returns values as memoryviews/buffers instead of bytes
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+class TestArrayWithLMDBStoreV3NoBuffers(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        pytest.importorskip("lmdb")
+        path = mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        store = LMDBStoreV3(path, buffers=False)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+class TestArrayWithSQLiteStoreV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        pytest.importorskip("sqlite3")
+        path = mktemp(suffix='.db')
+        atexit.register(atexit_rmtree, path)
+        store = SQLiteStoreV3(path)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Zlib(1))
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        pass  # not implemented
+
+
+# skipped adding V3 equivalents for compressors (no change in v3):
+#    TestArrayWithNoCompressor
+#    TestArrayWithBZ2Compressor
+#    TestArrayWithBloscCompressor
+#    TestArrayWithLZMACompressor
+
+# skipped test with filters  (v3 protocol removed filters)
+#    TestArrayWithFilters
+
+
+# custom store, does not support getsize()
+# Note: this custom mapping doesn't actually have all methods in the
+#       v3 spec (e.g. erase), but they aren't needed here.
+class CustomMappingV3(StoreV3):
+
+    def __init__(self):
+        self.inner = KVStoreV3(dict())
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __len__(self):
+        return len(self.inner)
+
+    def keys(self):
+        return self.inner.keys()
+
+    def values(self):
+        return self.inner.values()
+
+    def get(self, item, default=None):
+        try:
+            return self.inner[item]
+        except KeyError:
+            return default
+
+    def __getitem__(self, item):
+        return self.inner[item]
+
+    def __setitem__(self, item, value):
+        self.inner[item] = ensure_bytes(value)
+
+    def __delitem__(self, key):
+        del self.inner[key]
+
+    def __contains__(self, item):
+        return item in self.inner
+
+
+class TestArrayWithCustomMappingV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        store = CustomMappingV3()
+        kwargs.setdefault('compressor', Zlib(1))
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_nbytes_stored(self):
+        z = self.create_array(shape=1000, chunks=100)
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+        z[:] = 42
+        expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        assert expect_nbytes_stored == z.nbytes_stored
+
+
+class TestArrayNoCacheV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        store = KVStoreV3(dict())
+        kwargs.setdefault('compressor', Zlib(level=1))
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_cache_metadata(self):
+        a1 = self.create_array(shape=100, chunks=10, dtype='i1', cache_metadata=False)
+        a2 = Array(a1.store, path=a1.path, cache_metadata=True)
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
+
+        # a1 is not caching so *will* see updates made via other objects
+        a2.resize(200)
+        assert (200,) == a2.shape
+        assert 200 == a2.size
+        assert 200 == a2.nbytes
+        assert 20 == a2.nchunks
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
+
+        a2.append(np.zeros(100))
+        assert (300,) == a2.shape
+        assert 300 == a2.size
+        assert 300 == a2.nbytes
+        assert 30 == a2.nchunks
+        assert a1.shape == a2.shape
+        assert a1.size == a2.size
+        assert a1.nbytes == a2.nbytes
+        assert a1.nchunks == a2.nchunks
+
+        # a2 is caching so *will not* see updates made via other objects
+        a1.resize(400)
+        assert (400,) == a1.shape
+        assert 400 == a1.size
+        assert 400 == a1.nbytes
+        assert 40 == a1.nchunks
+        assert (300,) == a2.shape
+        assert 300 == a2.size
+        assert 300 == a2.nbytes
+        assert 30 == a2.nchunks
+
+    # differs from v2 case only in that path='arr1' is passed to Array
+    def test_cache_attrs(self):
+        a1 = self.create_array(shape=100, chunks=10, dtype='i1', cache_attrs=False)
+        a2 = Array(a1.store, path='arr1', cache_attrs=True)
+        assert a1.attrs.asdict() == a2.attrs.asdict()
+
+        # a1 is not caching so *will* see updates made via other objects
+        a2.attrs['foo'] = 'xxx'
+        a2.attrs['bar'] = 42
+        assert a1.attrs.asdict() == a2.attrs.asdict()
+
+        # a2 is caching so *will not* see updates made via other objects
+        a1.attrs['foo'] = 'yyy'
+        assert 'yyy' == a1.attrs['foo']
+        assert 'xxx' == a2.attrs['foo']
+
+    def test_object_arrays_danger(self):
+        # skip this one as it only works if metadata are cached
+        pass
+
+
+class TestArrayWithStoreCacheV3(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        store = LRUStoreCacheV3(dict(), max_size=None)
+        kwargs.setdefault('compressor', Zlib(level=1))
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def test_store_has_bytes_values(self):
+        # skip as the cache has no control over how the store provides values
+        pass
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreV3(TestArrayWithPathV3):
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        key_separator = kwargs.pop('key_separator', ".")
+        store = FSStoreV3(path, key_separator=key_separator, auto_mkdir=True)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Blosc())
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def expected(self):
+        return [
+           "86004b83376cb08536689d53f29ae44a5a2d931f",
+           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
+           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
+           "065de6123cbbfd46690b305ced6e4465cf5ff639",
+           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+        ]
+
+    def test_hexdigest(self):
+        found = []
+
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
+        found.append(z.hexdigest())
+
+        # Check basic 2-D array
+        z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z[200:400] = np.arange(200, 400, dtype='i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z.attrs['foo'] = 'bar'
+        found.append(z.hexdigest())
+
+        assert self.expected() == found
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        store = FSStoreV3(path)
+        cache_metadata = kwargs.pop("cache_metadata", True)
+        cache_attrs = kwargs.pop("cache_attrs", True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault("compressor", Blosc())
+        init_array(store, path=array_path, **kwargs)
+        return Array(
+            store,
+            path=array_path,
+            read_only=read_only,
+            cache_metadata=cache_metadata,
+            cache_attrs=cache_attrs,
+            partial_decompress=True,
+            write_empty_chunks=write_empty_chunks,
+        )
+
+    def test_hexdigest(self):
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        assert "86004b83376cb08536689d53f29ae44a5a2d931f" == z.hexdigest()
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
+        assert "2add13ba6be94522a3c6627a06556f0525c4b8bf" == z.hexdigest()
+
+        # Check basic 2-D array
+        z = self.create_array(
+            shape=(
+                20,
+                35,
+            ),
+            chunks=10,
+            dtype="<i4",
+        )
+        assert "e2fea56c53fbdecc666d48ed1ef49d69538544d1" == z.hexdigest()
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z[200:400] = np.arange(200, 400, dtype="i4")
+        assert "065de6123cbbfd46690b305ced6e4465cf5ff639" == z.hexdigest()
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z.attrs["foo"] = "bar"
+        assert "62a467fd8ff6fed7c422cc5214c311af04437b8d" == z.hexdigest()
+
+    def test_non_cont(self):
+        z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
+        z[:, :, :] = 1
+        # actually go through the partial read by accessing a single item
+        assert z[0, :, 0].any()
+
+    def test_read_nitems_less_than_blocksize_from_multiple_chunks(self):
+        '''Tests to make sure decompression doesn't fail when `nitems` is
+        less than a compressed block size, but covers multiple blocks
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[40_000:80_000] = 1
+        b = Array(z.store, path=z.path, read_only=True, partial_decompress=True)
+        assert (b[40_000:80_000] == 1).all()
+
+    def test_read_from_all_blocks(self):
+        '''Tests to make sure `PartialReadBuffer.read_part` doesn't fail when
+        stop isn't in the `start_points` array
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[2:99_000] = 1
+        b = Array(z.store, path=z.path, read_only=True, partial_decompress=True)
+        assert (b[2:99_000] == 1).all()
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreV3Nested(TestArrayWithPathV3):
+
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        key_separator = kwargs.pop('key_separator', "/")
+        store = FSStoreV3(path, key_separator=key_separator, auto_mkdir=True)
+        cache_metadata = kwargs.pop('cache_metadata', True)
+        cache_attrs = kwargs.pop('cache_attrs', True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault('compressor', Blosc())
+        init_array(store, path=array_path, **kwargs)
+        return Array(store, path=array_path, read_only=read_only, cache_metadata=cache_metadata,
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+
+    def expected(self):
+        return [
+           "86004b83376cb08536689d53f29ae44a5a2d931f",
+           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
+           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
+           "065de6123cbbfd46690b305ced6e4465cf5ff639",
+           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+        ]
+
+    def test_hexdigest(self):
+        found = []
+
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
+        found.append(z.hexdigest())
+
+        # Check basic 2-D array
+        z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z[200:400] = np.arange(200, 400, dtype='i4')
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
+        z.attrs['foo'] = 'bar'
+        found.append(z.hexdigest())
+
+        assert self.expected() == found
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestArrayWithFSStoreV3NestedPartialRead(TestArrayWithPathV3):
+    @staticmethod
+    def create_array(array_path='arr1', read_only=False, **kwargs):
+        path = mkdtemp()
+        atexit.register(shutil.rmtree, path)
+        key_separator = kwargs.pop('key_separator', "/")
+        store = FSStoreV3(path, key_separator=key_separator, auto_mkdir=True)
+        cache_metadata = kwargs.pop("cache_metadata", True)
+        cache_attrs = kwargs.pop("cache_attrs", True)
+        write_empty_chunks = kwargs.pop('write_empty_chunks', True)
+        kwargs.setdefault("compressor", Blosc())
+        init_array(store, path=array_path, **kwargs)
+        return Array(
+            store,
+            path=array_path,
+            read_only=read_only,
+            cache_metadata=cache_metadata,
+            cache_attrs=cache_attrs,
+            partial_decompress=True,
+            write_empty_chunks=write_empty_chunks,
+        )
+
+    def expected(self):
+        return [
+           "86004b83376cb08536689d53f29ae44a5a2d931f",
+           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
+           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
+           "065de6123cbbfd46690b305ced6e4465cf5ff639",
+           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+        ]
+
+    def test_hexdigest(self):
+        found = []
+
+        # Check basic 1-D array
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with different type
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
+        found.append(z.hexdigest())
+
+        # Check basic 2-D array
+        z = self.create_array(
+            shape=(
+                20,
+                35,
+            ),
+            chunks=10,
+            dtype="<i4",
+        )
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with some data
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z[200:400] = np.arange(200, 400, dtype="i4")
+        found.append(z.hexdigest())
+
+        # Check basic 1-D array with attributes
+        z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
+        z.attrs["foo"] = "bar"
+        found.append(z.hexdigest())
+
+        assert self.expected() == found
+
+    def test_non_cont(self):
+        z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
+        z[:, :, :] = 1
+        # actually go through the partial read by accessing a single item
+        assert z[0, :, 0].any()
+
+    def test_read_nitems_less_than_blocksize_from_multiple_chunks(self):
+        '''Tests to make sure decompression doesn't fail when `nitems` is
+        less than a compressed block size, but covers multiple blocks
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[40_000:80_000] = 1
+        b = Array(z.store, path=z.path, read_only=True, partial_decompress=True)
+        assert (b[40_000:80_000] == 1).all()
+
+    def test_read_from_all_blocks(self):
+        '''Tests to make sure `PartialReadBuffer.read_part` doesn't fail when
+        stop isn't in the `start_points` array
+        '''
+        z = self.create_array(shape=1000000, chunks=100_000)
+        z[2:99_000] = 1
+        b = Array(z.store, path=z.path, read_only=True, partial_decompress=True)
+        assert (b[2:99_000] == 1).all()

--- a/zarr/tests/test_core_v3.py
+++ b/zarr/tests/test_core_v3.py
@@ -70,7 +70,7 @@ class TestArrayWithPathV3(TestArrayWithPath):
         assert '/' + path == a.name  # TODO: should this include meta/root?
         assert 'bar' == a.basename
         assert store is a.store
-        assert "5eaa4f7f3e9035677c52cf32d4cd68db6bb92960" == a.hexdigest()
+        assert "968dccbbfc0139f703ead2fd1d503ad6e44db307" == a.hexdigest()
 
         # store not initialized
         store = KVStoreV3(dict())
@@ -186,11 +186,11 @@ class TestArrayWithPathV3(TestArrayWithPath):
 
     def expected(self):
         return [
-            "46f1c7f9f147791b18bc8a6ca39a0d6059368a53",
-            "2ebe1ed1164f79f7316cbca7fc855b99d108c34e",
-            "2b9ea26a23611be10cd4e2580fc0a9a80c001774",
-            "ef95d7af1e4edb37617c829846baeac4945785ba",
-            "8240cf3457152da3f66570abd6473f0f8d897532",
+            "73ab8ace56719a5c9308c3754f5e2d57bc73dc20",
+            "5fb3d02b8f01244721582929b3cad578aec5cea5",
+            "26b098bedb640846e18dc2fbc1c27684bb02b532",
+            "799a458c287d431d747bec0728987ca4fe764549",
+            "c780221df84eb91cb62f633f12d3f1eaa9cee6bd",
         ]
 
     def test_hexdigest(self):
@@ -260,25 +260,25 @@ class TestArrayWithChunkStoreV3(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert '96c2331a54c15e7202109776dbd6b6c873529b87' == z.hexdigest()
+        assert '1509abec4285494b61cd3e8d21f44adc3cf8ddf6' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert '328cfb5c543c63c568c7d5389019e213aed65b2d' == z.hexdigest()
+        assert '7cfb82ec88f7ecb7ab20ae3cb169736bc76332b8' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert '1b22df0382fc540bc331b7703378acf45bcfbd6f' == z.hexdigest()
+        assert 'b663857bb89a8ab648390454954a9cdd453aa24b' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert '8c234d8df5b1119060b1eb08d925b69d825700e4' == z.hexdigest()
+        assert '21e90fa927d09cbaf0e3b773130e2dc05d18ff9b' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert '4e9c7e90d01984345d0e12e904e949b545886eb0' == z.hexdigest()
+        assert 'e8c1fdd18b5c2ee050b59d0c8c95d07db642459c' == z.hexdigest()
 
     def test_nbytes_stored(self):
 
@@ -346,11 +346,11 @@ class TestArrayWithNestedDirectoryStoreV3(TestArrayWithDirectoryStoreV3):
 
     def expected(self):
         return [
-            "46f1c7f9f147791b18bc8a6ca39a0d6059368a53",
-            "2ebe1ed1164f79f7316cbca7fc855b99d108c34e",
-            "2b9ea26a23611be10cd4e2580fc0a9a80c001774",
-            "ef95d7af1e4edb37617c829846baeac4945785ba",
-            "8240cf3457152da3f66570abd6473f0f8d897532",
+            "73ab8ace56719a5c9308c3754f5e2d57bc73dc20",
+            "5fb3d02b8f01244721582929b3cad578aec5cea5",
+            "26b098bedb640846e18dc2fbc1c27684bb02b532",
+            "799a458c287d431d747bec0728987ca4fe764549",
+            "c780221df84eb91cb62f633f12d3f1eaa9cee6bd",
         ]
 
 
@@ -641,11 +641,11 @@ class TestArrayWithFSStoreV3(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "96c2331a54c15e7202109776dbd6b6c873529b87",
-            "328cfb5c543c63c568c7d5389019e213aed65b2d",
-            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
-            "8c234d8df5b1119060b1eb08d925b69d825700e4",
-            "4e9c7e90d01984345d0e12e904e949b545886eb0",
+            "1509abec4285494b61cd3e8d21f44adc3cf8ddf6",
+            "7cfb82ec88f7ecb7ab20ae3cb169736bc76332b8",
+            "b663857bb89a8ab648390454954a9cdd453aa24b",
+            "21e90fa927d09cbaf0e3b773130e2dc05d18ff9b",
+            "e8c1fdd18b5c2ee050b59d0c8c95d07db642459c",
         ]
 
     def test_hexdigest(self):
@@ -701,11 +701,11 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
-        assert "96c2331a54c15e7202109776dbd6b6c873529b87" == z.hexdigest()
+        assert "1509abec4285494b61cd3e8d21f44adc3cf8ddf6" == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
-        assert "328cfb5c543c63c568c7d5389019e213aed65b2d" == z.hexdigest()
+        assert "7cfb82ec88f7ecb7ab20ae3cb169736bc76332b8" == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(
@@ -716,17 +716,17 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
             chunks=10,
             dtype="<i4",
         )
-        assert "1b22df0382fc540bc331b7703378acf45bcfbd6f" == z.hexdigest()
+        assert "b663857bb89a8ab648390454954a9cdd453aa24b" == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z[200:400] = np.arange(200, 400, dtype="i4")
-        assert "8c234d8df5b1119060b1eb08d925b69d825700e4" == z.hexdigest()
+        assert "21e90fa927d09cbaf0e3b773130e2dc05d18ff9b" == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z.attrs["foo"] = "bar"
-        assert "4e9c7e90d01984345d0e12e904e949b545886eb0" == z.hexdigest()
+        assert "e8c1fdd18b5c2ee050b59d0c8c95d07db642459c" == z.hexdigest()
 
     def test_non_cont(self):
         z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
@@ -772,11 +772,11 @@ class TestArrayWithFSStoreV3Nested(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "96c2331a54c15e7202109776dbd6b6c873529b87",
-            "328cfb5c543c63c568c7d5389019e213aed65b2d",
-            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
-            "8c234d8df5b1119060b1eb08d925b69d825700e4",
-            "4e9c7e90d01984345d0e12e904e949b545886eb0",
+            "1509abec4285494b61cd3e8d21f44adc3cf8ddf6",
+            "7cfb82ec88f7ecb7ab20ae3cb169736bc76332b8",
+            "b663857bb89a8ab648390454954a9cdd453aa24b",
+            "21e90fa927d09cbaf0e3b773130e2dc05d18ff9b",
+            "e8c1fdd18b5c2ee050b59d0c8c95d07db642459c",
         ]
 
     def test_hexdigest(self):
@@ -832,11 +832,11 @@ class TestArrayWithFSStoreV3NestedPartialRead(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "96c2331a54c15e7202109776dbd6b6c873529b87",
-            "328cfb5c543c63c568c7d5389019e213aed65b2d",
-            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
-            "8c234d8df5b1119060b1eb08d925b69d825700e4",
-            "4e9c7e90d01984345d0e12e904e949b545886eb0",
+            "1509abec4285494b61cd3e8d21f44adc3cf8ddf6",
+            "7cfb82ec88f7ecb7ab20ae3cb169736bc76332b8",
+            "b663857bb89a8ab648390454954a9cdd453aa24b",
+            "21e90fa927d09cbaf0e3b773130e2dc05d18ff9b",
+            "e8c1fdd18b5c2ee050b59d0c8c95d07db642459c",
         ]
 
     def test_hexdigest(self):

--- a/zarr/tests/test_core_v3.py
+++ b/zarr/tests/test_core_v3.py
@@ -70,7 +70,7 @@ class TestArrayWithPathV3(TestArrayWithPath):
         assert '/' + path == a.name  # TODO: should this include meta/root?
         assert 'bar' == a.basename
         assert store is a.store
-        assert "ee4a373f919c842589ace4fc6b787818d7668134" == a.hexdigest()
+        assert "5eaa4f7f3e9035677c52cf32d4cd68db6bb92960" == a.hexdigest()
 
         # store not initialized
         store = KVStoreV3(dict())
@@ -186,11 +186,11 @@ class TestArrayWithPathV3(TestArrayWithPath):
 
     def expected(self):
         return [
-            "7ff7c75be0c73c41f2c3624043bbdc730fa49f92",
-            "5821d73290a1bddc7626157724b8f4e86c7b519e",
-            "d27383c79f67bc30d98f80842075c714971615a4",
-            "f139aea7b4803e7fcae84fdf665efeb90f93c2ae",
-            "7101c03c6e3b44b03721fa1fb036e9a06504c985",
+            "46f1c7f9f147791b18bc8a6ca39a0d6059368a53",
+            "2ebe1ed1164f79f7316cbca7fc855b99d108c34e",
+            "2b9ea26a23611be10cd4e2580fc0a9a80c001774",
+            "ef95d7af1e4edb37617c829846baeac4945785ba",
+            "8240cf3457152da3f66570abd6473f0f8d897532",
         ]
 
     def test_hexdigest(self):
@@ -260,25 +260,25 @@ class TestArrayWithChunkStoreV3(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert '4e0d65f8efa798f333046dd27b92cf6f91e56bb4' == z.hexdigest()
+        assert '96c2331a54c15e7202109776dbd6b6c873529b87' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert '35256359d69449a8d1401ba4121186b954040b7d' == z.hexdigest()
+        assert '328cfb5c543c63c568c7d5389019e213aed65b2d' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert 'd48c530d3f85c3a481f720da447e56d346e17418' == z.hexdigest()
+        assert '1b22df0382fc540bc331b7703378acf45bcfbd6f' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert 'be71f6d22910ced92930ae7ff8b510b13c706f45' == z.hexdigest()
+        assert '8c234d8df5b1119060b1eb08d925b69d825700e4' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert 'aaf4c6f173b80c6214d697b35590ab0cd6330519' == z.hexdigest()
+        assert '4e9c7e90d01984345d0e12e904e949b545886eb0' == z.hexdigest()
 
     def test_nbytes_stored(self):
 
@@ -346,11 +346,11 @@ class TestArrayWithNestedDirectoryStoreV3(TestArrayWithDirectoryStoreV3):
 
     def expected(self):
         return [
-            "7ff7c75be0c73c41f2c3624043bbdc730fa49f92",
-            "5821d73290a1bddc7626157724b8f4e86c7b519e",
-            "d27383c79f67bc30d98f80842075c714971615a4",
-            "f139aea7b4803e7fcae84fdf665efeb90f93c2ae",
-            "7101c03c6e3b44b03721fa1fb036e9a06504c985",
+            "46f1c7f9f147791b18bc8a6ca39a0d6059368a53",
+            "2ebe1ed1164f79f7316cbca7fc855b99d108c34e",
+            "2b9ea26a23611be10cd4e2580fc0a9a80c001774",
+            "ef95d7af1e4edb37617c829846baeac4945785ba",
+            "8240cf3457152da3f66570abd6473f0f8d897532",
         ]
 
 
@@ -641,11 +641,11 @@ class TestArrayWithFSStoreV3(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
-            "35256359d69449a8d1401ba4121186b954040b7d",
-            "d48c530d3f85c3a481f720da447e56d346e17418",
-            "be71f6d22910ced92930ae7ff8b510b13c706f45",
-            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
+            "96c2331a54c15e7202109776dbd6b6c873529b87",
+            "328cfb5c543c63c568c7d5389019e213aed65b2d",
+            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
+            "8c234d8df5b1119060b1eb08d925b69d825700e4",
+            "4e9c7e90d01984345d0e12e904e949b545886eb0",
         ]
 
     def test_hexdigest(self):
@@ -701,11 +701,11 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
-        assert "4e0d65f8efa798f333046dd27b92cf6f91e56bb4" == z.hexdigest()
+        assert "96c2331a54c15e7202109776dbd6b6c873529b87" == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
-        assert "35256359d69449a8d1401ba4121186b954040b7d" == z.hexdigest()
+        assert "328cfb5c543c63c568c7d5389019e213aed65b2d" == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(
@@ -716,17 +716,17 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
             chunks=10,
             dtype="<i4",
         )
-        assert "d48c530d3f85c3a481f720da447e56d346e17418" == z.hexdigest()
+        assert "1b22df0382fc540bc331b7703378acf45bcfbd6f" == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z[200:400] = np.arange(200, 400, dtype="i4")
-        assert "be71f6d22910ced92930ae7ff8b510b13c706f45" == z.hexdigest()
+        assert "8c234d8df5b1119060b1eb08d925b69d825700e4" == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z.attrs["foo"] = "bar"
-        assert "aaf4c6f173b80c6214d697b35590ab0cd6330519" == z.hexdigest()
+        assert "4e9c7e90d01984345d0e12e904e949b545886eb0" == z.hexdigest()
 
     def test_non_cont(self):
         z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
@@ -772,11 +772,11 @@ class TestArrayWithFSStoreV3Nested(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
-            "35256359d69449a8d1401ba4121186b954040b7d",
-            "d48c530d3f85c3a481f720da447e56d346e17418",
-            "be71f6d22910ced92930ae7ff8b510b13c706f45",
-            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
+            "96c2331a54c15e7202109776dbd6b6c873529b87",
+            "328cfb5c543c63c568c7d5389019e213aed65b2d",
+            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
+            "8c234d8df5b1119060b1eb08d925b69d825700e4",
+            "4e9c7e90d01984345d0e12e904e949b545886eb0",
         ]
 
     def test_hexdigest(self):
@@ -832,11 +832,11 @@ class TestArrayWithFSStoreV3NestedPartialRead(TestArrayWithPathV3):
 
     def expected(self):
         return [
-            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
-            "35256359d69449a8d1401ba4121186b954040b7d",
-            "d48c530d3f85c3a481f720da447e56d346e17418",
-            "be71f6d22910ced92930ae7ff8b510b13c706f45",
-            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
+            "96c2331a54c15e7202109776dbd6b6c873529b87",
+            "328cfb5c543c63c568c7d5389019e213aed65b2d",
+            "1b22df0382fc540bc331b7703378acf45bcfbd6f",
+            "8c234d8df5b1119060b1eb08d925b69d825700e4",
+            "4e9c7e90d01984345d0e12e904e949b545886eb0",
         ]
 
     def test_hexdigest(self):

--- a/zarr/tests/test_core_v3.py
+++ b/zarr/tests/test_core_v3.py
@@ -70,7 +70,7 @@ class TestArrayWithPathV3(TestArrayWithPath):
         assert '/' + path == a.name  # TODO: should this include meta/root?
         assert 'bar' == a.basename
         assert store is a.store
-        assert "402b6d5509c264ef9f0a881007300a39d27c4990" == a.hexdigest()
+        assert "ee4a373f919c842589ace4fc6b787818d7668134" == a.hexdigest()
 
         # store not initialized
         store = KVStoreV3(dict())
@@ -186,11 +186,11 @@ class TestArrayWithPathV3(TestArrayWithPath):
 
     def expected(self):
         return [
-            "b3c57672933da371618596f48d87c2c1bdf76445",
-            "a71e05a0356c4c03418fb08b036238bad7c92a70",
-            "1d89bc519dbdbf8457569fc9f95f621da00294be",
-            "c5247a55edb89fe36105e2b46009d2a123de38a5",
-            "011965beb88874e928cfedcad9918418d9b37be5",
+            "7ff7c75be0c73c41f2c3624043bbdc730fa49f92",
+            "5821d73290a1bddc7626157724b8f4e86c7b519e",
+            "d27383c79f67bc30d98f80842075c714971615a4",
+            "f139aea7b4803e7fcae84fdf665efeb90f93c2ae",
+            "7101c03c6e3b44b03721fa1fb036e9a06504c985",
         ]
 
     def test_hexdigest(self):
@@ -260,25 +260,25 @@ class TestArrayWithChunkStoreV3(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
-        assert '86004b83376cb08536689d53f29ae44a5a2d931f' == z.hexdigest()
+        assert '4e0d65f8efa798f333046dd27b92cf6f91e56bb4' == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype='<f4')
-        assert '2add13ba6be94522a3c6627a06556f0525c4b8bf' == z.hexdigest()
+        assert '35256359d69449a8d1401ba4121186b954040b7d' == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(shape=(20, 35,), chunks=10, dtype='<i4')
-        assert 'e2fea56c53fbdecc666d48ed1ef49d69538544d1' == z.hexdigest()
+        assert 'd48c530d3f85c3a481f720da447e56d346e17418' == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z[200:400] = np.arange(200, 400, dtype='i4')
-        assert '065de6123cbbfd46690b305ced6e4465cf5ff639' == z.hexdigest()
+        assert 'be71f6d22910ced92930ae7ff8b510b13c706f45' == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype='<i4')
         z.attrs['foo'] = 'bar'
-        assert '62a467fd8ff6fed7c422cc5214c311af04437b8d' == z.hexdigest()
+        assert 'aaf4c6f173b80c6214d697b35590ab0cd6330519' == z.hexdigest()
 
     def test_nbytes_stored(self):
 
@@ -346,11 +346,11 @@ class TestArrayWithNestedDirectoryStoreV3(TestArrayWithDirectoryStoreV3):
 
     def expected(self):
         return [
-            "b3c57672933da371618596f48d87c2c1bdf76445",
-            "a71e05a0356c4c03418fb08b036238bad7c92a70",
-            "1d89bc519dbdbf8457569fc9f95f621da00294be",
-            "c5247a55edb89fe36105e2b46009d2a123de38a5",
-            "011965beb88874e928cfedcad9918418d9b37be5",
+            "7ff7c75be0c73c41f2c3624043bbdc730fa49f92",
+            "5821d73290a1bddc7626157724b8f4e86c7b519e",
+            "d27383c79f67bc30d98f80842075c714971615a4",
+            "f139aea7b4803e7fcae84fdf665efeb90f93c2ae",
+            "7101c03c6e3b44b03721fa1fb036e9a06504c985",
         ]
 
 
@@ -641,11 +641,11 @@ class TestArrayWithFSStoreV3(TestArrayWithPathV3):
 
     def expected(self):
         return [
-           "86004b83376cb08536689d53f29ae44a5a2d931f",
-           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
-           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
-           "065de6123cbbfd46690b305ced6e4465cf5ff639",
-           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
+            "35256359d69449a8d1401ba4121186b954040b7d",
+            "d48c530d3f85c3a481f720da447e56d346e17418",
+            "be71f6d22910ced92930ae7ff8b510b13c706f45",
+            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
         ]
 
     def test_hexdigest(self):
@@ -701,11 +701,11 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
     def test_hexdigest(self):
         # Check basic 1-D array
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
-        assert "86004b83376cb08536689d53f29ae44a5a2d931f" == z.hexdigest()
+        assert "4e0d65f8efa798f333046dd27b92cf6f91e56bb4" == z.hexdigest()
 
         # Check basic 1-D array with different type
         z = self.create_array(shape=(1050,), chunks=100, dtype="<f4")
-        assert "2add13ba6be94522a3c6627a06556f0525c4b8bf" == z.hexdigest()
+        assert "35256359d69449a8d1401ba4121186b954040b7d" == z.hexdigest()
 
         # Check basic 2-D array
         z = self.create_array(
@@ -716,17 +716,17 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithPathV3):
             chunks=10,
             dtype="<i4",
         )
-        assert "e2fea56c53fbdecc666d48ed1ef49d69538544d1" == z.hexdigest()
+        assert "d48c530d3f85c3a481f720da447e56d346e17418" == z.hexdigest()
 
         # Check basic 1-D array with some data
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z[200:400] = np.arange(200, 400, dtype="i4")
-        assert "065de6123cbbfd46690b305ced6e4465cf5ff639" == z.hexdigest()
+        assert "be71f6d22910ced92930ae7ff8b510b13c706f45" == z.hexdigest()
 
         # Check basic 1-D array with attributes
         z = self.create_array(shape=(1050,), chunks=100, dtype="<i4")
         z.attrs["foo"] = "bar"
-        assert "62a467fd8ff6fed7c422cc5214c311af04437b8d" == z.hexdigest()
+        assert "aaf4c6f173b80c6214d697b35590ab0cd6330519" == z.hexdigest()
 
     def test_non_cont(self):
         z = self.create_array(shape=(500, 500, 500), chunks=(50, 50, 50), dtype="<i4")
@@ -772,11 +772,11 @@ class TestArrayWithFSStoreV3Nested(TestArrayWithPathV3):
 
     def expected(self):
         return [
-           "86004b83376cb08536689d53f29ae44a5a2d931f",
-           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
-           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
-           "065de6123cbbfd46690b305ced6e4465cf5ff639",
-           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
+            "35256359d69449a8d1401ba4121186b954040b7d",
+            "d48c530d3f85c3a481f720da447e56d346e17418",
+            "be71f6d22910ced92930ae7ff8b510b13c706f45",
+            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
         ]
 
     def test_hexdigest(self):
@@ -832,11 +832,11 @@ class TestArrayWithFSStoreV3NestedPartialRead(TestArrayWithPathV3):
 
     def expected(self):
         return [
-           "86004b83376cb08536689d53f29ae44a5a2d931f",
-           "2add13ba6be94522a3c6627a06556f0525c4b8bf",
-           "e2fea56c53fbdecc666d48ed1ef49d69538544d1",
-           "065de6123cbbfd46690b305ced6e4465cf5ff639",
-           "62a467fd8ff6fed7c422cc5214c311af04437b8d",
+            "4e0d65f8efa798f333046dd27b92cf6f91e56bb4",
+            "35256359d69449a8d1401ba4121186b954040b7d",
+            "d48c530d3f85c3a481f720da447e56d346e17418",
+            "be71f6d22910ced92930ae7ff8b510b13c706f45",
+            "aaf4c6f173b80c6214d697b35590ab0cd6330519",
         ]
 
     def test_hexdigest(self):

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -15,7 +15,7 @@ from zarr.creation import (array, create, empty, empty_like, full, full_like,
                            zeros_like)
 from zarr.hierarchy import open_group
 from zarr.n5 import N5Store
-from zarr.storage import DirectoryStore, KVStore
+from zarr.storage import DirectoryStore, DirectoryStoreV3, KVStore, KVStoreV3
 from zarr.sync import ThreadSynchronizer
 
 
@@ -47,24 +47,36 @@ class MockH5pyDataset:
         return self.data[item]
 
 
-def test_array():
+def _init_creation_kwargs(zarr_version):
+    kwargs = {'zarr_version': zarr_version}
+    if zarr_version == 3:
+        kwargs['path'] = 'array'
+    return kwargs
+
+
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_array(zarr_version):
+
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
+    kwargs = _init_creation_kwargs(zarr_version)
 
     # with numpy array
     a = np.arange(100)
-    z = array(a, chunks=10)
+    z = array(a, chunks=10, **kwargs)
     assert a.shape == z.shape
     assert a.dtype == z.dtype
+    assert z._store._store_version == expected_zarr_version
     assert_array_equal(a, z[:])
 
     # with array-like
     a = list(range(100))
-    z = array(a, chunks=10)
+    z = array(a, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert np.asarray(a).dtype == z.dtype
     assert_array_equal(np.asarray(a), z[:])
 
     # with another zarr array
-    z2 = array(z)
+    z2 = array(z, **kwargs)
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
@@ -74,73 +86,86 @@ def test_array():
 
     b = np.arange(1000).reshape(100, 10)
     c = MockBcolzArray(b, 10)
-    z3 = array(c)
+    z3 = array(c, **kwargs)
     assert c.shape == z3.shape
     assert (10, 10) == z3.chunks
 
     b = np.arange(1000).reshape(100, 10)
     c = MockH5pyDataset(b, chunks=(10, 2))
-    z4 = array(c)
+    z4 = array(c, **kwargs)
     assert c.shape == z4.shape
     assert (10, 2) == z4.chunks
 
     c = MockH5pyDataset(b, chunks=None)
-    z5 = array(c)
+    z5 = array(c, **kwargs)
     assert c.shape == z5.shape
     assert isinstance(z5.chunks, tuple)
 
     # with dtype=None
     a = np.arange(100, dtype='i4')
-    z = array(a, dtype=None)
+    z = array(a, dtype=None, **kwargs)
     assert_array_equal(a[:], z[:])
     assert a.dtype == z.dtype
 
     # with dtype=something else
     a = np.arange(100, dtype='i4')
-    z = array(a, dtype='i8')
+    z = array(a, dtype='i8', **kwargs)
     assert_array_equal(a[:], z[:])
     assert np.dtype('i8') == z.dtype
 
 
-def test_empty():
-    z = empty(100, chunks=10)
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_empty(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    z = empty(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
 
 
-def test_zeros():
-    z = zeros(100, chunks=10)
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_zeros(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    z = zeros(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.zeros(100), z[:])
 
 
-def test_ones():
-    z = ones(100, chunks=10)
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_ones(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    z = ones(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.ones(100), z[:])
 
 
-def test_full():
-    z = full(100, chunks=10, fill_value=42, dtype='i4')
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_full(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    z = full(100, chunks=10, fill_value=42, dtype='i4', **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42, dtype='i4'), z[:])
 
     # nan
-    z = full(100, chunks=10, fill_value=np.nan, dtype='f8')
+    z = full(100, chunks=10, fill_value=np.nan, dtype='f8', **kwargs)
     assert np.all(np.isnan(z[:]))
 
+
+@pytest.mark.parametrize('zarr_version', [None, 2])
+def test_full_additional_dtypes(zarr_version):
+    """Test additional types that aren't part of the base v3 spec."""
+    kwargs = _init_creation_kwargs(zarr_version)
     # NaT
-    z = full(100, chunks=10, fill_value='NaT', dtype='M8[s]')
+    z = full(100, chunks=10, fill_value='NaT', dtype='M8[s]', **kwargs)
     assert np.all(np.isnat(z[:]))
-    z = full(100, chunks=10, fill_value='NaT', dtype='m8[s]')
+    z = full(100, chunks=10, fill_value='NaT', dtype='m8[s]', **kwargs)
     assert np.all(np.isnat(z[:]))
 
     # byte string dtype
     v = b'xxx'
-    z = full(100, chunks=10, fill_value=v, dtype='S3')
+    z = full(100, chunks=10, fill_value=v, dtype='S3', **kwargs)
     assert v == z[0]
     a = z[...]
     assert z.dtype == a.dtype
@@ -149,7 +174,7 @@ def test_full():
 
     # unicode string dtype
     v = 'xxx'
-    z = full(100, chunks=10, fill_value=v, dtype='U3')
+    z = full(100, chunks=10, fill_value=v, dtype='U3', **kwargs)
     assert v == z[0]
     a = z[...]
     assert z.dtype == a.dtype
@@ -162,37 +187,51 @@ def test_full():
         full(100, chunks=10, fill_value=v, dtype='U3')
 
 
-def test_open_array():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_open_array(zarr_version):
 
     store = 'data/array.zarr'
+    kwargs = _init_creation_kwargs(zarr_version)
 
     # mode == 'w'
-    z = open_array(store, mode='w', shape=100, chunks=10)
+    z = open_array(store, mode='w', shape=100, chunks=10, **kwargs)
     z[:] = 42
     assert isinstance(z, Array)
-    assert isinstance(z.store, DirectoryStore)
+    if z._store._store_version == 2:
+        assert isinstance(z.store, DirectoryStore)
+    else:
+        assert isinstance(z.store, DirectoryStoreV3)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
 
     # mode in 'r', 'r+'
-    open_group('data/group.zarr', mode='w')
+    group_kwargs = kwargs.copy()
+    if zarr_version == 3:
+        group_kwargs['path'] = 'group'
+    open_group('data/group.zarr', mode='w', **group_kwargs)
     for mode in 'r', 'r+':
         with pytest.raises(ValueError):
             open_array('doesnotexist', mode=mode)
         with pytest.raises(ValueError):
             open_array('data/group.zarr', mode=mode)
-    z = open_array(store, mode='r')
+    z = open_array(store, mode='r', **kwargs)
     assert isinstance(z, Array)
-    assert isinstance(z.store, DirectoryStore)
+    if z._store._store_version == 2:
+        assert isinstance(z.store, DirectoryStore)
+    else:
+        assert isinstance(z.store, DirectoryStoreV3)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
     with pytest.raises(PermissionError):
         z[:] = 43
-    z = open_array(store, mode='r+')
+    z = open_array(store, mode='r+', **kwargs)
     assert isinstance(z, Array)
-    assert isinstance(z.store, DirectoryStore)
+    if z._store._store_version == 2:
+        assert isinstance(z.store, DirectoryStore)
+    else:
+        assert isinstance(z.store, DirectoryStoreV3)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
@@ -201,51 +240,75 @@ def test_open_array():
 
     # mode == 'a'
     shutil.rmtree(store)
-    z = open_array(store, mode='a', shape=100, chunks=10)
+    z = open_array(store, mode='a', shape=100, chunks=10, **kwargs)
     z[:] = 42
     assert isinstance(z, Array)
-    assert isinstance(z.store, DirectoryStore)
+    if z._store._store_version == 2:
+        assert isinstance(z.store, DirectoryStore)
+    else:
+        assert isinstance(z.store, DirectoryStoreV3)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
-    with pytest.raises(ValueError):
-        open_array('data/group.zarr', mode='a')
+
+    expected_error = TypeError if zarr_version == 3 else ValueError
+    # v3 path does not conflict, but will raise TypeError without shape kwarg
+    with pytest.raises(expected_error):
+        # array would end up at data/group.zarr/meta/root/array.array.json
+        open_array('data/group.zarr', mode='a', **kwargs)
 
     # mode in 'w-', 'x'
     for mode in 'w-', 'x':
         shutil.rmtree(store)
-        z = open_array(store, mode=mode, shape=100, chunks=10)
+        z = open_array(store, mode=mode, shape=100, chunks=10, **kwargs)
         z[:] = 42
         assert isinstance(z, Array)
-        assert isinstance(z.store, DirectoryStore)
+        if z._store._store_version == 2:
+            assert isinstance(z.store, DirectoryStore)
+        else:
+            assert isinstance(z.store, DirectoryStoreV3)
         assert (100,) == z.shape
         assert (10,) == z.chunks
         assert_array_equal(np.full(100, fill_value=42), z[:])
         with pytest.raises(ValueError):
-            open_array(store, mode=mode)
-        with pytest.raises(ValueError):
-            open_array('data/group.zarr', mode=mode)
+            open_array(store, mode=mode, **kwargs)
+        expected_error = TypeError if zarr_version == 3 else ValueError
+        # v3 path does not conflict, but will raise TypeError without shape kwarg
+        with pytest.raises(expected_error):
+            open_array('data/group.zarr', mode=mode, **kwargs)
 
     # with synchronizer
-    z = open_array(store, synchronizer=ThreadSynchronizer())
+    z = open_array(store, synchronizer=ThreadSynchronizer(), **kwargs)
     assert isinstance(z, Array)
 
     # with path
-    z = open_array(store, shape=100, path='foo/bar', mode='w')
+    kwargs_no_path = kwargs.copy()
+    kwargs_no_path.pop('path', None)
+    z = open_array(store, shape=100, path='foo/bar', mode='w',
+                   **kwargs_no_path)
     assert isinstance(z, Array)
     assert 'foo/bar' == z.path
 
     # with chunk store
     meta_store = 'data/meta.zarr'
     chunk_store = 'data/chunks.zarr'
-    z = open_array(store=meta_store, chunk_store=chunk_store, shape=11, mode='w')
+    z = open_array(store=meta_store, chunk_store=chunk_store, shape=11,
+                   mode='w', **kwargs)
     z[:] = 42
     assert os.path.abspath(meta_store) == z.store.path
     assert os.path.abspath(chunk_store) == z.chunk_store.path
 
+
+# TODO: N5 support for v3
+@pytest.mark.parametrize('zarr_version', [None, 2])
+def test_open_array_n5(zarr_version):
+
+    store = 'data/array.zarr'
+    kwargs = _init_creation_kwargs(zarr_version)
+
     # for N5 store
     store = 'data/array.n5'
-    z = open_array(store, mode='w', shape=100, chunks=10)
+    z = open_array(store, mode='w', shape=100, chunks=10, **kwargs)
     z[:] = 42
     assert isinstance(z, Array)
     assert isinstance(z.store, N5Store)
@@ -254,7 +317,10 @@ def test_open_array():
     assert_array_equal(np.full(100, fill_value=42), z[:])
 
     store = 'data/group.n5'
-    z = open_group(store, mode='w')
+    group_kwargs = kwargs.copy()
+    if zarr_version == 3:
+        group_kwargs['path'] = 'group'
+    z = open_group(store, mode='w', **group_kwargs)
     i = z.create_group('inner')
     a = i.zeros("array", shape=100, chunks=10)
     a[:] = 42
@@ -264,7 +330,7 @@ def test_open_array():
         o.write("{}")
 
     # Re-open
-    a = open_group(store)["inner"]["array"]
+    a = open_group(store, **group_kwargs)["inner"]["array"]
     assert isinstance(a, Array)
     assert isinstance(z.store, N5Store)
     assert (100,) == a.shape
@@ -272,140 +338,181 @@ def test_open_array():
     assert_array_equal(np.full(100, fill_value=42), a[:])
 
 
-def test_open_array_dict_store():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_open_array_dict_store(zarr_version):
 
     # dict will become a KVStore
     store = dict()
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_store_type = KVStoreV3 if zarr_version == 3 else KVStore
 
     # mode == 'w'
-    z = open_array(store, mode='w', shape=100, chunks=10)
+    z = open_array(store, mode='w', shape=100, chunks=10, **kwargs)
     z[:] = 42
     assert isinstance(z, Array)
-    assert isinstance(z.store, KVStore)
+    assert isinstance(z.store, expected_store_type)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert_array_equal(np.full(100, fill_value=42), z[:])
 
 
-def test_create_in_dict():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_create_in_dict(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_store_type = KVStoreV3 if zarr_version == 3 else KVStore
+
     for func in [empty, zeros, ones]:
-        a = func(100, store=dict())
-        assert isinstance(a.store, KVStore)
+        a = func(100, store=dict(), **kwargs)
+        assert isinstance(a.store, expected_store_type)
 
-    a = full(100, 5, store=dict())
-    assert isinstance(a.store, KVStore)
+    a = full(100, 5, store=dict(), **kwargs)
+    assert isinstance(a.store, expected_store_type)
 
 
-def test_empty_like():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_empty_like(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
 
     # zarr array
     z = empty(100, chunks=10, dtype='f4', compressor=Zlib(5),
-              order='F')
-    z2 = empty_like(z)
+              order='F', **kwargs)
+    # zarr_version will be inferred from z, but have to specify a path in v3
+    z2 = empty_like(z, path=kwargs.get('path', None))
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
     assert z.compressor.get_config() == z2.compressor.get_config()
     assert z.fill_value == z2.fill_value
     assert z.order == z2.order
+    assert (z._store._store_version == z2._store._store_version ==
+            expected_zarr_version)
 
     # numpy array
     a = np.empty(100, dtype='f4')
-    z3 = empty_like(a)
+    z3 = empty_like(a, **kwargs)
     assert a.shape == z3.shape
     assert (100,) == z3.chunks
     assert a.dtype == z3.dtype
     assert z3.fill_value is None
+    assert z3._store._store_version == expected_zarr_version
 
     # something slightly silly
     a = [0] * 100
-    z3 = empty_like(a, shape=200)
+    z3 = empty_like(a, shape=200, **kwargs)
     assert (200,) == z3.shape
 
     # other array-likes
     b = np.arange(1000).reshape(100, 10)
     c = MockBcolzArray(b, 10)
-    z = empty_like(c)
+    z = empty_like(c, **kwargs)
     assert b.shape == z.shape
     assert (10, 10) == z.chunks
     c = MockH5pyDataset(b, chunks=(10, 2))
-    z = empty_like(c)
+    z = empty_like(c, **kwargs)
     assert b.shape == z.shape
     assert (10, 2) == z.chunks
     c = MockH5pyDataset(b, chunks=None)
-    z = empty_like(c)
+    z = empty_like(c, **kwargs)
     assert b.shape == z.shape
     assert isinstance(z.chunks, tuple)
 
 
-def test_zeros_like():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_zeros_like(zarr_version):
+
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
+
     # zarr array
     z = zeros(100, chunks=10, dtype='f4', compressor=Zlib(5),
-              order='F')
-    z2 = zeros_like(z)
+              order='F', **kwargs)
+    z2 = zeros_like(z, path=kwargs.get('path', None))
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
     assert z.compressor.get_config() == z2.compressor.get_config()
     assert z.fill_value == z2.fill_value
     assert z.order == z2.order
+    assert (z._store._store_version == z2._store._store_version ==
+            expected_zarr_version)
     # numpy array
     a = np.empty(100, dtype='f4')
-    z3 = zeros_like(a, chunks=10)
+    z3 = zeros_like(a, chunks=10, **kwargs)
     assert a.shape == z3.shape
     assert (10,) == z3.chunks
     assert a.dtype == z3.dtype
     assert 0 == z3.fill_value
 
 
-def test_ones_like():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_ones_like(zarr_version):
+
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
+
     # zarr array
     z = ones(100, chunks=10, dtype='f4', compressor=Zlib(5),
-             order='F')
-    z2 = ones_like(z)
+             order='F', **kwargs)
+    z2 = ones_like(z, path=kwargs.get('path', None))
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
     assert z.compressor.get_config() == z2.compressor.get_config()
     assert z.fill_value == z2.fill_value
     assert z.order == z2.order
+    assert (z._store._store_version == z2._store._store_version ==
+            expected_zarr_version)
     # numpy array
     a = np.empty(100, dtype='f4')
-    z3 = ones_like(a, chunks=10)
+    z3 = ones_like(a, chunks=10, **kwargs)
     assert a.shape == z3.shape
     assert (10,) == z3.chunks
     assert a.dtype == z3.dtype
     assert 1 == z3.fill_value
+    assert z3._store._store_version == expected_zarr_version
 
 
-def test_full_like():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_full_like(zarr_version):
+
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
+
     z = full(100, chunks=10, dtype='f4', compressor=Zlib(5),
-             fill_value=42, order='F')
-    z2 = full_like(z)
+             fill_value=42, order='F', **kwargs)
+    z2 = full_like(z, path=kwargs.get('path', None))
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
     assert z.compressor.get_config() == z2.compressor.get_config()
     assert z.fill_value == z2.fill_value
     assert z.order == z2.order
+    assert (z._store._store_version == z2._store._store_version ==
+            expected_zarr_version)
     # numpy array
     a = np.empty(100, dtype='f4')
-    z3 = full_like(a, chunks=10, fill_value=42)
+    z3 = full_like(a, chunks=10, fill_value=42, **kwargs)
     assert a.shape == z3.shape
     assert (10,) == z3.chunks
     assert a.dtype == z3.dtype
     assert 42 == z3.fill_value
+    assert z3._store._store_version == expected_zarr_version
     with pytest.raises(TypeError):
         # fill_value missing
-        full_like(a, chunks=10)
+        full_like(a, chunks=10, **kwargs)
 
 
-def test_open_like():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_open_like(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
+
     # zarr array
     path = tempfile.mktemp()
     atexit.register(shutil.rmtree, path)
     z = full(100, chunks=10, dtype='f4', compressor=Zlib(5),
-             fill_value=42, order='F')
+             fill_value=42, order='F', **kwargs)
     z2 = open_like(z, path)
     assert z.shape == z2.shape
     assert z.chunks == z2.chunks
@@ -413,31 +520,38 @@ def test_open_like():
     assert z.compressor.get_config() == z2.compressor.get_config()
     assert z.fill_value == z2.fill_value
     assert z.order == z2.order
+    assert (z._store._store_version == z2._store._store_version ==
+            expected_zarr_version)
     # numpy array
     path = tempfile.mktemp()
     atexit.register(shutil.rmtree, path)
     a = np.empty(100, dtype='f4')
-    z3 = open_like(a, path, chunks=10)
+    z3 = open_like(a, path, chunks=10, zarr_version=zarr_version)
     assert a.shape == z3.shape
     assert (10,) == z3.chunks
     assert a.dtype == z3.dtype
     assert 0 == z3.fill_value
+    assert z3._store._store_version == expected_zarr_version
 
 
-def test_create():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_create(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
+    expected_zarr_version = 2 if zarr_version is None else zarr_version
 
     # defaults
-    z = create(100)
+    z = create(100, **kwargs)
     assert isinstance(z, Array)
     assert (100,) == z.shape
     assert (100,) == z.chunks  # auto-chunks
     assert np.dtype(None) == z.dtype
     assert 'blosc' == z.compressor.codec_id
     assert 0 == z.fill_value
+    assert z._store._store_version == expected_zarr_version
 
     # all specified
     z = create(100, chunks=10, dtype='i4', compressor=Zlib(1),
-               fill_value=42, order='F')
+               fill_value=42, order='F', **kwargs)
     assert isinstance(z, Array)
     assert (100,) == z.shape
     assert (10,) == z.chunks
@@ -446,82 +560,91 @@ def test_create():
     assert 1 == z.compressor.level
     assert 42 == z.fill_value
     assert 'F' == z.order
+    assert z._store._store_version == expected_zarr_version
 
     # with synchronizer
     synchronizer = ThreadSynchronizer()
-    z = create(100, chunks=10, synchronizer=synchronizer)
+    z = create(100, chunks=10, synchronizer=synchronizer, **kwargs)
     assert isinstance(z, Array)
     assert (100,) == z.shape
     assert (10,) == z.chunks
     assert synchronizer is z.synchronizer
+    assert z._store._store_version == expected_zarr_version
 
     # don't allow string as compressor arg
     with pytest.raises(ValueError):
-        create(100, chunks=10, compressor='zlib')
+        create(100, chunks=10, compressor='zlib', **kwargs)
 
     # h5py compatibility
 
-    z = create(100, compression='zlib', compression_opts=9)
+    z = create(100, compression='zlib', compression_opts=9, **kwargs)
     assert 'zlib' == z.compressor.codec_id
     assert 9 == z.compressor.level
 
-    z = create(100, compression='default')
+    z = create(100, compression='default', **kwargs)
     assert 'blosc' == z.compressor.codec_id
 
     # errors
     with pytest.raises(ValueError):
         # bad compression argument
-        create(100, compression=1)
+        create(100, compression=1, **kwargs)
     with pytest.raises(ValueError):
         # bad fill value
-        create(100, dtype='i4', fill_value='foo')
+        create(100, dtype='i4', fill_value='foo', **kwargs)
 
     # auto chunks
-    z = create(1000000000, chunks=True)
+    z = create(1000000000, chunks=True, **kwargs)
     assert z.chunks[0] < z.shape[0]
-    z = create(1000000000, chunks=None)  # backwards-compatibility
+    z = create(1000000000, chunks=None, **kwargs)  # backwards-compatibility
     assert z.chunks[0] < z.shape[0]
     # no chunks
-    z = create(1000000000, chunks=False)
+    z = create(1000000000, chunks=False, **kwargs)
     assert z.chunks == z.shape
 
 
-def test_compression_args():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_compression_args(zarr_version):
+    kwargs = _init_creation_kwargs(zarr_version)
 
     with warnings.catch_warnings():
         warnings.simplefilter("default")
-        z = create(100, compression="zlib", compression_opts=9)
+        z = create(100, compression="zlib", compression_opts=9, **kwargs)
         assert isinstance(z, Array)
         assert "zlib" == z.compressor.codec_id
         assert 9 == z.compressor.level
 
         # 'compressor' overrides 'compression'
         with pytest.warns(UserWarning):
-            z = create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+            z = create(100, compressor=Zlib(9), compression="bz2",
+                       compression_opts=1, **kwargs)
         assert isinstance(z, Array)
         assert "zlib" == z.compressor.codec_id
         assert 9 == z.compressor.level
 
         # 'compressor' ignores 'compression_opts'
         with pytest.warns(UserWarning):
-            z = create(100, compressor=Zlib(9), compression_opts=1)
+            z = create(100, compressor=Zlib(9), compression_opts=1, **kwargs)
         assert isinstance(z, Array)
         assert "zlib" == z.compressor.codec_id
         assert 9 == z.compressor.level
 
         with pytest.warns(UserWarning):
             # 'compressor' overrides 'compression'
-            create(100, compressor=Zlib(9), compression="bz2", compression_opts=1)
+            create(100, compressor=Zlib(9), compression="bz2",
+                   compression_opts=1, **kwargs)
         with pytest.warns(UserWarning):
             # 'compressor' ignores 'compression_opts'
-            create(100, compressor=Zlib(9), compression_opts=1)
+            create(100, compressor=Zlib(9), compression_opts=1, **kwargs)
 
 
-def test_create_read_only():
+@pytest.mark.parametrize('zarr_version', [None, 2, 3])
+def test_create_read_only(zarr_version):
     # https://github.com/alimanfoo/zarr/issues/151
 
+    kwargs = _init_creation_kwargs(zarr_version)
+
     # create an array initially read-only, then enable writing
-    z = create(100, read_only=True)
+    z = create(100, read_only=True, **kwargs)
     assert z.read_only
     with pytest.raises(PermissionError):
         z[:] = 42
@@ -535,7 +658,7 @@ def test_create_read_only():
     # this is subtly different, but here we want to create an array with data, and then
     # have it be read-only
     a = np.arange(100)
-    z = array(a, read_only=True)
+    z = array(a, read_only=True, **kwargs)
     assert_array_equal(a, z[...])
     assert z.read_only
     with pytest.raises(PermissionError):

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -27,6 +27,10 @@ from zarr.storage import (ABSStore, DBMStore, KVStore, DirectoryStore, FSStore,
                           NestedDirectoryStore, SQLiteStore, ZipStore,
                           array_meta_key, atexit_rmglob, atexit_rmtree,
                           group_meta_key, init_array, init_group)
+from zarr.storage import (KVStoreV3, DirectoryStoreV3,  # MemoryStoreV3
+                          FSStoreV3, NestedDirectoryStoreV3, ZipStoreV3,
+                          DBMStoreV3, LMDBStoreV3, SQLiteStoreV3,
+                          LRUStoreCacheV3)
 from zarr.util import InfoReporter
 from zarr.tests.util import skip_test_env_var, have_fsspec, abs_container
 
@@ -96,30 +100,51 @@ class TestGroup(unittest.TestCase):
             Group(store, chunk_store=chunk_store)
         store.close()
 
+    def _subgroup_path(self, group, path):
+        path = path.rstrip('/')
+        absolute = path.startswith('/')
+        if absolute:
+            group_path = path
+        else:
+            if path:
+                group_path = '/'.join([group.path, path])
+            else:
+                group_path = path
+        group_path = group_path.lstrip('/')
+        group_name = '/' + group_path
+        return group_path, group_name
+
     def test_create_group(self):
         g1 = self.create_group()
 
+        if g1._version == 2:
+            path, name = '', '/'
+        else:
+            path, name = 'group', '/group'
         # check root group
-        assert '' == g1.path
-        assert '/' == g1.name
+        assert path == g1.path
+        assert name == g1.name
 
         # create level 1 child group
         g2 = g1.create_group('foo')
+        path, name = self._subgroup_path(g1, 'foo')
         assert isinstance(g2, Group)
-        assert 'foo' == g2.path
-        assert '/foo' == g2.name
+        assert path == g2.path
+        assert name == g2.name
 
         # create level 2 child group
         g3 = g2.create_group('bar')
+        path, name = self._subgroup_path(g2, 'bar')
         assert isinstance(g3, Group)
-        assert 'foo/bar' == g3.path
-        assert '/foo/bar' == g3.name
+        assert path == g3.path
+        assert name == g3.name
 
         # create level 3 child group
         g4 = g1.create_group('foo/bar/baz')
+        path, name = self._subgroup_path(g1, 'foo/bar/baz')
         assert isinstance(g4, Group)
-        assert 'foo/bar/baz' == g4.path
-        assert '/foo/bar/baz' == g4.name
+        assert path == g4.path
+        assert name == g4.name
 
         # create level 3 group via root
         g5 = g4.create_group('/a/b/c/')
@@ -138,17 +163,23 @@ class TestGroup(unittest.TestCase):
 
         o = Foo('test/object')
         go = g1.create_group(o)
+        path, name = self._subgroup_path(g1, str(o))
         assert isinstance(go, Group)
-        assert 'test/object' == go.path
+        assert path == go.path
         go = g1.create_group(b'test/bytes')
+        path, name = self._subgroup_path(g1, 'test/bytes')
         assert isinstance(go, Group)
-        assert 'test/bytes' == go.path
+        assert path == go.path
 
         # test bad keys
         with pytest.raises(ValueError):
             g1.create_group('foo')  # already exists
-        with pytest.raises(ValueError):
-            g1.create_group('a/b/c')  # already exists
+        if g1._version == 2:
+            with pytest.raises(ValueError):
+                g1.create_group('a/b/c')  # already exists
+        elif g1._version == 3:
+            # for v3 'group/a/b/c' does not already exist
+            g1.create_group('a/b/c')
         with pytest.raises(ValueError):
             g4.create_group('/a/b/c')  # already exists
         with pytest.raises(ValueError):
@@ -161,9 +192,9 @@ class TestGroup(unittest.TestCase):
         # multi
         g6, g7 = g1.create_groups('y', 'z')
         assert isinstance(g6, Group)
-        assert g6.path == 'y'
+        assert g6.path == self._subgroup_path(g1, 'y')[0]
         assert isinstance(g7, Group)
-        assert g7.path == 'z'
+        assert g7.path == self._subgroup_path(g1, 'z')[0]
 
         g1.store.close()
 
@@ -172,14 +203,17 @@ class TestGroup(unittest.TestCase):
 
         # test creation
         g2 = g1.require_group('foo')
+        path, name = self._subgroup_path(g1, 'foo')
         assert isinstance(g2, Group)
-        assert 'foo' == g2.path
+        assert path == g2.path
         g3 = g2.require_group('bar')
+        path, name = self._subgroup_path(g2, 'bar')
         assert isinstance(g3, Group)
-        assert 'foo/bar' == g3.path
+        assert path == g3.path
         g4 = g1.require_group('foo/bar/baz')
+        path, name = self._subgroup_path(g1, 'foo/bar/baz')
         assert isinstance(g4, Group)
-        assert 'foo/bar/baz' == g4.path
+        assert path == g4.path
         g5 = g4.require_group('/a/b/c/')
         assert isinstance(g5, Group)
         assert 'a/b/c' == g5.path
@@ -199,33 +233,50 @@ class TestGroup(unittest.TestCase):
         assert g5.store is g5a.store
 
         # test path normalization
-        assert g1.require_group('quux') == g1.require_group('/quux/')
+        if g1._version == 2:
+            # TODO: expected behavior for v3
+            assert g1.require_group('quux') == g1.require_group('/quux/')
 
         # multi
         g6, g7 = g1.require_groups('y', 'z')
         assert isinstance(g6, Group)
-        assert g6.path == 'y'
+        assert g6.path == self._subgroup_path(g1, 'y')[0]
         assert isinstance(g7, Group)
-        assert g7.path == 'z'
+        assert g7.path == self._subgroup_path(g1, 'z')[0]
 
         g1.store.close()
+
+    def _dataset_path(self, group, path):
+        path = path.rstrip('/')
+        absolute = path.startswith('/')
+        if absolute:
+            dataset_path = path
+        else:
+            dataset_path = '/'.join([group.path, path])
+        dataset_path = dataset_path.lstrip('/')
+        dataset_name = '/' + dataset_path
+        return dataset_path, dataset_name
 
     def test_create_dataset(self):
         g = self.create_group()
 
         # create as immediate child
-        d1 = g.create_dataset('foo', shape=1000, chunks=100)
+        dpath = 'foo'
+        d1 = g.create_dataset(dpath, shape=1000, chunks=100)
+        path, name = self._dataset_path(g, dpath)
         assert isinstance(d1, Array)
         assert (1000,) == d1.shape
         assert (100,) == d1.chunks
-        assert 'foo' == d1.path
-        assert '/foo' == d1.name
+        assert path == d1.path
+        assert name == d1.name
         assert g.store is d1.store
 
         # create as descendant
-        d2 = g.create_dataset('/a/b/c/', shape=2000, chunks=200, dtype='i1',
+        dpath = '/a/b/c/'
+        d2 = g.create_dataset(dpath, shape=2000, chunks=200, dtype='i1',
                               compression='zlib', compression_opts=9,
                               fill_value=42, order='F')
+        path, name = self._dataset_path(g, dpath)
         assert isinstance(d2, Array)
         assert (2000,) == d2.shape
         assert (200,) == d2.chunks
@@ -234,20 +285,22 @@ class TestGroup(unittest.TestCase):
         assert 9 == d2.compressor.level
         assert 42 == d2.fill_value
         assert 'F' == d2.order
-        assert 'a/b/c' == d2.path
-        assert '/a/b/c' == d2.name
+        assert path == d2.path
+        assert name == d2.name
         assert g.store is d2.store
 
         # create with data
         data = np.arange(3000, dtype='u2')
-        d3 = g.create_dataset('bar', data=data, chunks=300)
+        dpath = 'bar'
+        d3 = g.create_dataset(dpath, data=data, chunks=300)
+        path, name = self._dataset_path(g, dpath)
         assert isinstance(d3, Array)
         assert (3000,) == d3.shape
         assert (300,) == d3.chunks
         assert np.dtype('u2') == d3.dtype
         assert_array_equal(data, d3[:])
-        assert 'bar' == d3.path
-        assert '/bar' == d3.name
+        assert path == d3.path
+        assert name == d3.name
         assert g.store is d3.store
 
         # compression arguments handling follows...
@@ -290,25 +343,27 @@ class TestGroup(unittest.TestCase):
         g = self.create_group()
 
         # create
-        d1 = g.require_dataset('foo', shape=1000, chunks=100, dtype='f4')
+        dpath = 'foo'
+        d1 = g.require_dataset(dpath, shape=1000, chunks=100, dtype='f4')
         d1[:] = np.arange(1000)
+        path, name = self._dataset_path(g, dpath)
         assert isinstance(d1, Array)
         assert (1000,) == d1.shape
         assert (100,) == d1.chunks
         assert np.dtype('f4') == d1.dtype
-        assert 'foo' == d1.path
-        assert '/foo' == d1.name
+        assert path == d1.path
+        assert name == d1.name
         assert g.store is d1.store
         assert_array_equal(np.arange(1000), d1[:])
 
         # require
-        d2 = g.require_dataset('foo', shape=1000, chunks=100, dtype='f4')
+        d2 = g.require_dataset(dpath, shape=1000, chunks=100, dtype='f4')
         assert isinstance(d2, Array)
         assert (1000,) == d2.shape
         assert (100,) == d2.chunks
         assert np.dtype('f4') == d2.dtype
-        assert 'foo' == d2.path
-        assert '/foo' == d2.name
+        assert path == d2.path
+        assert name == d2.name
         assert g.store is d2.store
         assert_array_equal(np.arange(1000), d2[:])
         assert d1 == d2
@@ -419,7 +474,12 @@ class TestGroup(unittest.TestCase):
         # setup
         g1 = self.create_group()
         g2 = g1.create_group('foo/bar')
-        d1 = g2.create_dataset('/a/b/c', shape=1000, chunks=100)
+        if g1._version == 2:
+            d1 = g2.create_dataset('/a/b/c', shape=1000, chunks=100)
+        else:
+            # v3: cannot create a dataset at the root by starting with /
+            #     instead, need to create the dataset on g1 directly
+            d1 = g1.create_dataset('a/b/c', shape=1000, chunks=100)
         d1[:] = np.arange(1000)
         d2 = g1.create_dataset('foo/baz', shape=3000, chunks=300)
         d2[:] = np.arange(3000)
@@ -428,7 +488,13 @@ class TestGroup(unittest.TestCase):
         assert isinstance(g1['foo'], Group)
         assert isinstance(g1['foo']['bar'], Group)
         assert isinstance(g1['foo/bar'], Group)
-        assert isinstance(g1['/foo/bar/'], Group)
+        if g1._version == 2:
+            assert isinstance(g1['/foo/bar/'], Group)
+        else:
+            # start or end with / raises KeyError
+            # TODO: should we fix allow stripping of these on v3?
+            with pytest.raises(KeyError):
+                assert isinstance(g1['/foo/bar/'], Group)
         assert isinstance(g1['foo/baz'], Array)
         assert g2 == g1['foo/bar']
         assert g1['foo']['bar'] == g1['foo/bar']
@@ -454,7 +520,9 @@ class TestGroup(unittest.TestCase):
         assert 'baz' not in g1
         assert 'a/b/c/d' not in g1
         assert 'a/z' not in g1
-        assert 'quux' not in g1['foo']
+        if g1._version == 2:
+            # TODO: handle implicit group for v3 spec
+            assert 'quux' not in g1['foo']
 
         # test key errors
         with pytest.raises(KeyError):
@@ -470,12 +538,19 @@ class TestGroup(unittest.TestCase):
         assert 1 == len(g1['a/b'])
 
         # test __iter__, keys()
-        # currently assumes sorted by key
 
-        assert ['a', 'foo'] == list(g1)
-        assert ['a', 'foo'] == list(g1.keys())
-        assert ['bar', 'baz'] == list(g1['foo'])
-        assert ['bar', 'baz'] == list(g1['foo'].keys())
+        if g1._version == 2:
+            # currently assumes sorted by key
+            assert ['a', 'foo'] == list(g1)
+            assert ['a', 'foo'] == list(g1.keys())
+            assert ['bar', 'baz'] == list(g1['foo'])
+            assert ['bar', 'baz'] == list(g1['foo'].keys())
+        else:
+            # v3 is not necessarily sorted by key
+            assert ['a', 'foo'] == sorted(list(g1))
+            assert ['a', 'foo'] == sorted(list(g1.keys()))
+            assert ['bar', 'baz'] == sorted(list(g1['foo']))
+            assert ['bar', 'baz'] == sorted(list(g1['foo'].keys()))
         assert [] == sorted(g1['foo/bar'])
         assert [] == sorted(g1['foo/bar'].keys())
 
@@ -484,6 +559,9 @@ class TestGroup(unittest.TestCase):
 
         items = list(g1.items())
         values = list(g1.values())
+        if g1._version == 3:
+            # v3 are not automatically sorted by key
+            items, values = zip(*sorted(zip(items, values), key=lambda x: x[0]))
         assert 'a' == items[0][0]
         assert g1['a'] == items[0][1]
         assert g1['a'] == values[0]
@@ -493,6 +571,9 @@ class TestGroup(unittest.TestCase):
 
         items = list(g1['foo'].items())
         values = list(g1['foo'].values())
+        if g1._version == 3:
+            # v3 are not automatically sorted by key
+            items, values = zip(*sorted(zip(items, values), key=lambda x: x[0]))
         assert 'bar' == items[0][0]
         assert g1['foo']['bar'] == items[0][1]
         assert g1['foo']['bar'] == values[0]
@@ -501,11 +582,16 @@ class TestGroup(unittest.TestCase):
         assert g1['foo']['baz'] == values[1]
 
         # test array_keys(), arrays(), group_keys(), groups()
-        # currently assumes sorted by key
 
-        assert ['a', 'foo'] == list(g1.group_keys())
         groups = list(g1.groups())
         arrays = list(g1.arrays())
+        if g1._version == 2:
+            # currently assumes sorted by key
+            assert ['a', 'foo'] == list(g1.group_keys())
+        else:
+            assert ['a', 'foo'] == sorted(list(g1.group_keys()))
+            groups = sorted(groups)
+            arrays = sorted(arrays)
         assert 'a' == groups[0][0]
         assert g1['a'] == groups[0][1]
         assert 'foo' == groups[1][0]
@@ -517,6 +603,9 @@ class TestGroup(unittest.TestCase):
         assert ['baz'] == list(g1['foo'].array_keys())
         groups = list(g1['foo'].groups())
         arrays = list(g1['foo'].arrays())
+        if g1._version == 3:
+            groups = sorted(groups)
+            arrays = sorted(arrays)
         assert 'bar' == groups[0][0]
         assert g1['foo']['bar'] == groups[0][1]
         assert 'baz' == arrays[0][0]
@@ -537,21 +626,27 @@ class TestGroup(unittest.TestCase):
 
         del items[:]
         g1.visitvalues(visitor2)
-        assert [
+        expected_items = [
             "a",
             "a/b",
             "a/b/c",
             "foo",
             "foo/bar",
             "foo/baz",
-        ] == items
+        ]
+        if g1._version == 3:
+            expected_items = [g1.path + '/' + i for i in expected_items]
+        assert expected_items == items
 
         del items[:]
         g1["foo"].visitvalues(visitor2)
-        assert [
+        expected_items = [
             "foo/bar",
             "foo/baz",
-        ] == items
+        ]
+        if g1._version == 3:
+            expected_items = [g1.path + '/' + i for i in expected_items]
+        assert expected_items == items
 
         del items[:]
         g1.visit(visitor3)
@@ -627,6 +722,9 @@ class TestGroup(unittest.TestCase):
         # noinspection PyUnusedLocal
         def visitor1(val, *args):
             name = getattr(val, "path", val)
+            if name.startswith('group/'):
+                # strip the group path for v3
+                name = name[6:]
             if name == "a/b/c":
                 return True
 
@@ -663,6 +761,9 @@ class TestGroup(unittest.TestCase):
         d2[:] = np.arange(3000)
         d3 = g2.create_dataset('zab', shape=2000, chunks=200)
         d3[:] = np.arange(2000)
+
+        if g1._version == 3:
+            pytest.skip("TODO: fix for V3")
 
         # test recursive array_keys
         array_keys = list(g1['foo'].array_keys(recurse=False))
@@ -762,9 +863,13 @@ class TestGroup(unittest.TestCase):
         g2.move("bar", "/bar")
         assert "foo2" in g
         assert "foo2/bar" not in g
-        assert "bar" in g
+        if g2._version == 2:
+            # TODO: how to access element created outside of group.path in v3?
+            assert "bar" in g
         assert isinstance(g["foo2"], Group)
-        assert_array_equal(data, g["bar"])
+        if g2._version == 2:
+            # TODO: how to access element created outside of group.path in v3?
+            assert_array_equal(data, g["bar"])
 
         with pytest.raises(ValueError):
             g2.move("bar", "bar2")
@@ -841,6 +946,9 @@ class TestGroup(unittest.TestCase):
         g1 = self.create_group()
         g2 = g1.create_group('foo/bar')
 
+        if g1._version == 3:
+            pytest.skip("TODO: update class for v3")
+
         assert g1 == g1['/']
         assert g1 == g1['//']
         assert g1 == g1['///']
@@ -893,7 +1001,9 @@ class TestGroup(unittest.TestCase):
         assert name == g2.name
         assert n == len(g2)
         assert keys == list(g2)
-        assert isinstance(g2['foo'], Group)
+        if g2._version == 2:
+            # TODO: handle implicit group for v3
+            assert isinstance(g2['foo'], Group)
         assert isinstance(g2['foo/bar'], Array)
 
         g2.store.close()
@@ -921,12 +1031,71 @@ def test_group_init_from_dict(chunk_dict):
         assert chunk_store is not g.chunk_store
 
 
+# noinspection PyStatementEffect
+class TestGroupV3(TestGroup, unittest.TestCase):
+
+    @staticmethod
+    def create_store():
+        # can be overridden in sub-classes
+        return KVStoreV3(dict()), None
+
+    def create_group(self, store=None, path='group', read_only=False,
+                     chunk_store=None, synchronizer=None):
+        # can be overridden in sub-classes
+        if store is None:
+            store, chunk_store = self.create_store()
+        init_group(store, path=path, chunk_store=chunk_store)
+        g = Group(store, path=path, read_only=read_only,
+                  chunk_store=chunk_store, synchronizer=synchronizer)
+        return g
+
+    def test_group_init_1(self):
+        store, chunk_store = self.create_store()
+        g = self.create_group(store, chunk_store=chunk_store)
+        assert store is g.store
+        if chunk_store is None:
+            assert store is g.chunk_store
+        else:
+            assert chunk_store is g.chunk_store
+        assert not g.read_only
+        # different path/name in v3 case
+        assert 'group' == g.path
+        assert '/group' == g.name
+        assert 'group' == g.basename
+
+        assert isinstance(g.attrs, Attributes)
+        g.attrs['foo'] = 'bar'
+        assert g.attrs['foo'] == 'bar'
+
+        assert isinstance(g.info, InfoReporter)
+        assert isinstance(repr(g.info), str)
+        assert isinstance(g.info._repr_html_(), str)
+        store.close()
+
+    def test_group_init_errors_2(self):
+        store, chunk_store = self.create_store()
+        path = 'tmp'
+        init_array(store, path=path, shape=1000, chunks=100, chunk_store=chunk_store)
+        # array blocks group
+        with pytest.raises(ValueError):
+            Group(store, path=path, chunk_store=chunk_store)
+        store.close()
+
+
 class TestGroupWithMemoryStore(TestGroup):
 
     @staticmethod
     def create_store():
         return MemoryStore(), None
 
+
+# TODO: fix MemoryStoreV3 _get_parent, etc.
+# # noinspection PyStatementEffect
+# class TestGroupV3WithMemoryStore(TestGroupWithMemoryStore, TestGroupV3):
+
+#     @staticmethod
+#     def create_store():
+#         return MemoryStoreV3(), None
 
 class TestGroupWithDirectoryStore(TestGroup):
 
@@ -935,6 +1104,16 @@ class TestGroupWithDirectoryStore(TestGroup):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
         store = DirectoryStore(path)
+        return store, None
+
+
+class TestGroupV3WithDirectoryStore(TestGroupWithDirectoryStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = DirectoryStoreV3(path)
         return store, None
 
 
@@ -953,6 +1132,8 @@ class TestGroupWithABSStore(TestGroup):
         # internal attribute on ContainerClient isn't serializable for py36 and earlier
         super().test_pickle()
 
+# TODO TestGroupV3WithABSStore(TestGroup):
+
 
 class TestGroupWithNestedDirectoryStore(TestGroup):
 
@@ -961,6 +1142,16 @@ class TestGroupWithNestedDirectoryStore(TestGroup):
         path = tempfile.mkdtemp()
         atexit.register(atexit_rmtree, path)
         store = NestedDirectoryStore(path)
+        return store, None
+
+
+class TestGroupV3WithNestedDirectoryStore(TestGroupWithNestedDirectoryStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = NestedDirectoryStoreV3(path)
         return store, None
 
 
@@ -987,6 +1178,29 @@ class TestGroupWithFSStore(TestGroup):
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestGroupV3WithFSStore(TestGroupWithFSStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        pytest.skip("TODO: Fix for V3")
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = FSStoreV3(path)
+        return store, None
+
+    def test_round_trip_nd(self):
+        data = np.arange(1000).reshape(10, 10, 10)
+        name = 'raw'
+
+        store, _ = self.create_store()
+        f = open_group(store, path='group', mode='w')
+        f.create_dataset(name, data=data, chunks=(5, 5, 5),
+                         compressor=None)
+        h = open_group(store, path='group', mode='r')
+        np.testing.assert_array_equal(h[name][:], data)
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestGroupWithNestedFSStore(TestGroupWithFSStore):
 
     @staticmethod
@@ -1002,6 +1216,30 @@ class TestGroupWithNestedFSStore(TestGroupWithFSStore):
 
         store, _ = self.create_store()
         f = open_group(store, mode='w')
+
+        # cannot specify dimension_separator that conflicts with the store
+        with pytest.raises(ValueError):
+            f.create_dataset(name, data=data, chunks=(5, 5, 5),
+                             compressor=None, dimension_separator='.')
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestGroupV3WithNestedFSStore(TestGroupV3WithFSStore):
+
+    @staticmethod
+    def create_store():
+        pytest.skip("TODO: Fix for V3")
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = FSStoreV3(path, key_separator='/', auto_mkdir=True)
+        return store, None
+
+    def test_inconsistent_dimension_separator(self):
+        data = np.arange(1000).reshape(10, 10, 10)
+        name = 'raw'
+
+        store, _ = self.create_store()
+        f = open_group(store, path='group', mode='w')
 
         # cannot specify dimension_separator that conflicts with the store
         with pytest.raises(ValueError):
@@ -1036,6 +1274,16 @@ class TestGroupWithZipStore(TestGroup):
         pass
 
 
+class TestGroupV3WithZipStore(TestGroupWithZipStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mktemp(suffix='.zip')
+        atexit.register(os.remove, path)
+        store = ZipStoreV3(path)
+        return store, None
+
+
 class TestGroupWithDBMStore(TestGroup):
 
     @staticmethod
@@ -1043,6 +1291,16 @@ class TestGroupWithDBMStore(TestGroup):
         path = tempfile.mktemp(suffix='.anydbm')
         atexit.register(atexit_rmglob, path + '*')
         store = DBMStore(path, flag='n')
+        return store, None
+
+
+class TestGroupV3WithDBMStore(TestGroupWithDBMStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        path = tempfile.mktemp(suffix='.anydbm')
+        atexit.register(atexit_rmglob, path + '*')
+        store = DBMStoreV3(path, flag='n')
         return store, None
 
 
@@ -1057,6 +1315,17 @@ class TestGroupWithDBMStoreBerkeleyDB(TestGroup):
         return store, None
 
 
+class TestGroupV3WithDBMStoreBerkeleyDB(TestGroupWithDBMStoreBerkeleyDB, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        bsddb3 = pytest.importorskip("bsddb3")
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStoreV3(path, flag='n', open=bsddb3.btopen)
+        return store, None
+
+
 class TestGroupWithLMDBStore(TestGroup):
 
     @staticmethod
@@ -1068,6 +1337,17 @@ class TestGroupWithLMDBStore(TestGroup):
         return store, None
 
 
+class TestGroupV3WithLMDBStore(TestGroupWithLMDBStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        pytest.importorskip("lmdb")
+        path = tempfile.mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        store = LMDBStoreV3(path)
+        return store, None
+
+
 class TestGroupWithSQLiteStore(TestGroup):
 
     def create_store(self):
@@ -1075,6 +1355,16 @@ class TestGroupWithSQLiteStore(TestGroup):
         path = tempfile.mktemp(suffix='.db')
         atexit.register(atexit_rmtree, path)
         store = SQLiteStore(path)
+        return store, None
+
+
+class TestGroupV3WithSQLiteStore(TestGroupWithSQLiteStore, TestGroupV3):
+
+    def create_store(self):
+        pytest.importorskip("sqlite3")
+        path = tempfile.mktemp(suffix='.db')
+        atexit.register(atexit_rmtree, path)
+        store = SQLiteStoreV3(path)
         return store, None
 
 
@@ -1109,6 +1399,41 @@ class TestGroupWithChunkStore(TestGroup):
         assert expect == actual
 
 
+class TestGroupV3WithChunkStore(TestGroupWithChunkStore, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        return KVStoreV3(dict()), KVStoreV3(dict())
+
+    def test_chunk_store(self):
+        # setup
+        store, chunk_store = self.create_store()
+        path = 'group1'
+        g = self.create_group(store, path=path, chunk_store=chunk_store)
+
+        # check attributes
+        assert store is g.store
+        assert chunk_store is g.chunk_store
+
+        # create array
+        a = g.zeros('foo', shape=100, chunks=10)
+        assert store is a.store
+        assert chunk_store is a.chunk_store
+        a[:] = np.arange(100)
+        assert_array_equal(np.arange(100), a[:])
+
+        # check store keys
+        group_key = 'meta/root/' + path + '.group.json'
+        array_key = 'meta/root/' + path + '/foo' + '.array.json'
+        expect = sorted([group_key, array_key, 'zarr.json'])
+        actual = sorted(store.keys())
+        assert expect == actual
+        expect = ['data/root/' + path + '/foo/c' + str(i) for i in range(10)]
+        expect += ['zarr.json']
+        actual = sorted(chunk_store.keys())
+        assert expect == actual
+
+
 class TestGroupWithStoreCache(TestGroup):
 
     @staticmethod
@@ -1117,43 +1442,74 @@ class TestGroupWithStoreCache(TestGroup):
         return store, None
 
 
-def test_group():
+class TestGroupV3WithStoreCache(TestGroupWithStoreCache, TestGroupV3):
+
+    @staticmethod
+    def create_store():
+        store = LRUStoreCacheV3(dict(), max_size=None)
+        return store, None
+
+
+@pytest.mark.parametrize('zarr_version', [2, 3])
+def test_group(zarr_version):
     # test the group() convenience function
 
     # basic usage
-    g = group()
+    if zarr_version == 2:
+        g = group()
+        assert '' == g.path
+        assert '/' == g.name
+    else:
+        g = group(path='group1', zarr_version=zarr_version)
+        assert 'group1' == g.path
+        assert '/group1' == g.name
     assert isinstance(g, Group)
-    assert '' == g.path
-    assert '/' == g.name
 
     # usage with custom store
-    store = KVStore(dict())
-    g = group(store=store)
+    if zarr_version == 2:
+        store = KVStore(dict())
+        path = None
+    else:
+        store = KVStoreV3(dict())
+        path = 'foo'
+    g = group(store=store, path=path)
     assert isinstance(g, Group)
     assert store is g.store
 
     # overwrite behaviour
-    store = KVStore(dict())
-    init_array(store, shape=100, chunks=10)
+    if zarr_version == 2:
+        store = KVStore(dict())
+        path = None
+    else:
+        store = KVStoreV3(dict())
+        path = 'foo'
+    init_array(store, path=path, shape=100, chunks=10)
     with pytest.raises(ValueError):
-        group(store)
-    g = group(store, overwrite=True)
+        group(store, path=path)
+    g = group(store, path=path, overwrite=True)
     assert isinstance(g, Group)
     assert store is g.store
 
 
-def test_open_group():
+@pytest.mark.parametrize('zarr_version', [2, 3])
+def test_open_group(zarr_version):
     # test the open_group() convenience function
 
     store = 'data/group.zarr'
 
+    expected_store_type = DirectoryStore if zarr_version == 2 else DirectoryStoreV3
+
     # mode == 'w'
-    g = open_group(store, mode='w')
+    path = None if zarr_version == 2 else 'group1'
+    g = open_group(store, path=path, mode='w', zarr_version=zarr_version)
     assert isinstance(g, Group)
-    assert isinstance(g.store, DirectoryStore)
+    assert isinstance(g.store, expected_store_type)
     assert 0 == len(g)
     g.create_groups('foo', 'bar')
     assert 2 == len(g)
+
+    # TODO: update the r, r+ test case here for zarr_version == 3 after
+    #       open_array has StoreV3 support
 
     # mode in 'r', 'r+'
     open_array('data/array.zarr', shape=100, chunks=10, mode='w')
@@ -1175,37 +1531,40 @@ def test_open_group():
 
     # mode == 'a'
     shutil.rmtree(store)
-    g = open_group(store, mode='a')
+    g = open_group(store, path=path, mode='a', zarr_version=zarr_version)
     assert isinstance(g, Group)
-    assert isinstance(g.store, DirectoryStore)
+    assert isinstance(g.store, expected_store_type)
     assert 0 == len(g)
     g.create_groups('foo', 'bar')
     assert 2 == len(g)
     with pytest.raises(ValueError):
-        open_group('data/array.zarr', mode='a')
+        open_group('data/array.zarr', mode='a', zarr_version=zarr_version)
 
     # mode in 'w-', 'x'
     for mode in 'w-', 'x':
         shutil.rmtree(store)
-        g = open_group(store, mode=mode)
+        g = open_group(store, path=path, mode=mode, zarr_version=zarr_version)
         assert isinstance(g, Group)
-        assert isinstance(g.store, DirectoryStore)
+        assert isinstance(g.store, expected_store_type)
         assert 0 == len(g)
         g.create_groups('foo', 'bar')
         assert 2 == len(g)
         with pytest.raises(ValueError):
-            open_group(store, mode=mode)
-        with pytest.raises(ValueError):
-            open_group('data/array.zarr', mode=mode)
+            open_group(store, path=path, mode=mode, zarr_version=zarr_version)
+        if zarr_version == 2:
+            with pytest.raises(ValueError):
+                open_group('data/array.zarr', mode=mode)
 
     # open with path
-    g = open_group(store, path='foo/bar')
+    g = open_group(store, path='foo/bar', zarr_version=zarr_version)
     assert isinstance(g, Group)
     assert 'foo/bar' == g.path
 
 
-def test_group_completions():
-    g = group()
+@pytest.mark.parametrize('zarr_version', [2, 3])
+def test_group_completions(zarr_version):
+    path = None if zarr_version == 2 else 'group1'
+    g = group(path=path, zarr_version=zarr_version)
     d = dir(g)
     assert 'foo' not in d
     assert 'bar' not in d
@@ -1233,8 +1592,10 @@ def test_group_completions():
     assert '456' not in d  # not valid identifier
 
 
-def test_group_key_completions():
-    g = group()
+@pytest.mark.parametrize('zarr_version', [2, 3])
+def test_group_key_completions(zarr_version):
+    path = None if zarr_version == 2 else 'group1'
+    g = group(path=path, zarr_version=zarr_version)
     d = dir(g)
     # noinspection PyProtectedMember
     k = g._ipython_key_completions_()
@@ -1308,9 +1669,11 @@ def _check_tree(g, expect_bytes, expect_text):
         isinstance(widget, ipytree.Tree)
 
 
-def test_tree():
+@pytest.mark.parametrize('zarr_version', [2, 3])
+def test_tree(zarr_version):
     # setup
-    g1 = group()
+    path = None if zarr_version == 2 else 'group1'
+    g1 = group(path=path, zarr_version=zarr_version)
     g2 = g1.create_group('foo')
     g3 = g1.create_group('bar')
     g3.create_group('baz')
@@ -1318,20 +1681,38 @@ def test_tree():
     g5.create_dataset('baz', shape=100, chunks=10)
 
     # test root group
-    expect_bytes = textwrap.dedent("""\
-    /
-     +-- bar
-     |   +-- baz
-     |   +-- quux
-     |       +-- baz (100,) float64
-     +-- foo""").encode()
-    expect_text = textwrap.dedent("""\
-    /
-     ├── bar
-     │   ├── baz
-     │   └── quux
-     │       └── baz (100,) float64
-     └── foo""")
+    if zarr_version == 2:
+        expect_bytes = textwrap.dedent("""\
+        /
+         +-- bar
+         |   +-- baz
+         |   +-- quux
+         |       +-- baz (100,) float64
+         +-- foo""").encode()
+        expect_text = textwrap.dedent("""\
+        /
+         ├── bar
+         │   ├── baz
+         │   └── quux
+         │       └── baz (100,) float64
+         └── foo""")
+    else:
+        # Almost the same as for v2, but has a path name and the
+        # subgroups are not necessarily sorted alphabetically.
+        expect_bytes = textwrap.dedent("""\
+        group1
+         +-- foo
+         +-- bar
+             +-- baz
+             +-- quux
+                 +-- baz (100,) float64""").encode()
+        expect_text = textwrap.dedent("""\
+        group1
+         ├── foo
+         └── bar
+             ├── baz
+             └── quux
+                 └── baz (100,) float64""")
     _check_tree(g1, expect_bytes, expect_text)
 
     # test different group

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -18,9 +18,9 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from numcodecs.compat import ensure_bytes
 
 from zarr.codecs import BZ2, AsType, Blosc, Zlib
-from zarr.errors import MetadataError
+from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataError
 from zarr.hierarchy import group
-from zarr.meta import ZARR_FORMAT, decode_array_metadata
+from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3, decode_array_metadata
 from zarr.n5 import N5Store, N5FSStore
 from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           DictStore, DirectoryStore, KVStore, LMDBStore,
@@ -31,7 +31,12 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore, rename, listdir
+from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
+                          DirectoryStoreV3, NestedDirectoryStoreV3,
+                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
+                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
 from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container
+from zarr.tests.util import CountingDictV3
 
 
 @contextmanager
@@ -45,6 +50,15 @@ def does_not_raise():
     ("/", "/"),
 ])
 def dimension_separator_fixture(request):
+    return request.param
+
+
+@pytest.fixture(params=[
+    (None, "/"),
+    (".", "."),
+    ("/", "/"),
+])
+def dimension_separator_fixture_v3(request):
     return request.param
 
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -18,9 +18,9 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from numcodecs.compat import ensure_bytes
 
 from zarr.codecs import BZ2, AsType, Blosc, Zlib
-from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataError
+from zarr.errors import MetadataError
 from zarr.hierarchy import group
-from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3, decode_array_metadata
+from zarr.meta import ZARR_FORMAT, decode_array_metadata
 from zarr.n5 import N5Store, N5FSStore
 from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           DictStore, DirectoryStore, KVStore, LMDBStore,
@@ -31,12 +31,7 @@ from zarr.storage import (ABSStore, ConsolidatedMetadataStore, DBMStore,
                           attrs_key, default_compressor, getsize,
                           group_meta_key, init_array, init_group, migrate_1to2)
 from zarr.storage import FSStore, rename, listdir
-from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
-                          DirectoryStoreV3, NestedDirectoryStoreV3,
-                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
-                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
 from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container
-from zarr.tests.util import CountingDictV3
 
 
 @contextmanager

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -95,7 +95,7 @@ class StoreV3Tests(StoreTests):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
-        assert default_compressor.get_config() == meta['compressor']
+        assert default_compressor == meta['compressor']
         assert meta['fill_value'] is None
         # Missing MUST be assumed to be "/"
         assert meta.get('dimension_separator', "/") is want_dim_sep
@@ -118,7 +118,7 @@ class StoreV3Tests(StoreTests):
                                  chunk_shape=(200,),
                                  separator=('/')),
                  data_type=np.dtype('u1'),
-                 compressor=Zlib(1).get_config(),
+                 compressor=Zlib(1),
                  fill_value=0,
                  chunk_memory_layout=order,
                  filters=None)
@@ -165,7 +165,7 @@ class StoreV3Tests(StoreTests):
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
-        assert default_compressor.get_config() == meta['compressor']
+        assert default_compressor == meta['compressor']
         assert meta['fill_value'] is None
 
         store.close()
@@ -179,7 +179,7 @@ class StoreV3Tests(StoreTests):
                                     chunk_shape=(200,),
                                     separator=('/')),
                     data_type=np.dtype('u1'),
-                    compressor=Zlib(1).get_config(),
+                    compressor=Zlib(1),
                     fill_value=0,
                     chunk_memory_layout=order,
                     filters=None)

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -6,8 +6,6 @@ import tempfile
 import numpy as np
 import pytest
 
-from numcodecs.compat import ensure_bytes
-
 from zarr.codecs import Zlib
 from zarr.errors import ContainsArrayError, ContainsGroupError
 from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
@@ -25,8 +23,10 @@ from .test_storage import (StoreTests, TestMemoryStore, TestDirectoryStore,
                            TestDBMStoreNDBM, TestDBMStoreBerkeleyDB,
                            TestLMDBStore, TestSQLiteStore,
                            TestSQLiteStoreInMemory, TestLRUStoreCache,
-                           dimension_separator_fixture, s3,
                            skip_if_nested_chunks)
+
+# pytest will fail to run if the following fixtures aren't imported here
+from .test_storage import dimension_separator_fixture, s3  # noqa
 
 
 @pytest.fixture(params=[

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -1,0 +1,847 @@
+import array
+import atexit
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from numcodecs.compat import ensure_bytes
+
+from zarr.codecs import Zlib
+from zarr.errors import ContainsArrayError, ContainsGroupError
+from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
+from zarr.storage import (array_meta_key, atexit_rmglob, atexit_rmtree,
+                          default_compressor, getsize, init_array, init_group)
+from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
+                          DirectoryStoreV3, NestedDirectoryStoreV3,
+                          RedisStoreV3, MongoDBStoreV3, DBMStoreV3,
+                          LMDBStoreV3, SQLiteStoreV3, LRUStoreCacheV3)
+from zarr.tests.util import CountingDictV3, have_fsspec, skip_test_env_var
+
+from .test_storage import (StoreTests, TestMemoryStore, TestDirectoryStore,
+                           TestFSStore, TestNestedDirectoryStore, TestZipStore,
+                           TestDBMStore, TestDBMStoreDumb, TestDBMStoreGnu,
+                           TestDBMStoreNDBM, TestDBMStoreBerkeleyDB,
+                           TestLMDBStore, TestSQLiteStore,
+                           TestSQLiteStoreInMemory, TestLRUStoreCache,
+                           dimension_separator_fixture, s3,
+                           skip_if_nested_chunks)
+
+
+@pytest.fixture(params=[
+    (None, "/"),
+    (".", "."),
+    ("/", "/"),
+])
+def dimension_separator_fixture_v3(request):
+    return request.param
+
+
+class StoreV3Tests(StoreTests):
+
+    def test_getsize(self):
+        # TODO: determine proper getsize() behavior for v3
+
+        # Currently returns the combined size of entries under
+        # meta/root/path and data/root/path.
+        # Any path not under meta/root/ or data/root/ (including zarr.json)
+        # returns size 0.
+
+        store = self.create_store()
+        if isinstance(store, dict) or hasattr(store, 'getsize'):
+            assert 0 == getsize(store, 'zarr.json')
+            store['meta/root/foo/a'] = b'x'
+            assert 1 == getsize(store)
+            assert 1 == getsize(store, 'foo')
+            store['meta/root/foo/b'] = b'x'
+            assert 2 == getsize(store, 'foo')
+            assert 1 == getsize(store, 'foo/b')
+            store['meta/root/bar/a'] = b'yy'
+            assert 2 == getsize(store, 'bar')
+            store['data/root/bar/a'] = b'zzz'
+            assert 5 == getsize(store, 'bar')
+            store['data/root/baz/a'] = b'zzz'
+            assert 3 == getsize(store, 'baz')
+            assert 10 == getsize(store)
+            store['data/root/quux'] = array.array('B', b'zzzz')
+            assert 14 == getsize(store)
+            assert 4 == getsize(store, 'quux')
+            store['data/root/spong'] = np.frombuffer(b'zzzzz', dtype='u1')
+            assert 19 == getsize(store)
+            assert 5 == getsize(store, 'spong')
+
+        store.close()
+
+    # noinspection PyStatementEffect
+    def test_hierarchy(self):
+        pytest.skip("TODO: adapt v2 test_hierarchy tests to v3")
+
+    def test_init_array(self, dimension_separator_fixture_v3):
+
+        pass_dim_sep, want_dim_sep = dimension_separator_fixture_v3
+
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100,
+                   dimension_separator=pass_dim_sep)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.array.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_array_metadata(store[mkey])
+        # TODO: zarr_format already stored at the heirarchy level should we
+        #       also keep it in the .array.json?
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
+        # Missing MUST be assumed to be "/"
+        assert meta.get('dimension_separator', "/") is want_dim_sep
+        assert meta['chunk_grid']['separator'] is want_dim_sep
+        store.close()
+
+    def _test_init_array_overwrite(self, order):
+        # setup
+        store = self.create_store()
+
+        if store._store_version < 3:
+            path = None
+            mkey = array_meta_key
+        else:
+            path = 'arr1'  # no default, have to specify for v3
+            mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(
+            dict(shape=(2000,),
+                 chunk_grid=dict(type='regular',
+                                 chunk_shape=(200,),
+                                 separator=('/')),
+                 data_type=np.dtype('u1'),
+                 compressor=Zlib(1).get_config(),
+                 fill_value=0,
+                 chunk_memory_layout=order,
+                 filters=None)
+        )
+
+        # don't overwrite (default)
+        with pytest.raises(ContainsArrayError):
+            init_array(store, path=path, shape=1000, chunks=100)
+
+        # do overwrite
+        try:
+            init_array(store, path=path, shape=1000, chunks=100,
+                       dtype='i4', overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            meta = store._metadata_class.decode_array_metadata(
+                store[mkey]
+            )
+            assert (1000,) == meta['shape']
+            if store._store_version == 2:
+                assert ZARR_FORMAT == meta['zarr_format']
+                assert (100,) == meta['chunks']
+                assert np.dtype('i4') == meta['dtype']
+            elif store._store_version == 3:
+                assert ZARR_FORMAT_v3 == meta['zarr_format']
+                assert (100,) == meta['chunk_grid']['chunk_shape']
+                assert np.dtype('i4') == meta['data_type']
+            else:
+                raise ValueError(
+                    "unexpected store version: {store._store_version}"
+                )
+        store.close()
+
+    def test_init_array_path(self):
+        path = 'foo/bar'
+        store = self.create_store()
+        init_array(store, shape=1000, chunks=100, path=path)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.array.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_array_metadata(store[mkey])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert default_compressor.get_config() == meta['compressor']
+        assert meta['fill_value'] is None
+
+        store.close()
+
+    def _test_init_array_overwrite_path(self, order):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        meta = dict(shape=(2000,),
+                    chunk_grid=dict(type='regular',
+                                    chunk_shape=(200,),
+                                    separator=('/')),
+                    data_type=np.dtype('u1'),
+                    compressor=Zlib(1).get_config(),
+                    fill_value=0,
+                    chunk_memory_layout=order,
+                    filters=None)
+        mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(meta)
+
+        # don't overwrite
+        with pytest.raises(ContainsArrayError):
+            init_array(store, shape=1000, chunks=100, path=path)
+
+        # do overwrite
+        try:
+            init_array(store, shape=1000, chunks=100, dtype='i4', path=path,
+                       overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            # should have been overwritten
+            meta = store._metadata_class.decode_array_metadata(store[mkey])
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+
+        store.close()
+
+    def test_init_array_overwrite_group(self):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        array_key = 'meta/root/' + path + '.array.json'
+        group_key = 'meta/root/' + path + '.group.json'
+        store[group_key] = store._metadata_class.encode_group_metadata()
+
+        with pytest.raises(ContainsGroupError):
+            init_array(store, shape=1000, chunks=100, path=path)
+
+        # do overwrite
+        try:
+            init_array(store, shape=1000, chunks=100, dtype='i4', path=path,
+                       overwrite=True)
+        except NotImplementedError:
+            pass
+        else:
+            assert group_key not in store
+            assert array_key in store
+            meta = store._metadata_class.decode_array_metadata(
+                store[array_key]
+            )
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+
+        store.close()
+
+    def _test_init_array_overwrite_chunk_store(self, order):
+        # setup
+        store = self.create_store()
+        chunk_store = self.create_store()
+        path = 'arr1'
+        mkey = 'meta/root/' + path + '.array.json'
+        store[mkey] = store._metadata_class.encode_array_metadata(
+            dict(shape=(2000,),
+                 chunk_grid=dict(type='regular',
+                                 chunk_shape=(200,),
+                                 separator=('/')),
+                 data_type=np.dtype('u1'),
+                 compressor=None,
+                 fill_value=0,
+                 filters=None,
+                 chunk_memory_layout=order)
+        )
+
+        chunk_store['data/root/arr1/0'] = b'aaa'
+        chunk_store['data/root/arr1/1'] = b'bbb'
+
+        assert 'data/root/arr1/0' in chunk_store
+        assert 'data/root/arr1/1' in chunk_store
+
+        # don't overwrite (default)
+        with pytest.raises(ValueError):
+            init_array(store, path=path, shape=1000, chunks=100, chunk_store=chunk_store)
+
+        # do overwrite
+        try:
+            init_array(store, path=path, shape=1000, chunks=100, dtype='i4',
+                       overwrite=True, chunk_store=chunk_store)
+        except NotImplementedError:
+            pass
+        else:
+            assert mkey in store
+            meta = store._metadata_class.decode_array_metadata(store[mkey])
+            assert ZARR_FORMAT_v3 == meta['zarr_format']
+            assert (1000,) == meta['shape']
+            assert (100,) == meta['chunk_grid']['chunk_shape']
+            assert np.dtype('i4') == meta['data_type']
+            assert 'data/root/arr1/0' not in chunk_store
+            assert 'data/root/arr1/1' not in chunk_store
+
+        store.close()
+        chunk_store.close()
+
+    def test_init_array_compat(self):
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100, compressor='none')
+        mkey = 'meta/root/' + path + '.array.json'
+        meta = store._metadata_class.decode_array_metadata(
+            store[mkey]
+        )
+        assert meta['compressor'] is None
+
+        store.close()
+
+    def test_init_group(self):
+        store = self.create_store()
+        path = "meta/root/foo"
+        init_group(store, path=path)
+
+        # check metadata
+        mkey = 'meta/root/' + path + '.group.json'
+        assert mkey in store
+        meta = store._metadata_class.decode_group_metadata(store[mkey])
+        assert meta == {'attributes': {}}
+
+        store.close()
+
+    def _test_init_group_overwrite(self, order):
+        pytest.skip(
+            "In v3 array and group names cannot overlap"
+        )
+
+    def _test_init_group_overwrite_path(self, order):
+        # setup
+        path = 'foo/bar'
+        store = self.create_store()
+        meta = dict(
+            shape=(2000,),
+            chunk_grid=dict(type='regular',
+                            chunk_shape=(200,),
+                            separator=('/')),
+            data_type=np.dtype('u1'),
+            compressor=None,
+            fill_value=0,
+            filters=None,
+            chunk_memory_layout=order,
+        )
+        array_key = 'meta/root/' + path + '.array.json'
+        group_key = 'meta/root/' + path + '.group.json'
+        store[array_key] = store._metadata_class.encode_array_metadata(meta)
+
+        # don't overwrite
+        with pytest.raises(ContainsArrayError):
+            init_group(store, path=path)
+
+        # do overwrite
+        try:
+            init_group(store, overwrite=True, path=path)
+        except NotImplementedError:
+            pass
+        else:
+            assert array_key not in store
+            assert group_key in store
+            # should have been overwritten
+            meta = store._metadata_class.decode_group_metadata(store[group_key])
+            # assert ZARR_FORMAT == meta['zarr_format']
+            assert meta == {'attributes': {}}
+
+        store.close()
+
+    def _test_init_group_overwrite_chunk_store(self, order):
+        pytest.skip(
+            "In v3 array and group names cannot overlap"
+        )
+
+
+class TestMappingStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        return KVStoreV3(dict())
+
+    def test_set_invalid_content(self):
+        # Generic mappings support non-buffer types
+        pass
+
+
+class TestMemoryStoreV3(TestMemoryStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        skip_if_nested_chunks(**kwargs)
+        return MemoryStoreV3(**kwargs)
+
+
+class TestDirectoryStoreV3(TestDirectoryStore, StoreV3Tests):
+
+    def create_store(self, normalize_keys=False, **kwargs):
+        # For v3, don't have to skip if nested.
+        # skip_if_nested_chunks(**kwargs)
+
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = DirectoryStoreV3(path, normalize_keys=normalize_keys, **kwargs)
+        return store
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestFSStoreV3(TestFSStore, StoreV3Tests):
+
+    def create_store(self, normalize_keys=False,
+                     dimension_separator=".",
+                     path=None,
+                     **kwargs):
+
+        if path is None:
+            path = tempfile.mkdtemp()
+            atexit.register(atexit_rmtree, path)
+
+        store = FSStoreV3(
+            path,
+            normalize_keys=normalize_keys,
+            dimension_separator=dimension_separator,
+            **kwargs)
+        return store
+
+    def test_init_array(self):
+        store = self.create_store()
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100)
+
+        # check metadata
+        array_meta_key = 'meta/root/' + path + '.array.json'
+        assert array_meta_key in store
+        meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        assert meta['chunk_grid']['separator'] == "/"
+
+    # TODO: remove this skip once v3 support is added to hierarchy.Group
+    @pytest.mark.skipif(True, reason="need v3 support in zarr.hierarchy.Group")
+    def test_deep_ndim(self):
+        import zarr
+
+        store = self.create_store()
+        foo = zarr.open_group(store=store, path='group1')
+        bar = foo.create_group("bar")
+        baz = bar.create_dataset("baz",
+                                 shape=(4, 4, 4),
+                                 chunks=(2, 2, 2),
+                                 dtype="i8")
+        baz[:] = 1
+        assert set(store.listdir()) == set(["data", "meta", "zarr.json"])
+        assert set(store.listdir("meta/root/group1")) == set(["bar", "bar.group.json"])
+        assert set(store.listdir("data/root/group1")) == set(["bar"])
+        assert foo["bar"]["baz"][(0, 0, 0)] == 1
+
+
+@pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+class TestFSStoreV3WithKeySeparator(StoreV3Tests):
+
+    def create_store(self, normalize_keys=False, key_separator=".", **kwargs):
+
+        # Since the user is passing key_separator, that will take priority.
+        skip_if_nested_chunks(**kwargs)
+
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        return FSStoreV3(
+            path,
+            normalize_keys=normalize_keys,
+            key_separator=key_separator)
+
+
+# TODO: remove NestedDirectoryStoreV3?
+class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
+                                 TestDirectoryStoreV3):
+
+    def create_store(self, normalize_keys=False, **kwargs):
+        path = tempfile.mkdtemp()
+        atexit.register(atexit_rmtree, path)
+        store = NestedDirectoryStoreV3(path, normalize_keys=normalize_keys, **kwargs)
+        return store
+
+    def test_init_array(self):
+        store = self.create_store()
+        # assert store._dimension_separator == "/"
+        path = 'arr1'
+        init_array(store, path=path, shape=1000, chunks=100)
+
+        # check metadata
+        array_meta_key = 'meta/root/' + path + '.array.json'
+        assert array_meta_key in store
+        meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
+        assert ZARR_FORMAT_v3 == meta['zarr_format']
+        assert (1000,) == meta['shape']
+        assert (100,) == meta['chunk_grid']['chunk_shape']
+        assert np.dtype(None) == meta['data_type']
+        # assert meta['dimension_separator'] == "/"
+        assert meta['chunk_grid']['separator'] == "/"
+
+# TODO: enable once N5StoreV3 has been implemented
+# @pytest.mark.skipif(True, reason="N5StoreV3 not yet fully implemented")
+# class TestN5StoreV3(TestN5Store, TestNestedDirectoryStoreV3, StoreV3Tests):
+
+
+class TestZipStoreV3(TestZipStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        path = tempfile.mktemp(suffix='.zip')
+        atexit.register(os.remove, path)
+        store = ZipStoreV3(path, mode='w', **kwargs)
+        return store
+
+    def test_mode(self):
+        with ZipStoreV3('data/store.zip', mode='w') as store:
+            store['foo'] = b'bar'
+        store = ZipStoreV3('data/store.zip', mode='r')
+        with pytest.raises(PermissionError):
+            store['foo'] = b'bar'
+        with pytest.raises(PermissionError):
+            store.clear()
+
+
+class TestDBMStoreV3(TestDBMStore, StoreV3Tests):
+
+    def create_store(self, dimension_separator=None):
+        path = tempfile.mktemp(suffix='.anydbm')
+        atexit.register(atexit_rmglob, path + '*')
+        # create store using default dbm implementation
+        store = DBMStoreV3(path, flag='n', dimension_separator=dimension_separator)
+        return store
+
+
+class TestDBMStoreV3Dumb(TestDBMStoreDumb, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        path = tempfile.mktemp(suffix='.dumbdbm')
+        atexit.register(atexit_rmglob, path + '*')
+
+        import dbm.dumb as dumbdbm
+        store = DBMStoreV3(path, flag='n', open=dumbdbm.open, **kwargs)
+        return store
+
+
+class TestDBMStoreV3Gnu(TestDBMStoreGnu, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        gdbm = pytest.importorskip("dbm.gnu")
+        path = tempfile.mktemp(suffix=".gdbm")  # pragma: no cover
+        atexit.register(os.remove, path)  # pragma: no cover
+        store = DBMStoreV3(
+            path, flag="n", open=gdbm.open, write_lock=False, **kwargs
+        )  # pragma: no cover
+        return store  # pragma: no cover
+
+
+class TestDBMStoreV3NDBM(TestDBMStoreNDBM, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        ndbm = pytest.importorskip("dbm.ndbm")
+        path = tempfile.mktemp(suffix=".ndbm")  # pragma: no cover
+        atexit.register(atexit_rmglob, path + "*")  # pragma: no cover
+        store = DBMStoreV3(path, flag="n", open=ndbm.open, **kwargs)  # pragma: no cover
+        return store  # pragma: no cover
+
+
+class TestDBMStoreV3BerkeleyDB(TestDBMStoreBerkeleyDB, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        bsddb3 = pytest.importorskip("bsddb3")
+        path = tempfile.mktemp(suffix='.dbm')
+        atexit.register(os.remove, path)
+        store = DBMStoreV3(path, flag='n', open=bsddb3.btopen, write_lock=False, **kwargs)
+        return store
+
+
+class TestLMDBStoreV3(TestLMDBStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("lmdb")
+        path = tempfile.mktemp(suffix='.lmdb')
+        atexit.register(atexit_rmtree, path)
+        buffers = True
+        store = LMDBStoreV3(path, buffers=buffers, **kwargs)
+        return store
+
+
+class TestSQLiteStoreV3(TestSQLiteStore, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("sqlite3")
+        path = tempfile.mktemp(suffix='.db')
+        atexit.register(atexit_rmtree, path)
+        store = SQLiteStoreV3(path, **kwargs)
+        return store
+
+
+class TestSQLiteStoreV3InMemory(TestSQLiteStoreInMemory, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("sqlite3")
+        store = SQLiteStoreV3(':memory:', **kwargs)
+        return store
+
+
+@skip_test_env_var("ZARR_TEST_MONGO")
+class TestMongoDBStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        pytest.importorskip("pymongo")
+        store = MongoDBStoreV3(host='127.0.0.1', database='zarr_tests',
+                               collection='zarr_tests', **kwargs)
+        # start with an empty store
+        store.clear()
+        return store
+
+
+@skip_test_env_var("ZARR_TEST_REDIS")
+class TestRedisStoreV3(StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        # TODO: this is the default host for Redis on Travis,
+        # we probably want to generalize this though
+        pytest.importorskip("redis")
+        store = RedisStoreV3(host='localhost', port=6379, **kwargs)
+        # start with an empty store
+        store.clear()
+        return store
+
+
+class TestLRUStoreCacheV3(TestLRUStoreCache, StoreV3Tests):
+
+    def create_store(self, **kwargs):
+        # wrapper therefore no dimension_separator argument
+        skip_if_nested_chunks(**kwargs)
+        return LRUStoreCacheV3(dict(), max_size=2**27)
+
+    def test_cache_values_no_max_size(self):
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        assert 1 == store.counter['__setitem__', 'bar']
+
+        # setup cache
+        cache = LRUStoreCacheV3(store, max_size=None)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == store.counter['__setitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test __setitem__, __getitem__
+        cache['foo'] = b'zzz'
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        # should be a cache hit
+        assert b'zzz' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        assert 2 == cache.hits
+        assert 1 == cache.misses
+
+        # manually invalidate all cached values
+        cache.invalidate_values()
+        assert b'zzz' == cache['foo']
+        assert 2 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+        cache.invalidate()
+        assert b'zzz' == cache['foo']
+        assert 3 == store.counter['__getitem__', 'foo']
+        assert 2 == store.counter['__setitem__', 'foo']
+
+        # test __delitem__
+        del cache['foo']
+        with pytest.raises(KeyError):
+            # noinspection PyStatementEffect
+            cache['foo']
+        with pytest.raises(KeyError):
+            # noinspection PyStatementEffect
+            store['foo']
+
+        # verify other keys untouched
+        assert 0 == store.counter['__getitem__', 'bar']
+        assert 1 == store.counter['__setitem__', 'bar']
+
+    def test_cache_values_with_max_size(self):
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        # setup cache - can only hold one item
+        cache = LRUStoreCacheV3(store, max_size=5)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first 'foo' __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second 'foo' __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test first 'bar' __getitem__, cache miss
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 1 == cache.hits
+        assert 2 == cache.misses
+
+        # test second 'bar' __getitem__, cache hit
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'foo' __getitem__, should have been evicted, cache miss
+        assert b'xxx' == cache['foo']
+        assert 2 == store.counter['__getitem__', 'foo']
+        assert 2 == cache.hits
+        assert 3 == cache.misses
+
+        # test 'bar' __getitem__, should have been evicted, cache miss
+        assert b'yyy' == cache['bar']
+        assert 2 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 4 == cache.misses
+
+        # setup store
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__getitem__', 'foo']
+        assert 0 == store.counter['__getitem__', 'bar']
+        # setup cache - can hold two items
+        cache = LRUStoreCacheV3(store, max_size=6)
+        assert 0 == cache.hits
+        assert 0 == cache.misses
+
+        # test first 'foo' __getitem__, cache miss
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 0 == cache.hits
+        assert 1 == cache.misses
+
+        # test second 'foo' __getitem__, cache hit
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 1 == cache.hits
+        assert 1 == cache.misses
+
+        # test first 'bar' __getitem__, cache miss
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 1 == cache.hits
+        assert 2 == cache.misses
+
+        # test second 'bar' __getitem__, cache hit
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 2 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'foo' __getitem__, should still be cached
+        assert b'xxx' == cache['foo']
+        assert 1 == store.counter['__getitem__', 'foo']
+        assert 3 == cache.hits
+        assert 2 == cache.misses
+
+        # test 'bar' __getitem__, should still be cached
+        assert b'yyy' == cache['bar']
+        assert 1 == store.counter['__getitem__', 'bar']
+        assert 4 == cache.hits
+        assert 2 == cache.misses
+
+    def test_cache_keys(self):
+
+        # setup
+        store = CountingDictV3()
+        store['foo'] = b'xxx'
+        store['bar'] = b'yyy'
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        assert 0 == store.counter['keys']
+        cache = LRUStoreCacheV3(store, max_size=None)
+
+        # keys should be cached on first call
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'foo']
+        assert 1 == store.counter['keys']
+        # keys should now be cached
+        assert keys == sorted(cache.keys())
+        assert 1 == store.counter['keys']
+        assert 'foo' in cache
+        assert 0 == store.counter['__contains__', 'foo']
+        assert keys == sorted(cache)
+        assert 0 == store.counter['__iter__']
+        assert 1 == store.counter['keys']
+
+        # cache should be cleared if store is modified - crude but simple for now
+        cache['baz'] = b'zzz'
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'baz', 'foo']
+        assert 2 == store.counter['keys']
+        # keys should now be cached
+        assert keys == sorted(cache.keys())
+        assert 2 == store.counter['keys']
+
+        # manually invalidate keys
+        cache.invalidate_keys()
+        keys = sorted(cache.keys())
+        assert keys == ['bar', 'baz', 'foo']
+        assert 3 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        cache.invalidate_keys()
+        keys = sorted(cache)
+        assert keys == ['bar', 'baz', 'foo']
+        assert 4 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+        cache.invalidate_keys()
+        assert 'foo' in cache
+        assert 5 == store.counter['keys']
+        assert 0 == store.counter['__contains__', 'foo']
+        assert 0 == store.counter['__iter__']
+
+        # check these would get counted if called directly
+        assert 'foo' in store
+        assert 1 == store.counter['__contains__', 'foo']
+        assert keys == sorted(store)
+        assert 1 == store.counter['__iter__']
+
+
+# TODO: implement ABSStoreV3
+# @skip_test_env_var("ZARR_TEST_ABS")
+# class TestABSStoreV3(TestABSStore, StoreV3Tests):

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -8,7 +8,7 @@ import pytest
 
 from zarr.codecs import Zlib
 from zarr.errors import ContainsArrayError, ContainsGroupError
-from zarr.meta import ZARR_FORMAT, ZARR_FORMAT_v3
+from zarr.meta import ZARR_FORMAT
 from zarr.storage import (array_meta_key, atexit_rmglob, atexit_rmtree,
                           default_compressor, getsize, init_array, init_group)
 from zarr.storage import (KVStoreV3, MemoryStoreV3, ZipStoreV3, FSStoreV3,
@@ -92,7 +92,6 @@ class StoreV3Tests(StoreTests):
         meta = store._metadata_class.decode_array_metadata(store[mkey])
         # TODO: zarr_format already stored at the heirarchy level should we
         #       also keep it in the .array.json?
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -146,7 +145,6 @@ class StoreV3Tests(StoreTests):
                 assert (100,) == meta['chunks']
                 assert np.dtype('i4') == meta['dtype']
             elif store._store_version == 3:
-                assert ZARR_FORMAT_v3 == meta['zarr_format']
                 assert (100,) == meta['chunk_grid']['chunk_shape']
                 assert np.dtype('i4') == meta['data_type']
             else:
@@ -164,7 +162,6 @@ class StoreV3Tests(StoreTests):
         mkey = 'meta/root/' + path + '.array.json'
         assert mkey in store
         meta = store._metadata_class.decode_array_metadata(store[mkey])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -203,7 +200,6 @@ class StoreV3Tests(StoreTests):
             assert mkey in store
             # should have been overwritten
             meta = store._metadata_class.decode_array_metadata(store[mkey])
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -233,7 +229,6 @@ class StoreV3Tests(StoreTests):
             meta = store._metadata_class.decode_array_metadata(
                 store[array_key]
             )
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -277,7 +272,6 @@ class StoreV3Tests(StoreTests):
         else:
             assert mkey in store
             meta = store._metadata_class.decode_array_metadata(store[mkey])
-            assert ZARR_FORMAT_v3 == meta['zarr_format']
             assert (1000,) == meta['shape']
             assert (100,) == meta['chunk_grid']['chunk_shape']
             assert np.dtype('i4') == meta['data_type']
@@ -295,7 +289,7 @@ class StoreV3Tests(StoreTests):
         meta = store._metadata_class.decode_array_metadata(
             store[mkey]
         )
-        assert meta['compressor'] is None
+        assert 'compressor' not in meta
 
         store.close()
 
@@ -350,7 +344,6 @@ class StoreV3Tests(StoreTests):
             assert group_key in store
             # should have been overwritten
             meta = store._metadata_class.decode_group_metadata(store[group_key])
-            # assert ZARR_FORMAT == meta['zarr_format']
             assert meta == {'attributes': {}}
 
         store.close()
@@ -418,7 +411,6 @@ class TestFSStoreV3(TestFSStore, StoreV3Tests):
         array_meta_key = 'meta/root/' + path + '.array.json'
         assert array_meta_key in store
         meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']
@@ -479,7 +471,6 @@ class TestNestedDirectoryStoreV3(TestNestedDirectoryStore,
         array_meta_key = 'meta/root/' + path + '.array.json'
         assert array_meta_key in store
         meta = store._metadata_class.decode_array_metadata(store[array_meta_key])
-        assert ZARR_FORMAT_v3 == meta['zarr_format']
         assert (1000,) == meta['shape']
         assert (100,) == meta['chunk_grid']['chunk_shape']
         assert np.dtype(None) == meta['data_type']

--- a/zarr/tests/test_sync.py
+++ b/zarr/tests/test_sync.py
@@ -15,7 +15,8 @@ from zarr.hierarchy import Group
 from zarr.storage import (DirectoryStore, KVStore, atexit_rmtree, init_array,
                           init_group)
 from zarr.sync import ProcessSynchronizer, ThreadSynchronizer
-from zarr.tests.test_attrs import TestAttributes
+# zarr_version fixture must be imported although not used directly here
+from zarr.tests.test_attrs import TestAttributes, zarr_version  # noqa
 from zarr.tests.test_core import TestArray
 from zarr.tests.test_hierarchy import TestGroup
 

--- a/zarr/tests/util.py
+++ b/zarr/tests/util.py
@@ -1,7 +1,7 @@
 import collections
 import os
 
-from zarr.storage import Store
+from zarr.storage import Store, StoreV3
 
 import pytest
 
@@ -39,6 +39,10 @@ class CountingDict(Store):
     def __delitem__(self, key):
         self.counter['__delitem__', key] += 1
         del self.wrapped[key]
+
+
+class CountingDictV3(CountingDict, StoreV3):
+    pass
 
 
 def skip_test_env_var(name):


### PR DESCRIPTION
This PR builds on #896 adding v3 support to the high-level array creation routines.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
