### PR TITLE
Unnecessary comprehension

### DIFF
--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -961,10 +961,8 @@ class PartialChunkIterator:
         # any selection can not be out of the range of the chunk
         selection_shape = np.empty(self.arr_shape)[tuple(selection)].shape
         if any(
-            [
-                selection_dim < 0 or selection_dim > arr_dim
-                for selection_dim, arr_dim in zip(selection_shape, self.arr_shape)
-            ]
+            selection_dim < 0 or selection_dim > arr_dim
+            for selection_dim, arr_dim in zip(selection_shape, self.arr_shape)
         ):
             raise IndexError(
                 "a selection index is out of range for the dimension"


### PR DESCRIPTION
Built-in function [any()](https://docs.python.org/3/library/functions.html#any) does not require a comprehension, it operates directly on a generator expression.

This fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PTC-W0016/occurrences


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
