### PR TITLE
Unnecessary `None` provided as default

### DIFF
--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -75,7 +75,7 @@ def open(store: StoreLike = None, mode: str = "a", **kwargs):
 
     """
 
-    path = kwargs.get('path', None)
+    path = kwargs.get('path')
     # handle polymorphic store arg
     clobber = mode == 'w'
     # we pass storage options explicitly, since normalize_store_arg might construct
@@ -1179,7 +1179,7 @@ def open_consolidated(store: StoreLike, metadata_key=".zmetadata", mode="r+", **
     from .storage import ConsolidatedMetadataStore
 
     # normalize parameters
-    store = normalize_store_arg(store, storage_options=kwargs.get("storage_options", None))
+    store = normalize_store_arg(store, storage_options=kwargs.get("storage_options"))
     if mode not in {'r', 'r+'}:
         raise ValueError("invalid mode, expected either 'r' or 'r+'; found {!r}"
                          .format(mode))

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -339,7 +339,7 @@ def array(data, **kwargs):
         data = np.asanyarray(data)
 
     # setup dtype
-    kw_dtype = kwargs.get('dtype', None)
+    kw_dtype = kwargs.get('dtype')
     if kw_dtype is None:
         kwargs['dtype'] = data.dtype
     else:
@@ -348,7 +348,7 @@ def array(data, **kwargs):
     # setup shape and chunks
     data_shape, data_chunks = _get_shape_chunks(data)
     kwargs['shape'] = data_shape
-    kw_chunks = kwargs.get('chunks', None)
+    kw_chunks = kwargs.get('chunks')
     if kw_chunks is None:
         kwargs['chunks'] = data_chunks
     else:

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2305,7 +2305,7 @@ class TestArrayWithFilters(TestArray):
     @staticmethod
     def create_array(read_only=False, **kwargs):
         store = KVStore(dict())
-        dtype = kwargs.get('dtype', None)
+        dtype = kwargs.get('dtype')
         filters = [
             Delta(dtype=dtype),
             FixedScaleOffset(dtype=dtype, scale=1, offset=0),


### PR DESCRIPTION
Fixes these DeepSource.io alerts:
https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PTC-W0039/occurrences

> It is unnecessary to provide `None` as the default value when the key is not present in the dictionary as `get` implicitly returns `None`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
