### PR TITLE
Use `tobytes` in docs

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -814,7 +814,7 @@ Here is an example using S3Map to read an array created previously::
     array([b'H', b'e', b'l', b'l', b'o', b' ', b'f', b'r', b'o', b'm', b' ',
            b't', b'h', b'e', b' ', b'c', b'l', b'o', b'u', b'd', b'!'],
           dtype='|S1')
-    >>> z[:].tostring()
+    >>> z[:].tobytes()
     b'Hello from the cloud!'
 
 Zarr now also has a builtin storage backend for Azure Blob Storage.
@@ -855,11 +855,11 @@ store. E.g.::
     >>> z = root['foo/bar/baz']
     >>> from timeit import timeit
     >>> # first data access is relatively slow, retrieved from store
-    ... timeit('print(z[:].tostring())', number=1, globals=globals())  # doctest: +SKIP
+    ... timeit('print(z[:].tobytes())', number=1, globals=globals())  # doctest: +SKIP
     b'Hello from the cloud!'
     0.1081731989979744
     >>> # second data access is faster, uses cache
-    ... timeit('print(z[:].tostring())', number=1, globals=globals())  # doctest: +SKIP
+    ... timeit('print(z[:].tobytes())', number=1, globals=globals())  # doctest: +SKIP
     b'Hello from the cloud!'
     0.0009490990014455747
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -2100,11 +2100,11 @@ class LRUStoreCache(Store):
         >>> z = root['foo/bar/baz']  # doctest: +REMOTE_DATA
         >>> from timeit import timeit
         >>> # first data access is relatively slow, retrieved from store
-        ... timeit('print(z[:].tostring())', number=1, globals=globals())  # doctest: +SKIP
+        ... timeit('print(z[:].tobytes())', number=1, globals=globals())  # doctest: +SKIP
         b'Hello from the cloud!'
         0.1081731989979744
         >>> # second data access is faster, uses cache
-        ... timeit('print(z[:].tostring())', number=1, globals=globals())  # doctest: +SKIP
+        ... timeit('print(z[:].tobytes())', number=1, globals=globals())  # doctest: +SKIP
         b'Hello from the cloud!'
         0.0009490990014455747
 


### PR DESCRIPTION
Pulls doc fixes from PR ( https://github.com/zarr-developers/zarr-python/pull/636 ). Namely using `tobytes` in docs (the preferred NumPy API for this functionality [going forward]( https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html )).

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
