### PR TITLE
Proper C-style formatting for integer

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1151,8 +1151,8 @@ def s3(request):
     pytest.importorskip("moto")
 
     port = 5555
-    endpoint_uri = 'http://127.0.0.1:%s/' % port
-    proc = subprocess.Popen(shlex.split("moto_server s3 -p %s" % port),
+    endpoint_uri = 'http://127.0.0.1:%d/' % port
+    proc = subprocess.Popen(shlex.split("moto_server s3 -p %d" % port),
                             stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
 
     timeout = 5


### PR DESCRIPTION
Variable `port` is initialized as an integer, should be formatted with `%d`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
