### PR TITLE
fix consolidate_metadata with FSStore

### DIFF
--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1117,7 +1117,7 @@ def consolidate_metadata(store: StoreLike, metadata_key=".zmetadata"):
     open_consolidated
 
     """
-    store = normalize_store_arg(store)
+    store = normalize_store_arg(store, clobber=True)
 
     def is_zarr_key(key):
         return (key.endswith('.zarray') or key.endswith('.zgroup') or

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -19,6 +19,7 @@ from numcodecs.compat import ensure_bytes
 
 import zarr
 from zarr.codecs import BZ2, AsType, Blosc, Zlib
+from zarr.convenience import consolidate_metadata
 from zarr.errors import MetadataError
 from zarr.hierarchy import group
 from zarr.meta import ZARR_FORMAT, decode_array_metadata
@@ -1008,6 +1009,10 @@ class TestFSStore(StoreTests):
         a[:4] = [0, 1, 2, 3]
         assert "data" in os.listdir(path1)
         assert ".zgroup" in os.listdir(path1)
+
+        # consolidated metadata (GH#915)
+        consolidate_metadata("file://" + path1)
+        assert ".zmetadata" in os.listdir(path1)
 
         g = zarr.open_group("simplecache::file://" + path1, mode='r',
                             storage_options={"cache_storage": path2,


### PR DESCRIPTION
This PR fixes a small bug in the `consolidate_metadata` convenience function where, when using fsspec compatible store paths, the `FSStore` was opened as read-only, causing the write of the consolidated metadata key to fail.

Closes #915  

cc @martindurant, @freeman-lab

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
