### PR TITLE
DOC: drop 3.8 reference

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -90,7 +90,7 @@ you have cloned the Zarr source code and your current working directory is the r
 the repository, you can do something like the following::
 
     $ mkdir -p ~/pyenv/zarr-dev
-    $ virtualenv --no-site-packages --python=/usr/bin/python3.8 ~/pyenv/zarr-dev
+    $ virtualenv --no-site-packages --python=/usr/bin/python ~/pyenv/zarr-dev
     $ source ~/pyenv/zarr-dev/bin/activate
     $ pip install -r requirements_dev_minimal.txt -r requirements_dev_numpy.txt
     $ pip install -e .


### PR DESCRIPTION
Closes https://github.com/zarr-developers/zarr-python/issues/917

I don't have 3.8 installed (I have 3.9 installed). Dropping the 3.8 reference makes it copy-pastable. I would hope users have a recent version of python installed to work work (i.e. not 2.7 :grimacing:). I Could have chosen to make the version 3.9 but it may require a bump to 3.10 in the future.