### PR TITLE
Drop shortcut `fsspec[s3]` for dependency

### DIFF
--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -19,5 +19,6 @@ pytest-cov==3.0.0
 pytest-doctestplus==0.11.2
 pytest-timeout==2.0.2
 h5py==3.6.0
-fsspec[s3]==2021.11.1
+fsspec==2021.11.1
+s3fs==2021.11.1
 moto[server]>=1.3.14


### PR DESCRIPTION
Use of the short rather than `fsspec` and `s3fs` separately leads
to an old version of s3fs being installed. (The benefit of the
shortcut is that it prevents dependabot PRs from failing.)

see:
* https://github.com/fsspec/s3fs/issues/528
* https://github.com/zarr-developers/zarr-python/pull/914