### PR TITLE
Fix bug where the checksum of zipfiles is wrong

### DIFF
--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1565,7 +1565,7 @@ class ZipStore(Store):
             else:
                 keyinfo.external_attr = 0o644 << 16     # ?rw-r--r--
 
-            self.zf.writestr(keyinfo, value)
+            self.zf.writestr(keyinfo, value.tobytes())
 
     def __delitem__(self, key):
         raise NotImplementedError

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1551,7 +1551,7 @@ class ZipStore(Store):
     def __setitem__(self, key, value):
         if self.mode == 'r':
             raise ReadOnlyError()
-        value = ensure_contiguous_ndarray(value)
+        value = ensure_contiguous_ndarray(value).view("u1")
         with self.mutex:
             # writestr(key, value) writes with default permissions from
             # zipfile (600) that are too restrictive, build ZipInfo for
@@ -1565,7 +1565,7 @@ class ZipStore(Store):
             else:
                 keyinfo.external_attr = 0o644 << 16     # ?rw-r--r--
 
-            self.zf.writestr(keyinfo, value.tobytes())
+            self.zf.writestr(keyinfo, value)
 
     def __delitem__(self, key):
         raise NotImplementedError

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1549,6 +1549,13 @@ class TestZipStore(StoreTests):
             assert perm == '0o40775'
         z.close()
 
+    def test_store_and_retrieve_ndarray(self):
+        store = ZipStore('data/store.zip')
+        x = np.array([[1, 2], [3, 4]])
+        store['foo'] = x
+        y = np.frombuffer(store['foo'], dtype=x.dtype).reshape(x.shape)
+        assert np.array_equiv(y, x)
+
 
 class TestDBMStore(StoreTests):
 


### PR DESCRIPTION
There is a bug causing incorrect length being written to the zip file, because Zipfile thinks the len() of the passed object is the length in bytes, but it was passing a ndarray, whose len() is the number of rows. The fix is to convert to bytes before passing to zipfile.writestr()

More details on how to reproduce this bug are here:
https://github.com/zarr-developers/zarr-python/issues/931