### PR TITLE
add release note regarding introduction of BaseStore and KVStore

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,9 @@ Release notes
 Unreleased
 ----------
 
+This release of Zarr Python introduces a new ``BaseStore`` class that all provided store classes implemented in Zarr Python now inherit from. This is done as part of refactoring to enable future support of the Zarr version 3 spec. Existing third-party stores that are a MutableMapping (e.g. dict) can be converted to a new-style key/value store inheriting from ``BaseStore`` by passing them as the argument to the new ``zarr.storage.KVStore`` class. For backwards compatibility, various higher-level array creation and convenience functions still accept plain Python dicts or other mutable mappings for the ``store`` argument, but will internally convert these to a ``KVStore``.
+
+
 Enhancements
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
As requested by @joshmoore, this PR adds a release note regarding the recent addition of `BaseStore` and `KVStore` in Zarr 2.11. Please suggest improvements/clarifications!

I think the changes should be transparent to the typical user of Zarr (especially those using it indirectly via Dask or Xarray). It is mainly important for library authors or those developing their own store classes.


TODO:
* [ ] GitHub Actions have all passed
