### PR TITLE
Fix indexing for scalar numpy values (#967)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,13 @@ Release notes
 Unreleased
 ----------
 
+Bug fixes
+~~~~~~~~~
+
+* Fix bug where indexing with a scalar numpy value returned a single-value array.
+  By :user:`Ben Jeffery <benjeffery>` :issue:`967`.
+
+
 .. _release_2.11.0:
 
 2.11.0

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -34,7 +34,10 @@ def is_integer_list(x):
 
 
 def is_integer_array(x, ndim=None):
-    t = hasattr(x, 'shape') and hasattr(x, 'dtype') and x.dtype.kind in 'ui'
+    t = not np.isscalar(x) and \
+        hasattr(x, 'shape') and \
+        hasattr(x, 'dtype') and \
+        x.dtype.kind in 'ui'
     if ndim is not None:
         t = t and len(x.shape) == ndim
     return t

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1451,4 +1451,3 @@ def test_numpy_int_indexing():
     z[:] = a
     assert a[42] == z[42]
     assert a[numpy.int64(42)] == z[numpy.int64(42)]
-

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1,3 +1,4 @@
+import numpy
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
@@ -1442,3 +1443,10 @@ def test_slice_selection_uints():
     idx = np.uint64(3)
     slice_sel = make_slice_selection((idx,))
     assert arr[slice_sel].shape == (1, 6)
+
+def test_numpy_int_indexing():
+    a = np.arange(1050)
+    z = zarr.create(shape=1050, chunks=100, dtype=a.dtype)
+    z[:] = a
+    assert a[42] == z[42]
+    assert a[numpy.int64(42)] == z[numpy.int64(42)]

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1444,9 +1444,11 @@ def test_slice_selection_uints():
     slice_sel = make_slice_selection((idx,))
     assert arr[slice_sel].shape == (1, 6)
 
+    
 def test_numpy_int_indexing():
     a = np.arange(1050)
     z = zarr.create(shape=1050, chunks=100, dtype=a.dtype)
     z[:] = a
     assert a[42] == z[42]
     assert a[numpy.int64(42)] == z[numpy.int64(42)]
+    

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1444,11 +1444,11 @@ def test_slice_selection_uints():
     slice_sel = make_slice_selection((idx,))
     assert arr[slice_sel].shape == (1, 6)
 
-    
+
 def test_numpy_int_indexing():
     a = np.arange(1050)
     z = zarr.create(shape=1050, chunks=100, dtype=a.dtype)
     z[:] = a
     assert a[42] == z[42]
     assert a[numpy.int64(42)] == z[numpy.int64(42)]
-    
+


### PR DESCRIPTION
Fixes #967 by adding a check for scalar numpy types.

TODO:
* [X] Add unit tests and/or doctests in docstrings
* [X] Add docstrings and API docs for any new/modified user-facing classes and functions
* [X] New/modified features documented in docs/tutorial.rst
* [X] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
