### PR TITLE
2.11.2 release

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,9 +4,9 @@ name: Minimal installation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
 
 jobs:
   minimum_build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Linux Testing
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
 
 jobs:
   build:

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 2_11 ]
 
 jobs:
   windows:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,11 @@ Release notes
 Unreleased
 ----------
 
+.. _release_2.11.2:
+
+2.11.2
+------
+
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,6 +6,14 @@ Release notes
 Unreleased
 ----------
 
+Bug fixes
+~~~~~~~~~
+
+* Changes the default value of ``write_empty_chunks`` to ``True`` to prevent
+  unanticipated data losses when the data types do not have a proper default
+  value when empty chunks are read back in.
+  By :user:`Vyas Ramasubramani <vyasr>`; :issue:`965`.
+
 .. _release_2.11.1:
 
 2.11.1

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1309,7 +1309,7 @@ Empty chunks
  
 As of version 2.11, it is possible to configure how Zarr handles the storage of
 chunks that are "empty" (i.e., every element in the chunk is equal to the array's fill value).
-When creating an array with ``write_empty_chunks=False`` (the default), 
+When creating an array with ``write_empty_chunks=False``, 
 Zarr will check whether a chunk is empty before compression and storage. If a chunk is empty,
 then Zarr does not store it, and instead deletes the chunk from storage 
 if the chunk had been previously stored. 
@@ -1318,7 +1318,7 @@ This optimization prevents storing redundant objects and can speed up reads, but
 added computation during array writes, since the contents of 
 each chunk must be compared to the fill value, and these advantages are contingent on the content of the array. 
 If you know that your data will form chunks that are almost always non-empty, then there is no advantage to the optimization described above. 
-In this case, creating an array with ``write_empty_chunks=True`` will instruct Zarr to write every chunk without checking for emptiness.
+In this case, creating an array with ``write_empty_chunks=True`` (the default) will instruct Zarr to write every chunk without checking for emptiness.
 
 The following example illustrates the effect of the ``write_empty_chunks`` flag on
 the time required to write an array with different values.::

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -154,7 +154,7 @@ class Array:
         cache_metadata=True,
         cache_attrs=True,
         partial_decompress=False,
-        write_empty_chunks=False,
+        write_empty_chunks=True,
     ):
         # N.B., expect at this point store is fully initialized with all
         # configuration metadata fully specified and normalized

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -73,11 +73,11 @@ def create(shape, chunks=True, dtype=None, compressor='default',
         .. versionadded:: 2.8
 
     write_empty_chunks : bool, optional
-        If True, all chunks will be stored regardless of their contents. If
-        False (default), each chunk is compared to the array's fill value prior
-        to storing. If a chunk is uniformly equal to the fill value, then that
-        chunk is not be stored, and the store entry for that chunk's key is
-        deleted. This setting enables sparser storage, as only chunks with
+        If True (default), all chunks will be stored regardless of their
+        contents. If False, each chunk is compared to the array's fill value
+        prior to storing. If a chunk is uniformly equal to the fill value, then
+        that chunk is not be stored, and the store entry for that chunk's key
+        is deleted. This setting enables sparser storage, as only chunks with
         non-fill-value data are stored, at the expense of overhead associated
         with checking the data of each chunk.
         .. versionadded:: 2.11
@@ -391,7 +391,7 @@ def open_array(
     chunk_store=None,
     storage_options=None,
     partial_decompress=False,
-    write_empty_chunks=False,
+    write_empty_chunks=True,
     **kwargs
 ):
     """Open an array using file-mode-like semantics.
@@ -447,11 +447,11 @@ def open_array(
         is Blosc, when getting data from the array chunks will be partially
         read and decompressed when possible.
     write_empty_chunks : bool, optional
-        If True, all chunks will be stored regardless of their contents. If
-        False (default), each chunk is compared to the array's fill value prior
-        to storing. If a chunk is uniformly equal to the fill value, then that
-        chunk is not be stored, and the store entry for that chunk's key is
-        deleted. This setting enables sparser storage, as only chunks with
+        If True (default), all chunks will be stored regardless of their
+        contents. If False, each chunk is compared to the array's fill value
+        prior to storing. If a chunk is uniformly equal to the fill value, then
+        that chunk is not be stored, and the store entry for that chunk's key
+        is deleted. This setting enables sparser storage, as only chunks with
         non-fill-value data are stored, at the expense of overhead associated
         with checking the data of each chunk.
         .. versionadded:: 2.11


### PR DESCRIPTION
Backport #1001 on top of 2.11.1 for immediate release.

TODO:
* [x] ⚠️ Updated https://readthedocs.org/dashboard/zarr/advanced/ "Default branch" to point to `2_11`
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
