### PR TITLE
Fix missing case to fully revert change to default write_empty_chunks.

### DIFF
--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -20,7 +20,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
            object_codec=None, dimension_separator=None,
-           write_empty_chunks=False, **kwargs):
+           write_empty_chunks=True, **kwargs):
     """Create an array.
 
     Parameters


### PR DESCRIPTION
Fix issue identified in https://github.com/zarr-developers/zarr-python/pull/1001#issuecomment-1090155352. I have manually tested this change with:

```python
>>> import zarr
>>> zarr.__version__
'2.11.2'
>>> a = zarr.create((100, 100), chunks=(100, 50), dtype="i4", store="example.zarr")
>>> a[:] = 0
>>> import os
>>> os.listdir("example.zarr")
['.zarray', '0.0', '0.1']
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
