### PR TITLE
Appending performance improvement

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2448,18 +2448,6 @@ class Array:
                     # chunk not initialized
                     pass
             old_cdata_shape_working_list[idx_cdata] = min(val_old_cdata, val_new_cdata)
-        '''
-        for cidx in itertools.product(*[range(n) for n in old_cdata_shape]):
-            if all(i < c for i, c in zip(cidx, new_cdata_shape)):
-                pass  # keep the chunk
-            else:
-                key = self._chunk_key(cidx)
-                try:
-                    del chunk_store[key]
-                except KeyError:
-                    # chunk not initialized
-                    pass
-        '''
 
     def append(self, data, axis=0):
         """Append `data` to `axis`.

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2429,6 +2429,26 @@ class Array:
 
         # remove any chunks not within range
         chunk_store = self.chunk_store
+        old_cdata_shape_working_list = list(old_cdata_shape)
+        for idx_cdata, (val_old_cdata, val_new_cdata) in enumerate(
+            zip(old_cdata_shape_working_list, new_cdata_shape)
+        ):
+            for cidx in itertools.product(
+                *[
+                    range(n_new, n_old) if (idx == idx_cdata) else range(n_old)
+                    for idx, (n_old, n_new) in enumerate(
+                        zip(old_cdata_shape_working_list, new_cdata_shape)
+                    )
+                ]
+            ):
+                key = self._chunk_key(cidx)
+                try:
+                    del chunk_store[key]
+                except KeyError:
+                    # chunk not initialized
+                    pass
+            old_cdata_shape_working_list[idx_cdata] = min(val_old_cdata, val_new_cdata)
+        '''
         for cidx in itertools.product(*[range(n) for n in old_cdata_shape]):
             if all(i < c for i, c in zip(cidx, new_cdata_shape)):
                 pass  # keep the chunk
@@ -2439,6 +2459,7 @@ class Array:
                 except KeyError:
                     # chunk not initialized
                     pass
+        '''
 
     def append(self, data, axis=0):
         """Append `data` to `axis`.

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2432,7 +2432,7 @@ class Array:
         #     only find and remove the chunk slices that exist in 'old' but not 'new' data.
         #   Note that a mutable list ('old_cdata_shape_working_list') is introduced here
         #     to dynamically adjust the number of chunks along the already-processed dimensions
-        #     in order to avoid duplicate chunk removal. 
+        #     in order to avoid duplicate chunk removal.
         chunk_store = self.chunk_store
         old_cdata_shape_working_list = list(old_cdata_shape)
         for idx_cdata, (val_old_cdata, val_new_cdata) in enumerate(

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2428,6 +2428,8 @@ class Array:
                                 for s, c in zip(new_shape, chunks))
 
         # remove any chunks not within range
+        #   The idea is that, along each dimension,
+        #   find and remove the chunk slices that only exist in 'old_cdata_shape'.
         chunk_store = self.chunk_store
         old_cdata_shape_working_list = list(old_cdata_shape)
         for idx_cdata, (val_old_cdata, val_new_cdata) in enumerate(

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2429,7 +2429,10 @@ class Array:
 
         # remove any chunks not within range
         #   The idea is that, along each dimension,
-        #   find and remove the chunk slices that only exist in 'old_cdata_shape'.
+        #     only find and remove the chunk slices that exist in 'old' but not 'new' data.
+        #   Note that a mutable list ('old_cdata_shape_working_list') is introduced here
+        #     to dynamically adjust the number of chunks along the already-processed dimensions
+        #     in order to avoid duplicate chunk removal. 
         chunk_store = self.chunk_store
         old_cdata_shape_working_list = list(old_cdata_shape)
         for idx_cdata, (val_old_cdata, val_new_cdata) in enumerate(

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -667,6 +667,15 @@ class TestArray(unittest.TestCase):
         assert (10, 10) == z.chunks
         assert_array_equal(a[:55, :1], z[:])
 
+        z.resize((1, 55))
+        assert (1, 55) == z.shape
+        assert (1, 55) == z[:].shape
+        assert np.dtype('i4') == z.dtype
+        assert np.dtype('i4') == z[:].dtype
+        assert (10, 10) == z.chunks
+        assert_array_equal(a[:1, :10], z[:, :10])
+        assert_array_equal(np.zeros((1, 55-10), dtype='i4'), z[:, 10:55])
+
         # via shape setter
         z.shape = (105, 105)
         assert (105, 105) == z.shape


### PR DESCRIPTION
This PR is trying to address the issue reported in #938:
```
When I repeatedly append data to a zarr array in s3, appending takes longer and longer and longer
```
The issue appears to be coming from [a method in zarr/core.py](https://github.com/zarr-developers/zarr-python/blob/e381bf76261a1cc9c10613465ab39b968a24737b/zarr/core.py#L2414) when trying to [remove any chunks not within range](https://github.com/zarr-developers/zarr-python/blob/e381bf76261a1cc9c10613465ab39b968a24737b/zarr/core.py#L2430).

Basically the existing implementation iterates through **all** the `old` chunks and removes those that don't exist in the `new` chunks. This seems time-consuming and unnecessary when appending new chunks to the end of an existing array with a large number of chunks.

Regarding this, this PR will iterate through each dimension, and **only** find and remove the chunk slices that exist in `old` but not `new` data. It also introduced a mutable list to dynamically adjust the number of chunks along the already-processed dimensions in order to avoid duplicate chunk removal. These details have been documented in [the comments from my changes](https://github.com/zarr-developers/zarr-python/compare/master...hailiangzhang:appending_performance_improvement#diff-f640a0c570765203632323d71a9d1145ec6121c90db73f56e1271ab0efd5b8d8R2431).

This should noticeably improve the performance when appending data to a huge zarr array; for our benchmark, it reduced the processing time by half. Moreover, the time of appending should stay the same as the array size grows.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
