### PR TITLE
v3: use dev version number (draft)

### DIFF
--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -17,8 +17,8 @@ ZARR_FORMAT_v3 = 3
 # FLOAT_FILLS = {"NaN": np.nan, "Infinity": np.PINF, "-Infinity": np.NINF}
 
 _default_entry_point_metadata_v3 = {
-    "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0",
-    "metadata_encoding": "https://purl.org/zarr/spec/protocol/core/3.0",
+    "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0-dev",
+    "metadata_encoding": "https://purl.org/zarr/spec/protocol/core/3.0-dev",
     "metadata_key_suffix": ".json",
     "extensions": [],
 }
@@ -391,7 +391,7 @@ class Metadata3(Metadata2):
         meta = cls.parse_metadata(s)
         # check metadata format
         # zarr_format = meta.get("zarr_format", None)
-        # if zarr_format != "https://purl.org/zarr/spec/protocol/core/3.0":
+        # if zarr_format != "https://purl.org/zarr/spec/protocol/core/3.0-dev":
         #     raise MetadataError("unsupported zarr format: %s" % zarr_format)
         if set(meta.keys()) != {
             "zarr_format",

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -504,7 +504,7 @@ def test_get_hierarchy_metadata():
     assert _get_hierarchy_metadata(store) == _default_entry_point_metadata_v3
 
     # ValueError if only a subset of keys are present
-    store['zarr.json'] = {'zarr_format': 'https://purl.org/zarr/spec/protocol/core/3.0'}
+    store['zarr.json'] = {'zarr_format': 'https://purl.org/zarr/spec/protocol/core/3.0-dev'}
     with pytest.raises(ValueError):
         _get_hierarchy_metadata(store)
 


### PR DESCRIPTION
For discussion. Until v3 is finalized, using a "dev" marker for the v3 version string would prevent datasets that are written in a transitional state from becoming normative.

This follows on from the PRs by @grlee77 to add support for writing V3 (#898) and to hide those implementations unless the user explicitly sets an environment variable (#1007).

An unknown here is how many v3 filesets are already in the wild. xtensor-zarr (cc: @davidbrochart) and z5 (@constantinpape) have had writing support for some time.

If we decide to move forward with this change, we should synchronize implementations and make an effort to contact (known) users of these transitional v3 implementations.