### PR TITLE
Make all unignored zarr warnings errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
 addopts = --durations=10
 filterwarnings =
-    error::DeprecationWarning:zarr.*
-    error::UserWarning:zarr.*
+    error:::zarr.*
+    ignore:Not all N5 implementations support blosc compression.*:RuntimeWarning
     ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning
     ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning


### PR DESCRIPTION
Following on from #654, I wanted to make sure that no warnings are being missed by the tests. This widens those that are considered errors to everything coming from a zarr.* package. (We could consider including closely related packages like fsspec, numcodecs, etc.)

The only ignore statement that was needed, perhaps for review by @d-v-b, was the n5/compression statement.