### PR TITLE
Fix URL to renamed file in Blosc repo

### DIFF
--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -206,7 +206,7 @@ through the primary compression library to obtain a new sequence of bytes
 comprising the compressed chunk data. No header is added to the compressed
 bytes or any other modification made. The internal structure of the compressed
 bytes will depend on which primary compressor was used. For example, the `Blosc
-compressor <https://github.com/Blosc/c-blosc/blob/master/README_HEADER.rst>`_
+compressor <https://github.com/Blosc/c-blosc/blob/master/README_CHUNK_FORMAT.rst>`_
 produces a sequence of bytes that begins with a 16-byte header followed by
 compressed data.
 


### PR DESCRIPTION
Just a fix for a broken link I found while reading the docs. See [the commit](https://github.com/Blosc/c-blosc/commit/8491305e8cc98bf90d5e5d4b5af98aedd13ee2fb) that changed the name.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
