### PR TITLE
Move `master` to `main`

### DIFF
--- a/.github/workflows/Pre-commit-hooks.yml
+++ b/.github/workflows/Pre-commit-hooks.yml
@@ -4,10 +4,10 @@ name: pre-commit
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow pull request events but only for the master branch
+  # Triggers the workflow pull request events but only for the main branch
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,9 +4,9 @@ name: Minimal installation
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   minimum_build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Linux Testing
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   windows:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/zarr-developers/zarr-python/blob/master/LICENSE">
+    <a href="https://github.com/zarr-developers/zarr-python/blob/main/LICENSE">
     <img src="https://img.shields.io/pypi/l/zarr.svg" alt="license" />
     </a>
 </td>
@@ -40,7 +40,7 @@
   <td>Build Status</td>
   <td>
     <a href="https://travis-ci.org/zarr-developers/zarr-python">
-    <img src="https://travis-ci.org/zarr-developers/zarr-python.svg?branch=master" alt="travis build status" />
+    <img src="https://travis-ci.org/zarr-developers/zarr-python.svg?branch=main" alt="travis build status" />
     </a>
   </td>
 </tr>
@@ -48,7 +48,7 @@
   <td>Coverage</td>
   <td>
     <a href="https://codecov.io/gh/zarr-developers/zarr-python">
-    <img src="https://codecov.io/gh/zarr-developers/zarr-python/branch/master/graph/badge.svg"/ alt="coverage">
+    <img src="https://codecov.io/gh/zarr-developers/zarr-python/branch/main/graph/badge.svg"/ alt="coverage">
     </a>
   </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/zarr-developers/community/master/logos/logo2.png"><br>
+  <img src="https://raw.githubusercontent.com/zarr-developers/community/main/logos/logo2.png"><br>
 </div>
 
 # Zarr

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,4 +12,4 @@ comment:
   behavior: default
   require_changes: true  # if true: only post the comment if coverage changes
   branches:               # branch names that can post comment
-    - "master"
+    - "main"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'zarr'
@@ -245,7 +245,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'zarr.tex', 'zarr Documentation',
+    (main_doc, 'zarr.tex', 'zarr Documentation',
      'Zarr Developers', 'manual'),
 ]
 
@@ -275,7 +275,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'zarr', 'zarr Documentation',
+    (main_doc, 'zarr', 'zarr Documentation',
      [author], 1)
 ]
 
@@ -289,7 +289,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'zarr', 'zarr Documentation',
+    (main_doc, 'zarr', 'zarr Documentation',
      author, 'zarr', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -108,9 +108,9 @@ report the bug or propose the feature you'd like to add.
 It's best to synchronize your fork with the upstream repository, then create a
 new, separate branch for each piece of work you want to do. E.g.::
 
-    git checkout master
+    git checkout main
     git fetch upstream
-    git rebase upstream/master
+    git rebase upstream/main
     git push
     git checkout -b shiny-new-feature
     git push -u origin shiny-new-feature
@@ -120,18 +120,18 @@ this branch specific to one bug or feature so it is clear what the branch brings
 Zarr.
 
 To update this branch with latest code from Zarr, you can retrieve the changes from
-the master branch and perform a rebase::
+the main branch and perform a rebase::
 
     git fetch upstream
-    git rebase upstream/master
+    git rebase upstream/main
 
-This will replay your commits on top of the latest Zarr git master. If this leads to
+This will replay your commits on top of the latest Zarr git main. If this leads to
 merge conflicts, these need to be resolved before submitting a pull request.
-Alternatively, you can merge the changes in from upstream/master instead of rebasing,
+Alternatively, you can merge the changes in from upstream/main instead of rebasing,
 which can be simpler::
 
     git fetch upstream
-    git merge upstream/master
+    git merge upstream/main
 
 Again, any conflicts need to be resolved before submitting a pull request.
 
@@ -206,7 +206,7 @@ Documentation
 
 Docstrings for user-facing classes and functions should follow the
 `numpydoc
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
+<https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt>`_
 standard, including sections for Parameters and Examples. All examples
 should run and pass as doctests under Python 3.8. To run doctests,
 activate your development environment, install optional requirements,
@@ -242,7 +242,7 @@ one core developers before being merged. Ideally, pull requests submitted by a c
 should be reviewed and approved by at least one other core developers before being merged.
 
 Pull requests should not be merged until all CI checks have passed (GitHub Actions
-Codecov) against code that has had the latest master merged in.
+Codecov) against code that has had the latest main merged in.
 
 Compatibility and versioning policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -337,9 +337,9 @@ Release procedure
    Most of the release process is now handled by github workflow which should
    automatically push a release to PyPI if a tag is pushed. 
 
-Checkout and update the master branch::
+Checkout and update the main branch::
 
-    $ git checkout master
+    $ git checkout main
     $ git pull
 
 Verify all tests pass on all supported Python versions, and docs build::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. zarr documentation master file, created by
+.. zarr documentation main file, created by
    sphinx-quickstart on Mon May  2 21:40:09 2016.
 
 Zarr

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Alternatively, install Zarr via conda::
     $ conda install -c conda-forge zarr
 
 To install the latest development version of Zarr, you can use pip with the
-latest GitHub master::
+latest GitHub main::
 
     $ pip install git+https://github.com/zarr-developers/zarr-python.git
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -873,7 +873,7 @@ Enhancements
   properties that enable a selection of items in an array to be retrieved or
   updated. See the :ref:`tutorial_indexing` tutorial section for more
   information. There is also a `notebook
-  <https://github.com/zarr-developers/zarr-python/blob/master/notebooks/advanced_indexing.ipynb>`_
+  <https://github.com/zarr-developers/zarr-python/blob/main/notebooks/advanced_indexing.ipynb>`_
   with extended examples and performance benchmarks. :issue:`78`, :issue:`89`,
   :issue:`112`, :issue:`172`.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -427,7 +427,7 @@ Groups also have the :func:`zarr.hierarchy.Group.tree` method, e.g.::
 If you're using Zarr within a Jupyter notebook (requires
 `ipytree <https://github.com/QuantStack/ipytree>`_), calling ``tree()`` will generate an
 interactive tree representation, see the `repr_tree.ipynb notebook
-<http://nbviewer.jupyter.org/github/zarr-developers/zarr-python/blob/master/notebooks/repr_tree.ipynb>`_
+<http://nbviewer.jupyter.org/github/zarr-developers/zarr-python/blob/main/notebooks/repr_tree.ipynb>`_
 for more examples.
 
 .. _tutorial_attrs:


### PR DESCRIPTION
Closes https://github.com/zarr-developers/community/issues/44

Moves all branch references from `master` to `main`. These are self-referential links (other Numcodecs things like CI).

Also updates terminology in doc generating code similarly and 3rd party links.

Other GitHub Actions and 3rd party links are left alone if they haven't already made the transition.

xref: https://github.com/pypa/gh-action-pypi-publish/issues/83
xref: https://github.com/conda-incubator/setup-miniconda/issues/231
xref: https://github.com/Blosc/c-blosc/issues/336

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
