### PR TITLE
[WIP] getitems / setitems for BaseStore

### DIFF
--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -2,7 +2,7 @@ import abc
 import os
 from collections.abc import MutableMapping
 from string import ascii_letters, digits
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, Hashable, List, Mapping, Optional, Union, Dict, Iterable
 
 from zarr.meta import Metadata2, Metadata3
 from zarr.util import normalize_storage_path
@@ -81,6 +81,18 @@ class BaseStore(MutableMapping):
             )  # pragma: no cover
         _rename_from_keys(self, src_path, dst_path)
 
+    def getitems(self, keys: Iterable[Hashable]) -> Dict[Hashable, Any]:
+        result = {}        
+        for key in keys:
+            try:
+                result[key] = self.__getitem__(key)
+            except KeyError:
+                pass
+        return result
+
+    def setitems(self, items):
+        return tuple(self.__setitem__(key, value) for key, value in items.items())
+
     @staticmethod
     def _ensure_store(store: Any):
         """
@@ -144,7 +156,6 @@ class Store(BaseStore):
             )  # pragma: no cover
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
-
 
 class StoreV3(BaseStore):
     _store_version = 3

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -90,7 +90,7 @@ class BaseStore(MutableMapping):
         _rename_from_keys(self, src_path, dst_path)
 
     def getitems(self, keys: Iterable[Hashable]) -> Dict[Hashable, Any]:
-        result = {}        
+        result = {}
         for key in keys:
             try:
                 result[key] = self.__getitem__(key)
@@ -164,6 +164,7 @@ class Store(BaseStore):
             )  # pragma: no cover
         path = normalize_storage_path(path)
         _rmdir_from_keys(self, path)
+
 
 class StoreV3(BaseStore):
     _store_version = 3

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1249,8 +1249,8 @@ class Array:
             # allow storage to get multiple items at once
             if all(map(lambda x: x > 0, indexer.shape)):
                 lchunk_coords, lchunk_selection, lout_selection = zip(*indexer)
-                self._chunkgetitems(lchunk_coords, lchunk_selection, out, lout_selection,
-                                    drop_axes=indexer.drop_axes, fields=fields)
+                self._chunk_getitems(lchunk_coords, lchunk_selection, out, lout_selection,
+                                     drop_axes=indexer.drop_axes, fields=fields)
 
         if out.shape:
             return out
@@ -1818,8 +1818,8 @@ class Array:
                             cv = cv[item]
                         chunk_values.append(cv)
 
-                self._chunksetitems(lchunk_coords, lchunk_selection, chunk_values,
-                                    fields=fields)
+                self._chunk_setitems(lchunk_coords, lchunk_selection, chunk_values,
+                                     fields=fields)
 
     def _process_chunk(
         self,
@@ -1952,7 +1952,7 @@ class Array:
             self._process_chunk(out, cdata, chunk_selection, drop_axes,
                                 out_is_ndarray, fields, out_selection)
 
-    def _chunkgetitems(self, lchunk_coords, lchunk_selection, out, lout_selection,
+    def _chunk_getitems(self, lchunk_coords, lchunk_selection, out, lout_selection,
                         drop_axes=None, fields=None):
         """As _chunk_getitem, but for lists of chunks
 
@@ -2004,7 +2004,7 @@ class Array:
                         fill_value = self._fill_value
                     out[out_select] = fill_value
 
-    def _chunksetitems(self, lchunk_coords, lchunk_selection, values, fields=None):
+    def _chunk_setitems(self, lchunk_coords, lchunk_selection, values, fields=None):
         ckeys = map(self._chunk_key, lchunk_coords)
         cdatas = {key: self._process_for_setitem(key, sel, val, fields=fields)
                   for key, sel, val in zip(ckeys, lchunk_selection, values)}

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1799,7 +1799,7 @@ class Array:
                 # put data
                 self._chunk_setitem(chunk_coords, chunk_selection, chunk_value, fields=fields)
         else:
-            if all(map(lambda x: x > 0, indexer.shape)):
+            if all(map(lambda x: x > 0, sel_shape)):
                 lchunk_coords, lchunk_selection, lout_selection = zip(*indexer)
                 chunk_values = []
                 for out_selection in lout_selection:

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -6,7 +6,7 @@ import operator
 import re
 from collections.abc import MutableMapping
 from functools import reduce
-from typing import Any
+from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 from numcodecs.compat import ensure_bytes, ensure_ndarray
@@ -788,7 +788,7 @@ class Array:
             result = self.get_basic_selection(pure_selection, fields=fields)
         return result
 
-    def get_basic_selection(self, selection=Ellipsis, out=None, fields=None):
+    def get_basic_selection(self, selection=Ellipsis, out=None, fields: Optional[Union[str, Sequence[str]]]=None):
         """Retrieve data for an item or region of the array.
 
         Parameters
@@ -1238,20 +1238,8 @@ class Array:
             out = np.empty(out_shape, dtype=out_dtype, order=self._order)
         else:
             check_array_shape('out', out, out_shape)
-
-        # iterate over chunks
-        #if any(map(lambda x: x == 0, self.shape)):
-        #    # sequentially get one key at a time from storage
-        #    for chunk_coords, chunk_selection, out_selection in indexer:
-        #
-        #        # load chunk selection into output array
-        #        self._chunk_getitem(chunk_coords, chunk_selection, out, out_selection,
-        #                            drop_axes=indexer.drop_axes, fields=fields)
-        #else:
-            # allow storage to get multiple items at once
-        #    if all(map(lambda x: x > 0, out_shape)):
         
-        if indexer_parts:
+        if len(indexer_parts) > 0:
             lchunk_coords, lchunk_selection, lout_selection = zip(*indexer_parts)
             self._chunk_getitems(lchunk_coords, lchunk_selection, out, lout_selection,
                                 drop_axes=indexer.drop_axes, fields=fields)

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1255,6 +1255,7 @@ class Array:
             lchunk_coords, lchunk_selection, lout_selection = zip(*indexer_parts)
             self._chunk_getitems(lchunk_coords, lchunk_selection, out, lout_selection,
                                 drop_axes=indexer.drop_axes, fields=fields)
+        if out.shape:
             return out
         else:
             return out[()]

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -707,7 +707,7 @@ class KVStore(Store):
     a mutable mapping, to avoid having to test stores for presence of methods.
 
     This, for most methods should just be a pass-through to the underlying KV
-    store which is likely to expose a MuttableMapping interface,
+    store which is likely to expose a MutableMapping interface,
     """
 
     def __init__(self, mutablemapping):
@@ -1356,9 +1356,9 @@ class FSStore(Store):
 
         return key.lower() if self.normalize_keys else key
 
-    def getitems(self, keys, **kwargs):
+    def getitems(self, keys, on_error="omit"):
         keys_transformed = [self._normalize_key(key) for key in keys]
-        results = self.map.getitems(keys_transformed, on_error="omit")
+        results = self.map.getitems(keys_transformed, on_error=on_error)
         # The function calling this method may not recognize the transformed keys
         # So we send the values returned by self.map.getitems back into the original key space.
         return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1357,11 +1357,15 @@ class FSStore(Store):
         return key.lower() if self.normalize_keys else key
 
     def getitems(self, keys, on_error="omit"):
-        keys_transformed = [self._normalize_key(key) for key in keys]
-        results = self.map.getitems(keys_transformed, on_error=on_error)
+        key_map = {self._normalize_key(key): key for key in keys}
+        from_store = self.map.getitems(tuple(key_map.keys()), on_error=on_error)
         # The function calling this method may not recognize the transformed keys
         # So we send the values returned by self.map.getitems back into the original key space.
-        return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
+        result = {}
+        for rk, rv in from_store.items():
+            input_key = key_map[rk]
+            result[input_key] = rv
+        return result
 
     def __getitem__(self, key):
         key = self._normalize_key(key)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -131,6 +131,12 @@ class StoreTests:
         assert key in store
         assert b'bar' == ensure_bytes(store[key])
 
+        # test getitems, setitems
+        data = {'key_0': b'value_0', 'key_1': b'value_1'}
+        assert store.getitems(data.keys()) == {}
+        store.setitems(data)
+        assert store.getitems(data.keys()) == data
+
         # test __delitem__ (optional)
         try:
             del store[key]

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -132,7 +132,7 @@ class StoreTests:
         assert b'bar' == ensure_bytes(store[key])
 
         # test getitems, setitems
-        data = {'key_0': b'value_0', 'key_1': b'value_1'}
+        data = {self.root + 'key_0': b'value_0', self.root + 'key_1': b'value_1'}
         assert store.getitems(data.keys()) == {}
         store.setitems(data)
         assert store.getitems(data.keys()) == data


### PR DESCRIPTION
This PR adds `getitems` and `setitems` methods to `BaseStore`, and removes some redundant `hasattr(store, 'getitems')` calls. This makes `FSStore` a bit less special and hopefully would make async array methods a little easier to engineer.

Tests and docs are WIP

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
