### PR TITLE
drop py37

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         numpy_version: ['!=1.21.0', '==1.17.*']
         exclude:
           - python-version: 3.9

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             'ipytree',
         ],
     },
-    python_requires='>=3.7, <4',
+    python_requires='>=3.8, <4',
     install_requires=dependencies,
     package_dir={'': '.'},
     packages=['zarr', 'zarr._storage', 'zarr.tests'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37-npy{117,latest}, py38, py39, docs
+envlist = py38, py39, py310, docs
 
 [testenv]
 install_command = pip install --no-binary=numcodecs {opts} {packages}
@@ -19,27 +19,19 @@ commands =
     # clear out any data files generated during tests
     python -c 'import glob; import shutil; import os; [(shutil.rmtree(d) if os.path.isdir(d) else os.remove(d) if os.path.isfile(d) else None) for d in glob.glob("./example*")]'
     # main unit test runner
-    py{38,39}: pytest -v --cov=zarr --cov-config=.coveragerc zarr
-    # don't collect coverage when running older numpy versions
-    py37-npy117: pytest -v zarr
-    # collect coverage and run doctests under py37
-    py37-npylatest: pytest -v --cov=zarr --cov-config=.coveragerc --doctest-plus zarr --remote-data
-    # generate a coverage report
-    py37-npylatest,py38,py39: coverage report -m
+    py{38,39,310}: pytest -v --cov=zarr --cov-config=.coveragerc zarr
     # run doctests in the tutorial and spec
-    py{38,39}: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
+    py{38,39,310}: python -m doctest -o NORMALIZE_WHITESPACE -o ELLIPSIS docs/tutorial.rst docs/spec/v2.rst
     # pep8 checks
-    py{38,39}: flake8 zarr
+    py{38,39, 310}: flake8 zarr
     # print environment for debugging
     pip freeze
 deps =
-    py37-npy117: numpy==1.17.*
-    py37-npylatest,py38: -rrequirements_dev_numpy.txt
     -rrequirements_dev_minimal.txt
     -rrequirements_dev_optional.txt
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 changedir = docs
 deps =
     -rrequirements_rtfd.txt


### PR DESCRIPTION
Drop python 3.7

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
