### PR TITLE
remove option to return None when the input is None from _ensure_store

### DIFF
--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -100,9 +100,7 @@ class BaseStore(MutableMapping):
         """
         from zarr.storage import KVStore  # avoid circular import
 
-        if store is None:
-            return None
-        elif isinstance(store, BaseStore):
+        if isinstance(store, BaseStore):
             if not store._store_version == 2:
                 raise ValueError(
                     f"cannot initialize a v2 store with a v{store._store_version} store"

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -73,8 +73,6 @@ def test_ensure_store():
     with pytest.raises(ValueError):
         Store._ensure_store(KVStoreV3(dict()))
 
-    assert Store._ensure_store(None) is None
-
 
 def test_capabilities():
     s = KVStore(dict())


### PR DESCRIPTION
As discussed in https://github.com/zarr-developers/zarr-python/pull/1051#issuecomment-1175539995, it does not seem logical that `_ensure_store` should return None (which is not a `BaseStore`). As far as I am aware, the ability to pass through None is not needed, so this PR removes it.


[Description of PR]

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
