### PR TITLE
More typos found by codespell

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,6 +16,12 @@ Documentation
 
 * Typo fixes to close quotes. By :user:`Pavithra Eswaramoorthy <pavithraes>`
 
+Maintenance
+~~~~~~~~~~~
+
+* Fix spelling.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>`, :issue:`1073`.
+
 
 .. _release_2.12.0:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -897,7 +897,7 @@ The second invocation here will be much faster. Note that the ``storage_options`
 have become more complex here, to account for the two parts of the supplied
 URL.
 
-It is also possible to initialize the filesytem outside of Zarr and then pass
+It is also possible to initialize the filesystem outside of Zarr and then pass
 it through. This requires creating an :class:`zarr.storage.FSStore` object
 explicitly. For example::
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -153,7 +153,7 @@ class Array:
 
     def __init__(
         self,
-        store: Any,  # BaseStore not stricly required due to normalize_store_arg
+        store: Any,  # BaseStore not strictly required due to normalize_store_arg
         path=None,
         read_only=False,
         chunk_store=None,

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -81,7 +81,7 @@ def get_extended_dtype_info(dtype) -> dict:
             fallback=None,
         )
     else:
-        raise ValueError(f"Unsupport dtype: {dtype}")
+        raise ValueError(f"Unsupported dtype: {dtype}")
 
 
 class Metadata2:
@@ -399,7 +399,7 @@ class Metadata3(Metadata2):
             "metadata_key_suffix",
             "extensions",
         }:
-            raise ValueError(f"Unexpected keys in metdata. meta={meta}")
+            raise ValueError(f"Unexpected keys in metadata. meta={meta}")
         return meta
 
     @classmethod


### PR DESCRIPTION
Fix a few typos found by codespell.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [X] GitHub Actions have all passed
* [X] Test coverage is 100% (Codecov passes)
