### PR TITLE
Update DeepSource configuration

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,6 +5,3 @@ test_patterns = ["zarr/tests/test_*.py"]
 [[analyzers]]
 name = "python"
 enabled = true
-
-  [analyzers.meta]
-  runtime_version = "3.x.x"


### PR DESCRIPTION
The default Python version has become 3.x.x:
https://deepsource.io/docs/analyzer/python/

> `runtime_version`
> * **Type**: [String](https://toml.io/en/v1.0.0#string)
> **Presence**: optional
> **Description**: Runtime version of your language in [semver](https://semver.org/).
> * **Available Values**: "2.x.x", "3.x.x"
> * **Default Value**: "3.x.x"

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
