### PR TITLE
Close quote typo fix

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -6,10 +6,16 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
-    .. _unreleased:
+.. _unreleased:
 
-    Unreleased
-    ----------
+Unreleased
+----------
+
+Documentation
+~~~~~~~~~~~~~
+
+* Typo fixes to close quotes. By :user:`Pavithra Eswaramoorthy <pavithraes>`
+
 
 .. _release_2.12.0:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1404,7 +1404,7 @@ access patterns and incur a substantial performance hit when using
 file based stores. One of the most pathological examples is
 switching from column-based chunking to row-based chunking e.g. ::
 
-    >>> a = zarr.zeros((10000,10000), chunks=(10000, 1), dtype='uint16, store='a.zarr')
+    >>> a = zarr.zeros((10000,10000), chunks=(10000, 1), dtype='uint16', store='a.zarr')
     >>> b = zarr.array(a, chunks=(1,10000), store='b.zarr')
 
 which will require every chunk in the input data set to be repeatedly read when creating
@@ -1412,7 +1412,7 @@ each output chunk. If the entire array will fit within memory, this is simply re
 by forcing the entire input array into memory as a numpy array before converting
 back to zarr with the desired chunking. ::
 
-    >>> a = zarr.zeros((10000,10000), chunks=(10000, 1), dtype='uint16, store='a.zarr')
+    >>> a = zarr.zeros((10000,10000), chunks=(10000, 1), dtype='uint16', store='a.zarr')
     >>> b = a[...]
     >>> c = zarr.array(b, chunks=(1,10000), store='c.zarr')
 


### PR DESCRIPTION
Tiny typo fix to close quotes in the docs code snippets

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
