### PR TITLE
Zarr v3: support root path

### DIFF
--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -420,11 +420,11 @@ def _listdir_from_keys(store: BaseStore, path: Optional[str] = None) -> List[str
 
 def _prefix_to_array_key(store: StoreLike, prefix: str) -> str:
     if getattr(store, "_store_version", 2) == 3:
+        sfx = _get_metadata_suffix(store)  # type: ignore
         if prefix:
-            sfx = _get_metadata_suffix(store)  # type: ignore
             key = meta_root + prefix.rstrip("/") + ".array" + sfx
         else:
-            raise ValueError("prefix must be supplied to get a v3 array key")
+            key = meta_root[:-1] + '.array' + sfx
     else:
         key = prefix + array_meta_key
     return key
@@ -432,11 +432,11 @@ def _prefix_to_array_key(store: StoreLike, prefix: str) -> str:
 
 def _prefix_to_group_key(store: StoreLike, prefix: str) -> str:
     if getattr(store, "_store_version", 2) == 3:
+        sfx = _get_metadata_suffix(store)  # type: ignore
         if prefix:
-            sfx = _get_metadata_suffix(store)  # type: ignore
             key = meta_root + prefix.rstrip('/') + ".group" + sfx
         else:
-            raise ValueError("prefix must be supplied to get a v3 group key")
+            key = meta_root[:-1] + '.group' + sfx
     else:
         key = prefix + group_meta_key
     return key
@@ -449,7 +449,7 @@ def _prefix_to_attrs_key(store: StoreLike, prefix: str) -> str:
         if prefix:
             key = meta_root + prefix.rstrip('/') + ".array" + sfx
         else:
-            raise ValueError("prefix must be supplied to get a v3 array key")
+            key = meta_root[:-1] + '.array' + sfx
     else:
         key = prefix + attrs_key
     return key

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -155,7 +155,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     dimension_separator = normalize_dimension_separator(dimension_separator)
 
     if zarr_version > 2 and path is None:
-        raise ValueError("path must be supplied to initialize a zarr v3 array")
+        path = '/'
 
     # initialize array metadata
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1247,8 +1247,6 @@ def group(store=None, overwrite=False, chunk_store=None,
     if zarr_version != 2:
         assert_zarr_v3_api_available()
 
-    if zarr_version == 3 and path is None:
-        raise ValueError(f"path must be provided for a v{zarr_version} group")
     path = normalize_storage_path(path)
 
     if zarr_version == 2:

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1330,7 +1330,6 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
                 "zarr_version of store and chunk_store must match"
             )
 
-    store_version = getattr(store, '_store_version', 2)
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1333,9 +1333,6 @@ def open_group(store=None, mode='a', cache_attrs=True, synchronizer=None, path=N
             )
 
     store_version = getattr(store, '_store_version', 2)
-    if store_version == 3 and path is None:
-        raise ValueError("path must be supplied to initialize a zarr v3 group")
-
     path = normalize_storage_path(path)
 
     # ensure store is initialized

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -229,8 +229,14 @@ def _getsize(store: BaseStore, path: Path = None) -> int:
         size = 0
         store_version = getattr(store, '_store_version', 2)
         if store_version == 3:
-            members = store.list_prefix(data_root + path)  # type: ignore
-            members += store.list_prefix(meta_root + path)  # type: ignore
+            if path == '':
+                # have to list the root folders without trailing / in this case
+                members = store.list_prefix(data_root.rstrip('/'))   # type: ignore
+                members += store.list_prefix(meta_root.rstrip('/'))  # type: ignore
+            else:
+                members = store.list_prefix(data_root + path)  # type: ignore
+                members += store.list_prefix(meta_root + path)  # type: ignore
+            # also include zarr.json?
             # members += ['zarr.json']
         else:
             members = listdir(store, path)

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -73,11 +73,6 @@ def test_open_array(path_type, zarr_version):
     assert isinstance(z, Array)
     assert z.shape == (200,)
 
-    if zarr_version == 3:
-        # cannot open a v3 array without path
-        with pytest.raises(ValueError):
-            open(store, mode='w', shape=200, zarr_version=3)
-
     # open array, read-only
     z = open(store, mode='r', **kwargs)
     assert isinstance(z, Array)
@@ -107,11 +102,6 @@ def test_open_group(path_type, zarr_version):
     g = open(store, mode='w', **kwargs)
     assert isinstance(g, Group)
     assert 'foo' not in g
-
-    if zarr_version == 3:
-        # cannot open a v3 group without path
-        with pytest.raises(ValueError):
-            open(store, mode='w', zarr_version=3)
 
     # open group, read-only
     g = open(store, mode='r', **kwargs)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -170,15 +170,24 @@ class TestArray(unittest.TestCase):
 
         # dict as store
         z = self.create_array(shape=1000, chunks=100)
-        expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
+        if self.version == 3:
+            expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        else:
+            expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
-        expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
+        if self.version == 3:
+            expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+        else:
+            expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored
 
         # mess with store
         try:
-            z.store[z._key_prefix + 'foo'] = list(range(10))
+            if self.version == 2:
+                z.store[z._key_prefix + 'foo'] = list(range(10))
+            else:
+                z.store['meta/root/foo'] = list(range(10))
             assert -1 == z.nbytes_stored
         except TypeError:
             pass

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2729,8 +2729,7 @@ class TestArrayV3(TestArray):
             "c780221df84eb91cb62f633f12d3f1eaa9cee6bd"
         ]
 
-    def test_nbytes_stored(self):
-        pass  # TODO: fix
+    # TODO: fix test_nbytes_stored
 
 
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -64,13 +64,15 @@ from zarr.tests.util import abs_container, skip_test_env_var, have_fsspec
 class TestArray(unittest.TestCase):
 
     version = 2
+    root = ''
+    KVStoreClass = KVStore
 
     def test_array_init(self):
 
         # normal initialization
-        store = KVStore(dict())
+        store = self.KVStoreClass(dict())
         init_array(store, shape=100, chunks=10, dtype="<f8")
-        a = Array(store)
+        a = Array(store, zarr_version=self.version)
         assert isinstance(a, Array)
         assert (100,) == a.shape
         assert (10,) == a.chunks
@@ -78,13 +80,16 @@ class TestArray(unittest.TestCase):
         assert a.name is None
         assert a.basename is None
         assert store is a.store
-        assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
+        if self.version == 2:
+            assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
+        else:
+            assert "968dccbbfc0139f703ead2fd1d503ad6e44db307" == a.hexdigest()
         store.close()
 
         # initialize at path
-        store = KVStore(dict())
+        store = self.KVStoreClass(dict())
         init_array(store, shape=100, chunks=10, path='foo/bar', dtype='<f8')
-        a = Array(store, path='foo/bar')
+        a = Array(store, path='foo/bar', zarr_version=self.version)
         assert isinstance(a, Array)
         assert (100,) == a.shape
         assert (10,) == a.chunks
@@ -92,28 +97,31 @@ class TestArray(unittest.TestCase):
         assert '/foo/bar' == a.name
         assert 'bar' == a.basename
         assert store is a.store
-        assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
-
+        if self.version == 2:
+            assert "8fecb7a17ea1493d9c1430d04437b4f5b0b34985" == a.hexdigest()
+        else:
+            assert "968dccbbfc0139f703ead2fd1d503ad6e44db307" == a.hexdigest()
         # store not initialized
-        store = KVStore(dict())
+        store = self.KVStoreClass(dict())
         with pytest.raises(ValueError):
-            Array(store)
+            Array(store, zarr_version=self.version)
 
         # group is in the way
-        store = KVStore(dict())
+        store = self.KVStoreClass(dict())
         init_group(store, path='baz')
         with pytest.raises(ValueError):
-            Array(store, path='baz')
+            Array(store, path='baz', zarr_version=self.version)
 
     def create_array(self, read_only=False, **kwargs):
-        store = KVStore(dict())
+        store = self.KVStoreClass(dict())
         kwargs.setdefault('compressor', Zlib(level=1))
         cache_metadata = kwargs.pop('cache_metadata', True)
         cache_attrs = kwargs.pop('cache_attrs', True)
         write_empty_chunks = kwargs.pop('write_empty_chunks', True)
         init_array(store, **kwargs)
         return Array(store, read_only=read_only, cache_metadata=cache_metadata,
-                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks)
+                     cache_attrs=cache_attrs, write_empty_chunks=write_empty_chunks,
+                     zarr_version=self.version)
 
     def test_store_has_text_keys(self):
         # Initialize array
@@ -1003,7 +1011,7 @@ class TestArray(unittest.TestCase):
 
             assert 0 == z.nchunks_initialized
             # manually put something into the store to confuse matters
-            z.store['foo'] = b'bar'
+            z.store[self.root + 'foo'] = b'bar'
             assert 0 == z.nchunks_initialized
             z[:] = 42
             assert 10 == z.nchunks_initialized
@@ -2703,19 +2711,26 @@ class TestArrayWithFSStoreNestedPartialRead(TestArray):
 # StoreV3 test classes inheriting from the above below this point
 ####
 
-# Start with TestArrayWithPathV3 not TestArrayV3 since path must be supplied
-
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")
-class TestArrayV3(unittest.TestCase):
+class TestArrayV3(TestArray):
 
     version = 3
+    root = meta_root
+    KVStoreClass = KVStoreV3
 
-    def test_array_init(self):
+    def expected(self):
+        # tests for array without path will not be run for v3 stores
+        assert self.version == 3
+        return [
+            "73ab8ace56719a5c9308c3754f5e2d57bc73dc20",
+            "5fb3d02b8f01244721582929b3cad578aec5cea5",
+            "26b098bedb640846e18dc2fbc1c27684bb02b532",
+            "799a458c287d431d747bec0728987ca4fe764549",
+            "c780221df84eb91cb62f633f12d3f1eaa9cee6bd"
+        ]
 
-        # normal initialization without path
-        store = KVStoreV3(dict())
-        init_array(store, shape=100, chunks=10, dtype="<f8")
-        Array(store)
+    def test_nbytes_stored(self):
+        pass  # TODO: fix
 
 
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -19,9 +19,6 @@ from pkg_resources import parse_version
 
 from zarr._storage.store import (
     v3_api_available,
-    _prefix_to_array_key,
-    _prefix_to_attrs_key,
-    _prefix_to_group_key
 )
 from zarr.core import Array
 from zarr.errors import ArrayNotFoundError, ContainsGroupError
@@ -171,13 +168,17 @@ class TestArray(unittest.TestCase):
         # dict as store
         z = self.create_array(shape=1000, chunks=100)
         if self.version == 3:
-            expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+            expect_nbytes_stored = sum(
+                buffer_size(v) for k, v in z.store.items() if k != 'zarr.json'
+            )
         else:
             expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored
         z[:] = 42
         if self.version == 3:
-            expect_nbytes_stored = sum(buffer_size(v) for k, v in z.store.items() if k != 'zarr.json')
+            expect_nbytes_stored = sum(
+                buffer_size(v) for k, v in z.store.items() if k != 'zarr.json'
+            )
         else:
             expect_nbytes_stored = sum(buffer_size(v) for v in z.store.values())
         assert expect_nbytes_stored == z.nbytes_stored

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -53,7 +53,7 @@ class MockH5pyDataset:
         return self.data[item]
 
 
-def _init_creation_kwargs(zarr_version, at_root=False):
+def _init_creation_kwargs(zarr_version, at_root=True):
     kwargs = {'zarr_version': zarr_version}
     if not at_root:
         kwargs['path'] = 'array'

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -53,18 +53,19 @@ class MockH5pyDataset:
         return self.data[item]
 
 
-def _init_creation_kwargs(zarr_version):
+def _init_creation_kwargs(zarr_version, at_root=False):
     kwargs = {'zarr_version': zarr_version}
-    if zarr_version == 3:
+    if not at_root:
         kwargs['path'] = 'array'
     return kwargs
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_array(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_array(zarr_version, at_root):
 
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
 
     # with numpy array
     a = np.arange(100)
@@ -121,16 +122,18 @@ def test_array(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_empty(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_empty(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     z = empty(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_zeros(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_zeros(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     z = zeros(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
@@ -138,8 +141,9 @@ def test_zeros(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_ones(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_ones(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     z = ones(100, chunks=10, **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
@@ -147,8 +151,9 @@ def test_ones(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_full(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_full(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     z = full(100, chunks=10, fill_value=42, dtype='i4', **kwargs)
     assert (100,) == z.shape
     assert (10,) == z.chunks
@@ -195,10 +200,11 @@ def test_full_additional_dtypes(zarr_version):
 
 @pytest.mark.parametrize('dimension_separator', ['.', '/', None])
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_open_array(zarr_version, dimension_separator):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_open_array(zarr_version, at_root, dimension_separator):
 
     store = 'data/array.zarr'
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
 
     # mode == 'w'
     z = open_array(store, mode='w', shape=100, chunks=10,
@@ -391,11 +397,12 @@ def test_open_array_n5(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_open_array_dict_store(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_open_array_dict_store(zarr_version, at_root):
 
     # dict will become a KVStore
     store = dict()
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_store_type = KVStoreV3 if zarr_version == 3 else KVStore
 
     # mode == 'w'
@@ -409,8 +416,9 @@ def test_open_array_dict_store(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_create_in_dict(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_create_in_dict(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_store_type = KVStoreV3 if zarr_version == 3 else KVStore
 
     for func in [empty, zeros, ones]:
@@ -422,8 +430,9 @@ def test_create_in_dict(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_empty_like(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_empty_like(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     # zarr array
@@ -471,9 +480,10 @@ def test_empty_like(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_zeros_like(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_zeros_like(zarr_version, at_root):
 
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     # zarr array
@@ -498,9 +508,10 @@ def test_zeros_like(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_ones_like(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_ones_like(zarr_version, at_root):
 
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     # zarr array
@@ -526,9 +537,10 @@ def test_ones_like(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_full_like(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_full_like(zarr_version, at_root):
 
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     z = full(100, chunks=10, dtype='f4', compressor=Zlib(5),
@@ -556,8 +568,9 @@ def test_full_like(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_open_like(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_open_like(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     # zarr array
@@ -587,16 +600,13 @@ def test_open_like(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_create(zarr_version):
-    kwargs = _init_creation_kwargs(zarr_version)
+@pytest.mark.parametrize('at_root', [False, True])
+def test_create(zarr_version, at_root):
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
     # defaults
     z = create(100, **kwargs)
-    if zarr_version == 3:
-        with pytest.raises(ValueError):
-            # cannot create without specifying a path
-            z = create(100, zarr_version=3)
     assert isinstance(z, Array)
     assert (100,) == z.shape
     assert (100,) == z.chunks  # auto-chunks
@@ -694,10 +704,11 @@ def test_compression_args(zarr_version):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_create_read_only(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_create_read_only(zarr_version, at_root):
     # https://github.com/alimanfoo/zarr/issues/151
 
-    kwargs = _init_creation_kwargs(zarr_version)
+    kwargs = _init_creation_kwargs(zarr_version, at_root)
 
     # create an array initially read-only, then enable writing
     z = create(100, read_only=True, **kwargs)

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1621,7 +1621,11 @@ def test_open_group(zarr_version):
     assert 0 == len(g)
     g.create_groups('foo', 'bar')
     assert 2 == len(g)
-    with pytest.raises(ValueError):
+    if zarr_version == 2:
+        with pytest.raises(ValueError):
+            open_group('data/array.zarr', mode='a', zarr_version=zarr_version)
+    else:
+        # TODO, root: should this raise an error?
         open_group('data/array.zarr', mode='a', zarr_version=zarr_version)
 
     # mode in 'w-', 'x'

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -187,10 +187,6 @@ class TestGroup(unittest.TestCase):
             g4.create_group('/a/b/c')  # already exists
         with pytest.raises(ValueError):
             g1.create_group('')
-        with pytest.raises(ValueError):
-            g1.create_group('/')
-        with pytest.raises(ValueError):
-            g1.create_group('//')
 
         # multi
         g6, g7 = g1.create_groups('y', 'z')
@@ -1020,17 +1016,13 @@ class TestGroup(unittest.TestCase):
             # case, but have kept it for v2 behavior compatibility)
             assert g2 == g1['foo//bar']
 
+            # TODO, root: fix these cases
             # v3: leading / implies we are at the root, not within a group,
             # so these all raise KeyError
             for path in ['/foo/bar', '//foo/bar', '//foo//bar//',
                          '///fooo///bar///']:
                 with pytest.raises(KeyError):
                     g1[path]
-
-            # For v3 a prefix must be supplied
-            for path in ['/', '//', '///']:
-                with pytest.raises(ValueError):
-                    g2[path]
 
         with pytest.raises(ValueError):
             g1['.']
@@ -1556,9 +1548,6 @@ def test_group(zarr_version):
         assert '/' == g.name
     else:
         g = group(path='group1', zarr_version=zarr_version)
-        with pytest.raises(ValueError):
-            # must supply path for v3 groups
-            group(zarr_version=3)
         assert 'group1' == g.path
         assert '/group1' == g.name
     assert isinstance(g, Group)
@@ -1772,9 +1761,10 @@ def _check_tree(g, expect_bytes, expect_text):
 
 
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
-def test_tree(zarr_version):
+@pytest.mark.parametrize('at_root', [False, True])
+def test_tree(zarr_version, at_root):
     # setup
-    path = None if zarr_version == 2 else 'group1'
+    path = None if at_root else 'group1'
     g1 = group(path=path, zarr_version=zarr_version)
     g2 = g1.create_group('foo')
     g3 = g1.create_group('bar')
@@ -1782,17 +1772,18 @@ def test_tree(zarr_version):
     g5 = g3.create_group('quux')
     g5.create_dataset('baz', shape=100, chunks=10)
 
+    tree_path = '/' if at_root else path
     # test root group
     if zarr_version == 2:
-        expect_bytes = textwrap.dedent("""\
-        /
+        expect_bytes = textwrap.dedent(f"""\
+        {tree_path}
          +-- bar
          |   +-- baz
          |   +-- quux
          |       +-- baz (100,) float64
          +-- foo""").encode()
-        expect_text = textwrap.dedent("""\
-        /
+        expect_text = textwrap.dedent(f"""\
+        {tree_path}
          ├── bar
          │   ├── baz
          │   └── quux
@@ -1801,15 +1792,15 @@ def test_tree(zarr_version):
     else:
         # Almost the same as for v2, but has a path name and the
         # subgroups are not necessarily sorted alphabetically.
-        expect_bytes = textwrap.dedent("""\
-        group1
+        expect_bytes = textwrap.dedent(f"""\
+        {tree_path}
          +-- foo
          +-- bar
              +-- baz
              +-- quux
                  +-- baz (100,) float64""").encode()
-        expect_text = textwrap.dedent("""\
-        group1
+        expect_text = textwrap.dedent(f"""\
+        {tree_path}
          ├── foo
          └── bar
              ├── baz

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -316,9 +316,6 @@ def normalize_storage_path(path: Union[str, bytes, None]) -> str:
     if path is not None and not isinstance(path, str):
         path = str(path)
 
-    if path == '/':
-        return path
-
     if path:
 
         # convert backslash to forward slash

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -316,6 +316,9 @@ def normalize_storage_path(path: Union[str, bytes, None]) -> str:
     if path is not None and not isinstance(path, str):
         path = str(path)
 
+    if path == '/':
+        return path
+
     if path:
 
         # convert backslash to forward slash


### PR DESCRIPTION
closes #1039

v3 spec states path = '/' for arrays gives an array at /meta/root.array.json
               path = '/' for groups gives a group at /meta/root.array.json

In this implementation `path=None` will also result in a root array. Creation routines default to `path=None`, so this makes it so that the path argument does not have to be manually specified. 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
