### PR TITLE
add storage_transformers and get/set_partial_values

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -289,7 +289,9 @@ class Array:
                 if self._chunk_store is not None:
                     transformed_chunk_store = self._chunk_store
                     for storage_transformer in storage_transformers:
-                        transformed_chunk_store = storage_transformer._copy_for_array(transformed_chunk_store)
+                        transformed_chunk_store = (
+                            storage_transformer._copy_for_array(transformed_chunk_store)
+                        )
                     self._chunk_store = transformed_chunk_store
 
     def _refresh_metadata(self):

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -280,6 +280,18 @@ class Array:
                 filters = [get_codec(config) for config in filters]
             self._filters = filters
 
+            if self._version == 3:
+                storage_transformers = meta.get('storage_transformers', [])
+                transformed_store = self._store
+                for storage_transformer in storage_transformers:
+                    transformed_store = storage_transformer._copy_for_array(transformed_store)
+                self._store = transformed_store
+                if self._chunk_store is not None:
+                    transformed_chunk_store = self._chunk_store
+                    for storage_transformer in storage_transformers:
+                        transformed_chunk_store = storage_transformer._copy_for_array(transformed_chunk_store)
+                    self._chunk_store = transformed_chunk_store
+
     def _refresh_metadata(self):
         if not self._cache_metadata:
             self._load_metadata()

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -21,7 +21,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
            overwrite=False, path=None, chunk_store=None, filters=None,
            cache_metadata=True, cache_attrs=True, read_only=False,
            object_codec=None, dimension_separator=None, write_empty_chunks=True,
-           *, zarr_version=None, **kwargs):
+           storage_transformers=None, *, zarr_version=None, **kwargs):
     """Create an array.
 
     Parameters
@@ -161,7 +161,7 @@ def create(shape, chunks=True, dtype=None, compressor='default',
     init_array(store, shape=shape, chunks=chunks, dtype=dtype, compressor=compressor,
                fill_value=fill_value, order=order, overwrite=overwrite, path=path,
                chunk_store=chunk_store, filters=filters, object_codec=object_codec,
-               dimension_separator=dimension_separator)
+               dimension_separator=dimension_separator, storage_transformers=storage_transformers)
 
     # instantiate array
     z = Array(store, path=path, chunk_store=chunk_store, synchronizer=synchronizer,

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -9,7 +9,11 @@ from numcodecs.abc import Codec
 from zarr.errors import MetadataError
 from zarr.util import json_dumps, json_loads
 
-from typing import cast, Union, Any, List, Mapping as MappingType, Optional
+from typing import cast, Union, Any, List, Mapping as MappingType, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from zarr._storage.store import StorageTransformer
+
 
 ZARR_FORMAT = 2
 ZARR_FORMAT_v3 = 3
@@ -460,6 +464,31 @@ class Metadata3(Metadata2):
         return codec
 
     @classmethod
+    def _encode_storage_transformer_metadata(cls, storage_transformer: "StorageTransformer") -> Optional[Mapping]:
+        return {
+            "extension": storage_transformer.extension_uri,
+            "type": storage_transformer.type,
+            "configuration": storage_transformer.get_config(),
+        }
+
+    @classmethod
+    def _decode_storage_transformer_metadata(cls, meta: Mapping) -> "StorageTransformer":
+        from zarr.tests.test_storage_v3 import DummyStorageTransfomer
+        KNOWN_STORAGE_TRANSFORMERS = [DummyStorageTransfomer]
+
+        conf = meta.get('configuration', {})
+        extension_uri = meta['extension']
+        transformer_type = meta['type']
+
+        for StorageTransformerCls in KNOWN_STORAGE_TRANSFORMERS:
+            if StorageTransformerCls.extension_uri == extension_uri:
+                break
+        else:
+            raise NotImplementedError
+
+        return StorageTransformerCls.from_config(transformer_type, conf)
+
+    @classmethod
     def decode_array_metadata(cls, s: Union[MappingType, str]) -> MappingType[str, Any]:
         meta = cls.parse_metadata(s)
 
@@ -476,6 +505,11 @@ class Metadata3(Metadata2):
             # TODO: remove dimension_separator?
 
             compressor = cls._decode_codec_metadata(meta.get("compressor", None))
+            storage_transformers = meta.get("storage_transformers", None)
+            if storage_transformers:
+                storage_transformers = [
+                    cls._decode_storage_transformer_metadata(i) for i in storage_transformers
+                ]
             extensions = meta.get("extensions", [])
             meta = dict(
                 shape=tuple(meta["shape"]),
@@ -493,6 +527,8 @@ class Metadata3(Metadata2):
             # compressor field should be absent when there is no compression
             if compressor:
                 meta['compressor'] = compressor
+            if storage_transformers:
+                meta['storage_transformers'] = storage_transformers
 
         except Exception as e:
             raise MetadataError("error decoding metadata: %s" % e)
@@ -514,6 +550,11 @@ class Metadata3(Metadata2):
             object_codec = None
 
         compressor = cls._encode_codec_metadata(meta.get("compressor", None))
+        storage_transformers = meta.get("storage_transformers", None)
+        if storage_transformers:
+            storage_transformers = [
+                cls._encode_storage_transformer_metadata(i) for i in storage_transformers
+            ]
         extensions = meta.get("extensions", [])
         meta = dict(
             shape=meta["shape"] + sdshape,
@@ -532,6 +573,8 @@ class Metadata3(Metadata2):
             meta["compressor"] = compressor
         if dimension_separator:
             meta["dimension_separator"] = dimension_separator
+        if storage_transformers:
+            meta["storage_transformers"] = storage_transformers
         return json_dumps(meta)
 
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -464,7 +464,10 @@ class Metadata3(Metadata2):
         return codec
 
     @classmethod
-    def _encode_storage_transformer_metadata(cls, storage_transformer: "StorageTransformer") -> Optional[Mapping]:
+    def _encode_storage_transformer_metadata(
+        cls,
+        storage_transformer: "StorageTransformer"
+    ) -> Optional[Mapping]:
         return {
             "extension": storage_transformer.extension_uri,
             "type": storage_transformer.type,

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -294,6 +294,7 @@ def init_array(
     filters=None,
     object_codec=None,
     dimension_separator=None,
+    storage_transformers=None,
 ):
     """Initialize an array store with the given configuration. Note that this is a low-level
     function and there should be no need to call this directly from user code.
@@ -421,7 +422,8 @@ def init_array(
                          order=order, overwrite=overwrite, path=path,
                          chunk_store=chunk_store, filters=filters,
                          object_codec=object_codec,
-                         dimension_separator=dimension_separator)
+                         dimension_separator=dimension_separator,
+                         storage_transformers=storage_transformers)
 
 
 def _init_array_metadata(
@@ -438,6 +440,7 @@ def _init_array_metadata(
     filters=None,
     object_codec=None,
     dimension_separator=None,
+    storage_transformers=None,
 ):
 
     store_version = getattr(store, '_store_version', 2)
@@ -559,6 +562,7 @@ def _init_array_metadata(
     if store_version < 3:
         meta.update(dict(chunks=chunks, dtype=dtype, order=order,
                          filters=filters_config))
+        assert not storage_transformers
     else:
         if dimension_separator is None:
             dimension_separator = "/"
@@ -572,7 +576,8 @@ def _init_array_metadata(
                                  separator=dimension_separator),
                  chunk_memory_layout=order,
                  data_type=dtype,
-                 attributes=attributes)
+                 attributes=attributes,
+                 storage_transformers=storage_transformers)
         )
 
     key = _prefix_to_array_key(store, _path_to_prefix(path))

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -729,7 +729,10 @@ def test_json_dumps_chunks_numpy_dtype():
 
 def test_create_with_storage_transformers():
     kwargs = _init_creation_kwargs(zarr_version=3)
-    transformer = DummyStorageTransfomer("dummy_type", test_value=DummyStorageTransfomer.TEST_CONSTANT)
+    transformer = DummyStorageTransfomer(
+        "dummy_type",
+        test_value=DummyStorageTransfomer.TEST_CONSTANT
+    )
     z = create(1000000000, chunks=True, storage_transformers=[transformer], **kwargs)
     assert isinstance(z._store, DummyStorageTransfomer)
     assert z._store.test_value == DummyStorageTransfomer.TEST_CONSTANT

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -20,6 +20,7 @@ from zarr.storage import DirectoryStore, KVStore
 from zarr._storage.store import v3_api_available
 from zarr._storage.v3 import DirectoryStoreV3, KVStoreV3
 from zarr.sync import ThreadSynchronizer
+from zarr.tests.test_storage_v3 import DummyStorageTransfomer
 
 _VERSIONS = ((None, 2, 3) if v3_api_available else (None, 2))
 _VERSIONS2 = ((2, 3) if v3_api_available else (2, ))
@@ -724,3 +725,11 @@ def test_create_read_only(zarr_version):
 def test_json_dumps_chunks_numpy_dtype():
     z = zeros((10,), chunks=(np.int64(2),))
     assert np.all(z[...] == 0)
+
+
+def test_create_with_storage_transformers():
+    kwargs = _init_creation_kwargs(zarr_version=3)
+    transformer = DummyStorageTransfomer("dummy_type", test_value=DummyStorageTransfomer.TEST_CONSTANT)
+    z = create(1000000000, chunks=True, storage_transformers=[transformer], **kwargs)
+    assert isinstance(z._store, DummyStorageTransfomer)
+    assert z._store.test_value == DummyStorageTransfomer.TEST_CONSTANT

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr._storage.store import _get_hierarchy_metadata, v3_api_available, StorageTransformer, StoreV3
+from zarr._storage.store import _get_hierarchy_metadata, v3_api_available, StorageTransformer
 from zarr.meta import _default_entry_point_metadata_v3
 from zarr.storage import (atexit_rmglob, atexit_rmtree, data_root,
                           default_compressor, getsize, init_array, meta_root,
@@ -92,8 +92,8 @@ class InvalidDummyStore():
 class DummyStorageTransfomer(StorageTransformer):
     TEST_CONSTANT = "test1234"
 
-    extension_uri="https://purl.org/zarr/spec/storage_transformers/dummy/1.0"
-    valid_types=["dummy_type"]
+    extension_uri = "https://purl.org/zarr/spec/storage_transformers/dummy/1.0"
+    valid_types = ["dummy_type"]
 
     def __init__(self, _type, test_value) -> None:
         super().__init__(_type)
@@ -203,7 +203,9 @@ class StoreV3Tests(_StoreTests):
 
         store = self.create_store()
         path = 'arr1'
-        transformer = DummyStorageTransfomer("dummy_type", test_value=DummyStorageTransfomer.TEST_CONSTANT)
+        transformer = DummyStorageTransfomer(
+            "dummy_type", test_value=DummyStorageTransfomer.TEST_CONSTANT
+        )
         init_array(store, path=path, shape=1000, chunks=100,
                    dimension_separator=pass_dim_sep, storage_transformers=[transformer])
 

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -1,6 +1,7 @@
 import array
 import atexit
 import copy
+import inspect
 import os
 import tempfile
 
@@ -8,7 +9,7 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr._storage.store import _get_hierarchy_metadata, v3_api_available
+from zarr._storage.store import _get_hierarchy_metadata, v3_api_available, StorageTransformer, StoreV3
 from zarr.meta import _default_entry_point_metadata_v3
 from zarr.storage import (atexit_rmglob, atexit_rmtree, data_root,
                           default_compressor, getsize, init_array, meta_root,
@@ -86,6 +87,18 @@ class InvalidDummyStore():
 
     def keys(self):
         """keys"""
+
+
+class DummyStorageTransfomer(StorageTransformer):
+    TEST_CONSTANT = "test1234"
+
+    extension_uri="https://purl.org/zarr/spec/storage_transformers/dummy/1.0"
+    valid_types=["dummy_type"]
+
+    def __init__(self, _type, test_value) -> None:
+        super().__init__(_type)
+        assert test_value == self.TEST_CONSTANT
+        self.test_value = test_value
 
 
 def test_ensure_store_v3():
@@ -190,8 +203,9 @@ class StoreV3Tests(_StoreTests):
 
         store = self.create_store()
         path = 'arr1'
+        transformer = DummyStorageTransfomer("dummy_type", test_value=DummyStorageTransfomer.TEST_CONSTANT)
         init_array(store, path=path, shape=1000, chunks=100,
-                   dimension_separator=pass_dim_sep)
+                   dimension_separator=pass_dim_sep, storage_transformers=[transformer])
 
         # check metadata
         mkey = meta_root + path + '.array.json'
@@ -204,6 +218,9 @@ class StoreV3Tests(_StoreTests):
         assert meta['fill_value'] is None
         # Missing MUST be assumed to be "/"
         assert meta['chunk_grid']['separator'] is want_dim_sep
+        assert len(meta["storage_transformers"]) == 1
+        assert isinstance(meta["storage_transformers"][0], DummyStorageTransfomer)
+        assert meta["storage_transformers"][0].test_value == DummyStorageTransfomer.TEST_CONSTANT
         store.close()
 
     def test_list_prefix(self):
@@ -234,6 +251,46 @@ class StoreV3Tests(_StoreTests):
         else:
             with pytest.raises(NotImplementedError):
                 store.rename('a', 'b')
+
+    def test_get_partial_values(self):
+        store = self.create_store()
+        store[data_root + 'foo'] = b'abcdefg'
+        store[data_root + 'baz'] = b'z'
+        assert [b'a'] == store.get_partial_values(
+            [
+                (data_root + 'foo', (0, 1))
+            ]
+        )
+        assert [b'd', b'b', b'z', b'abc', b'defg'] == store.get_partial_values(
+            [
+                (data_root + 'foo', (3, 1)),
+                (data_root + 'foo', (1, 1)),
+                (data_root + 'baz', (0, 1)),
+                (data_root + 'foo', (0, 3)),
+                (data_root + 'foo', (3, 4)),
+            ]
+        )
+
+    def test_set_partial_values(self):
+        store = self.create_store()
+        store[data_root + 'foo'] = b'abcdefg'
+        store[data_root + 'baz'] = b'z'
+        store.set_partial_values(
+            [
+                (data_root + 'foo', 0, b'hey')
+            ]
+        )
+        assert store[data_root + 'foo'] == b'heydefg'
+        store.set_partial_values(
+            [
+                (data_root + 'foo', 1, b'oo'),
+                (data_root + 'baz', 1, b'zzz'),
+                (data_root + 'baz', 4, b'aaaa'),
+                (data_root + 'foo', 6, b'done'),
+            ]
+        )
+        assert store[data_root + 'foo'] == b'hoodefdone'
+        assert store[data_root + 'baz'] == b'zzzzaaaa'
 
 
 class TestMappingStoreV3(StoreV3Tests):
@@ -530,3 +587,19 @@ def test_top_level_imports():
             assert hasattr(zarr, store_name)  # pragma: no cover
         else:
             assert not hasattr(zarr, store_name)  # pragma: no cover
+
+
+def _get_public_and_dunder_methods(some_class):
+    return set(
+        name for name, _ in inspect.getmembers(some_class, predicate=inspect.isfunction)
+        if not name.startswith("_") or name.startswith("__")
+    )
+
+
+def test_storage_transformer_interface():
+    store_v3_methods = _get_public_and_dunder_methods(StoreV3)
+    store_v3_methods.discard("__init__")
+    storage_transformer_methods = _get_public_and_dunder_methods(StorageTransformer)
+    storage_transformer_methods.discard("__init__")
+    storage_transformer_methods.discard("get_config")
+    assert storage_transformer_methods == store_v3_methods


### PR DESCRIPTION
This PR adds two features of the [current v3 spec](https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html) to the zarr-python implementation:
* storage transformers
* `get_partial_values` and `set_partial_values`

The current spec is not finalized and waiting for finishing [review](https://github.com/zarr-developers/zarr-specs/pull/149) and approval of [ZEP001](https://zarr.dev/zeps/draft/ZEP0001.html). Since all v3 features are currently behind the `ZARR_V3_EXPERIMENTAL_API` flag, I think it might still be fine to incorporate those features to gain early feedback.

Both features are prerequisites for sharding as described [here](https://zarr-specs.readthedocs.io/en/latest/extensions/storage-transformers/sharding/v1.0.html#sharding-storage-transformer-v1), which I'd like to add as a follow-up PR, together with a new ZEP for it.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [New/modified features documented in docs/tutorial.rst] (v3 features seem not to be documented yet?)
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
