### PR TITLE
Simplify release docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -335,22 +335,23 @@ Release procedure
 .. note:: 
 
    Most of the release process is now handled by github workflow which should
-   automatically push a release to PyPI if a tag is pushed. 
+   automatically push a release to PyPI if a tag is pushed.
 
-Checkout and update the main branch::
+Before releasing, make sure that all pull requests which will be
+included in the release have been properly documented in
+`docs/release.rst`.
 
-    $ git checkout main
-    $ git pull
+To make a new release, go to
+https://github.com/zarr-developers/zarr-python/releases and
+click "Draft a new release". Choose a version number prefixed
+with a `v` (e.g. `v0.0.0`) and set the description to:
 
-Verify all tests pass on all supported Python versions, and docs build::
+```
+See release notes https://zarr.readthedocs.io/en/stable/release.html#release-0-0-0
+```
 
-    $ tox
+replacing the correct version numbers. For pre-release versions,
+the URL should omit the pre-release suffix, e.g. "a1" or "rc1".
 
-Tag the version (where "X.X.X" stands for the version number, e.g., "2.2.0")::
-
-    $ version=X.X.X
-    $ git tag -a v$version -m v$version
-    $ git push origin v$version
-
-Create a GitHub release in order to generate the Zenodo DOI and
-review the automatically generated zarr-feedstock PR.
+Be sure to review and merge the https://github.com/conda-forge/zarr-feedstock
+pull request that will be automatically generated.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,7 +16,7 @@ Release notes
 2.13.0
 ------
 .. warning::
-    Pre-release! Use `pip install --pre zarr` to evaluate this release.
+    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
 Major changes
 ~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed with @rabernat and @jakirkham, in order to encourage
more folks with push rights to release zarr-python, this change
makes it clear that a release is possible completely from within
GitHub. The previous instructions will continue to work but have
been removed to avoid confusion.


TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
