### PR TITLE
Remove/relax erroneous "meta" path check

### DIFF
--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -600,7 +600,6 @@ class Group(MutableMapping):
         if self._version == 2:
             for key in sorted(listdir(self._store, self._path)):
                 path = self._key_prefix + key
-                assert not path.startswith("meta/")
                 if contains_array(self._store, path):
                     _key = key.rstrip("/")
                     yield _key if keys_only else (_key, self[key])

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -600,7 +600,7 @@ class Group(MutableMapping):
         if self._version == 2:
             for key in sorted(listdir(self._store, self._path)):
                 path = self._key_prefix + key
-                assert not path.startswith("meta")
+                assert not path.startswith("meta/")
                 if contains_array(self._store, path):
                     _key = key.rstrip("/")
                     yield _key if keys_only else (_key, self[key])
@@ -615,7 +615,7 @@ class Group(MutableMapping):
                 if key.endswith(array_sfx):
                     key = key[:-len(array_sfx)]
                 path = self._key_prefix + key
-                assert not path.startswith("meta")
+                assert not path.startswith("meta/")
                 if key.endswith('.group' + self._metadata_key_suffix):
                     # skip group metadata keys
                     continue


### PR DESCRIPTION
[Description of PR]

resolves #1105

This PR removes the check disallowing keys starting with "meta" from the Zarr v2 code path. It was not there previously and appears to have been accidentally introduced along with the preliminary v3 support.

For v3, the check is updated to disallow starting with "meta/" instead of "meta" for consistency with `StoreV3._validate_key` (used by the `__setitem__` method of various v3 store classes). 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
~* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions~
~* [ ] New/modified features documented in docs/tutorial.rst~
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
