### PR TITLE
Add copy button to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'numpydoc',
     'sphinx_issues',
+    "sphinx_copybutton",
 ]
 
 numpydoc_show_class_members = False
@@ -312,3 +313,9 @@ texinfo_documents = [
 # :ref:`comparison manual <python:comparisons>`
 intersphinx_mapping = { 'python':('https://docs.python.org/', None), 
                         'numpy': ('https://numpy.org/doc/stable/', None)}
+
+
+# sphinx-copybutton configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_line_continuation_character = "\\"
+copybutton_prompt_is_regexp = True

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -39,6 +39,7 @@ Documentation
 ~~~~~~~~~~~~~
 
 * Typo fixes to close quotes. By :user:`Pavithra Eswaramoorthy <pavithraes>`
+* Added copy button to documentation :user:`Altay Sansal <tasansal>`
 
 Maintenance
 ~~~~~~~~~~~

--- a/requirements_rtfd.txt
+++ b/requirements_rtfd.txt
@@ -3,6 +3,7 @@ setuptools
 setuptools_scm
 sphinx
 sphinx-issues
+sphinx-copybutton
 sphinx-rtd-theme
 numpydoc
 numpy!=1.21.0


### PR DESCRIPTION
Added `sphinx_copybutton` extension to documentation.

Configuration strips `>>>`, `$`, and cell outputs, etc. Also supports multi line shell scripts `\\` (if needed in the future)

Here is the build with it enabled. It seems to be working as expected.
https://zarr--1124.org.readthedocs.build/en/1124/index.html

If the copy button has to be styled we can add a CSS too, right now its the default.

closes #1084 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
