### PR TITLE
Fix numcodecs dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = [
     'asciitree',
     'numpy>=1.7',
     'fasteners',
-    'numcodecs>=0.6.4',
+    'numcodecs>=0.10.0',
 ]
 
 setup(


### PR DESCRIPTION
`zarr` actually depends on `numcodecs>=0.10`, because it [imports `numcodecs.compat.ensure_ndarray_like`](https://github.com/zarr-developers/zarr-python/blob/main/zarr/util.py#L13) that has been introduced in `0.10.0`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
