### PR TITLE
Use generator instead of list comprehension

### DIFF
--- a/zarr/_storage/v3.py
+++ b/zarr/_storage/v3.py
@@ -153,7 +153,7 @@ class FSStoreV3(FSStore, StoreV3):
         # initialize the /data/root/... folder corresponding to the array!
         # Note: zarr.tests.test_core_v3.TestArrayWithFSStoreV3PartialRead fails
         # without this explicit creation of directories
-        subdirectories = set([os.path.dirname(v) for v in values.keys()])
+        subdirectories = set(os.path.dirname(v) for v in values.keys())
         for subdirectory in subdirectories:
             data_dir = os.path.join(self.path, subdirectory)
             if not self.fs.exists(data_dir):

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -559,7 +559,7 @@ def ix_(selection, shape):
 def oindex(a, selection):
     """Implementation of orthogonal indexing with slices and ints."""
     selection = replace_ellipsis(selection, a.shape)
-    drop_axes = tuple([i for i, s in enumerate(selection) if is_integer(s)])
+    drop_axes = tuple(i for i, s in enumerate(selection) if is_integer(s))
     selection = ix_(selection, a.shape)
     result = a[selection]
     if drop_axes:
@@ -569,7 +569,7 @@ def oindex(a, selection):
 
 def oindex_set(a, selection, value):
     selection = replace_ellipsis(selection, a.shape)
-    drop_axes = tuple([i for i, s in enumerate(selection) if is_integer(s)])
+    drop_axes = tuple(i for i, s in enumerate(selection) if is_integer(s))
     selection = ix_(selection, a.shape)
     if not np.isscalar(value) and drop_axes:
         value = np.asanyarray(value)
@@ -623,8 +623,8 @@ class OrthogonalIndexer:
                            if not isinstance(s, IntDimIndexer))
         self.is_advanced = not is_basic_selection(selection)
         if self.is_advanced:
-            self.drop_axes = tuple([i for i, dim_indexer in enumerate(self.dim_indexers)
-                                    if isinstance(dim_indexer, IntDimIndexer)])
+            self.drop_axes = tuple(i for i, dim_indexer in enumerate(self.dim_indexers)
+                                   if isinstance(dim_indexer, IntDimIndexer))
         else:
             self.drop_axes = None
 


### PR DESCRIPTION
[Redundant list comprehension can be replaced using generator PYL-R1728](https://deepsource.io/gh/DimitriPapadopoulos/zarr-python/issue/PYL-R1728/occurrences)

> Using a container in place of a generator for calls that can accept both, slows down the performance. Consider using generators for all function calls which accept both containers and genertors.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
