### PR TITLE
allow empty path in open_consolidated for zarr v3

### DIFF
--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1295,10 +1295,6 @@ def open_consolidated(store: StoreLike, metadata_key=".zmetadata", mode="r+", **
         # default is to store within 'consolidated' group on v3
         if not metadata_key.startswith('meta/root/'):
             metadata_key = 'meta/root/consolidated/' + metadata_key
-        if not path:
-            raise ValueError(
-                "path must be provided to open a Zarr 3.x consolidated store"
-            )
 
     # setup metadata store
     meta_store = ConsolidatedStoreClass(store, metadata_key=metadata_key)


### PR DESCRIPTION
closes #1141

`path=None` support for v3 was previously added in gh-1085. This change should have also been made at that time.

[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
