### PR TITLE
2.13.2: another fix for the conda-forge tests

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,15 @@ Release notes
     # .. warning::
     #    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
+.. _release_2.13.2:
+
+2.13.2
+------
+
+* Fix test failure on conda-forge builds (again).
+  By :user:`Josh Moore <joshmoore>`; see
+  `zarr-feedstock#65 <https://github.com/conda-forge/zarr-feedstock/pull/65>`_.
+
 .. _release_2.13.1:
 
 2.13.1

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -2563,11 +2563,12 @@ def test_normalize_store_arg(tmpdir):
 
 def test_meta_prefix_6853():
 
-    meta = pathlib.Path(zarr.__file__).resolve().parent.parent / "fixture" / "meta"
+    fixture = pathlib.Path(zarr.__file__).resolve().parent.parent / "fixture"
+    meta = fixture / "meta"
     if not meta.exists():   # pragma: no cover
         s = DirectoryStore(str(meta), dimension_separator=".")
         a = zarr.open(store=s, mode="w", shape=(2, 2), dtype="<i8")
         a[:] = [[1, 2], [3, 4]]
 
-    fixture = group(store=DirectoryStore('fixture'))
-    assert list(fixture.arrays())
+    fixtures = group(store=DirectoryStore(str(fixture)))
+    assert list(fixtures.arrays())


### PR DESCRIPTION
See description in https://github.com/zarr-developers/zarr-python/pull/1143 Testing locally, however, does not suffice. In this case, the relative path in the test worked for me, but doesn't work on conda-forge. The only reliable way to be sure is to run `./build-locally.py` in the zarr-feedstock **against pre-tagged code**. ⚠️ 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
