### PR TITLE
fastpath _array_iter for array_keys

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -75,8 +75,8 @@ The Zarr source code is hosted on GitHub at the following location:
 You will need your own fork to work on the code. Go to the link above and hit
 the "Fork" button. Then clone your fork to your local machine::
 
-    $ git clone git@github.com:your-user-name/zarr.git
-    $ cd zarr
+    $ git clone git@github.com:your-user-name/zarr-python.git
+    $ cd zarr-python
     $ git remote add upstream git@github.com:zarr-developers/zarr-python.git
 
 Creating a development environment

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -638,17 +638,19 @@ class Group(MutableMapping):
         else:
             dir_name = meta_root + self._path
             array_sfx = '.array' + self._metadata_key_suffix
+            group_sfx = '.group' + self._metadata_key_suffix
+
             for key in sorted(listdir(self._store, dir_name)):
                 if key.endswith(array_sfx):
                     key = key[:-len(array_sfx)]
-                path = self._key_prefix + key
-                assert not path.startswith("meta/")
-                if key.endswith('.group' + self._metadata_key_suffix):
-                    # skip group metadata keys
-                    continue
-                if contains_array(self._store, path):
                     _key = key.rstrip("/")
                     yield _key if keys_only else (_key, self[key])
+
+                path = self._key_prefix + key
+                assert not path.startswith("meta/")
+                if key.endswith(group_sfx):
+                    # skip group metadata keys
+                    continue
                 elif recurse and contains_group(self._store, path):
                     group = self[key]
                     for i in getattr(group, method)(recurse=recurse):


### PR DESCRIPTION
This PR modifies the v3 implementation of `Group._array_iter`. Previous behavior unnecessarily called `contains_array` for keys known to be arrays (i.e. keys that ended in `.array.json`). These changes fast track the iterator to return v3 array keys. In practice, this reduces the number of times a key is searched for in a store.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
