### PR TITLE
Omit chunks with no elements in slice selection with step

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,6 +14,15 @@ Release notes
     # .. warning::
     #    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
+.. _release_2.13.3:
+
+2.13.3
+------
+
+* Improve performance of slice selections with steps by omitting chunks with no relevant
+  data.
+  By :user:`J. Richard Moore <jrs65>` :issue:`843`.
+
 .. _release_2.13.2:
 
 2.13.2

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,7 +21,7 @@ Release notes
 
 * Improve performance of slice selections with steps by omitting chunks with no relevant
   data.
-  By :user:`J. Richard Moore <jrs65>` :issue:`843`.
+  By :user:`Richard Shaw <jrs65>` :issue:`843`.
 
 .. _release_2.13.2:
 

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -216,6 +216,11 @@ class SliceDimIndexer:
             dim_chunk_sel = slice(dim_chunk_sel_start, dim_chunk_sel_stop, self.step)
             dim_chunk_nitems = ceildiv((dim_chunk_sel_stop - dim_chunk_sel_start),
                                        self.step)
+
+            # If there are no elements on the selection within this chunk, then skip
+            if dim_chunk_nitems == 0:
+                continue
+
             dim_out_sel = slice(dim_out_offset, dim_out_offset + dim_chunk_nitems)
 
             yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)


### PR DESCRIPTION
This stops chunks being read unnecessarily when a slice selection with a step was used (reported in #843). 

Previously all chunks spanning the start-end range would be used regardless of whether they contained any elements. The changes in this PR are a small modification to `zarr.indexing.SliceDimIndexer` to stop it yielding empty selections up to `zarr.Array._get_selection`. Previously the chunk would be read and have no elements extracted from it, this stops it ever looking at the empty chunk.

I'm unsure about if a unit test should be added for this. It would be feasible to have a test asserting that only the minimal set of chunks are read, but that feels like it's testing an implementation detail. I'm happy to construct a test if that would be useful. Regardless I'll add some test code in a comment that succinctly shows the issue and the fix.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
