### PR TITLE
Remove LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,7 +1,0 @@
-# Config for LGTM.com static code analysis
-# https://lgtm.com/projects/g/zarr-developers/zarr-python
-
-extraction:
-  python:
-    python_setup:
-      version: 3


### PR DESCRIPTION
LGTM.com is being deprecated and replaced by GitHub code analysis:
[The next step for LGTM.com: GitHub code scanning!](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)

See also:
* #909
* #1127
* https://github.com/zarr-developers/zarr-python/pull/1158#issuecomment-1279834293

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [X] GitHub Actions have all passed
* [X] Test coverage is 100% (Codecov passes)
