### PR TITLE
Require `setuptools` 64.0.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "setuptools-scm", "wheel"]
+requires = ["setuptools>=64.0.0", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
I completely forgot that `setuptools` introduced editable installs in `v64.0.0`. This means that the installation will fail if a developer, who has `setuptools` < `v64.0.0` installed locally, tries to install `Zarr` with `pip install -e .` right now.

With this PR, the local version of `setuptools` will be automatically updated to the compatible version.

For more information see this tweet - https://twitter.com/juanluisback/status/1557734536586625025?t=rzVtT-91AwzSOvBHanCJ9g&s=19

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
