### PR TITLE
Tell codespell to skip `fixture` / fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
-        args: ["-L", "ba,ihs,kake,nd,noe,nwo,te"]
+        args: ["-L", "ba,ihs,kake,nd,noe,nwo,te", "-S", "fixture"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
 default_stages: [commit, push]
 default_language_version:
-  python: python3.9
+  python: python3
 repos:
   - repo: https://github.com/PyCQA/flake8
     rev: 3.8.2


### PR DESCRIPTION
This will avoid this kind of warnings with codespell 2.2.2:
```
WARNING: Decoding file using encoding=utf-8 failed: fixture/8/0/11
WARNING: Trying next encoding iso-8859-1
```

Seen in:
https://results.pre-commit.ci/run/github/48049137/1666036569.rj425j-vQKyvNbJ0CUHdcQ

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [X] GitHub Actions have all passed
* [X] Test coverage is 100% (Codecov passes)
