### PR TITLE
Use NumPy 1.20+ in `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - wheel
   - numcodecs >= 0.6.4
-  - numpy >= 1.7
+  - numpy >= 1.20
   - pip
   - pip:
     - asciitree


### PR DESCRIPTION
This `numpy` version constraint was missed when updating to `1.20` as a minimum. So go ahead and update it now.

xref: https://github.com/zarr-developers/zarr-python/pull/988
xref: https://github.com/zarr-developers/zarr-python/pull/1192

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
