### PR TITLE
Pin action versions (pypi-publish, setup-miniconda) for dependabot

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@master
+      uses: conda-incubator/setup-miniconda@v2
       with:
           channels: conda-forge
           environment-file: environment.yml

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           name: releases
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Closes #1148

Dependabot will now automatically update the actions with their latest stable release!

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
