### PR TITLE
Apply some pyupgrade suggestions

### DIFF
--- a/zarr/errors.py
+++ b/zarr/errors.py
@@ -1,5 +1,3 @@
-
-
 class MetadataError(Exception):
     pass
 

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -633,8 +633,7 @@ class Group(MutableMapping):
                     yield _key if keys_only else (_key, self[key])
                 elif recurse and contains_group(self._store, path):
                     group = self[key]
-                    for i in getattr(group, method)(recurse=recurse):
-                        yield i
+                    yield from getattr(group, method)(recurse=recurse)
         else:
             dir_name = meta_root + self._path
             array_sfx = '.array' + self._metadata_key_suffix
@@ -651,8 +650,7 @@ class Group(MutableMapping):
                     yield _key if keys_only else (_key, self[key])
                 elif recurse and contains_group(self._store, path):
                     group = self[key]
-                    for i in getattr(group, method)(recurse=recurse):
-                        yield i
+                    yield from getattr(group, method)(recurse=recurse)
 
     def visitvalues(self, func):
         """Run ``func`` on each object.
@@ -686,8 +684,7 @@ class Group(MutableMapping):
             yield obj
             keys = sorted(getattr(obj, "keys", lambda: [])())
             for k in keys:
-                for v in _visit(obj[k]):
-                    yield v
+                yield from _visit(obj[k])
 
         for each_obj in islice(_visit(self), 1, None):
             value = func(each_obj)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -702,8 +702,7 @@ def _dict_store_keys(d: Dict, prefix="", cls=dict):
     for k in d.keys():
         v = d[k]
         if isinstance(v, cls):
-            for sk in _dict_store_keys(v, prefix + k + '/', cls):
-                yield sk
+            yield from _dict_store_keys(v, prefix + k + '/', cls)
         else:
             yield prefix + k
 
@@ -863,8 +862,7 @@ class MemoryStore(Store):
         )
 
     def keys(self):
-        for k in _dict_store_keys(self.root, cls=self.cls):
-            yield k
+        yield from _dict_store_keys(self.root, cls=self.cls)
 
     def __iter__(self):
         return self.keys()
@@ -1462,7 +1460,7 @@ class FSStore(Store):
                     return sorted(new_children)
                 else:
                     return children
-        except IOError:
+        except OSError:
             return []
 
     def rmdir(self, path=None):
@@ -1794,8 +1792,7 @@ class ZipStore(Store):
             return sorted(self.zf.namelist())
 
     def keys(self):
-        for key in self.keylist():
-            yield key
+        yield from self.keylist()
 
     def __iter__(self):
         return self.keys()
@@ -2270,8 +2267,7 @@ class LMDBStore(Store):
     def values(self):
         with self.db.begin(buffers=self.buffers) as txn:
             with txn.cursor() as cursor:
-                for v in cursor.iternext(keys=False, values=True):
-                    yield v
+                yield from cursor.iternext(keys=False, values=True)
 
     def __iter__(self):
         return self.keys()
@@ -2581,8 +2577,7 @@ class SQLiteStore(Store):
 
     def items(self):
         kvs = self.cursor.execute('SELECT k, v FROM zarr')
-        for k, v in kvs:
-            yield k, v
+        yield from kvs
 
     def keys(self):
         ks = self.cursor.execute('SELECT k FROM zarr')
@@ -2796,12 +2791,10 @@ class RedisStore(Store):
                 for key in self.client.keys(self._key('*'))]
 
     def keys(self):
-        for key in self.keylist():
-            yield key
+        yield from self.keylist()
 
     def __iter__(self):
-        for key in self.keys():
-            yield key
+        yield from self.keys()
 
     def __len__(self):
         return len(self.keylist())


### PR DESCRIPTION
* Yield from an iterable instead of iterating to yield items.
* `io.open()` is an alias for for the builtin `open()` function:
  https://docs.python.org/3/library/io.html#io.open
* `IOError` is kept for compatibility with previous versions; starting from Python 3.3, it is an alias of `OSError`:
  https://docs.python.org/3/library/exceptions.html#IOError

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
