### PR TITLE
Redundant wheel in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "setuptools-scm", "wheel"]
+requires = ["setuptools>=64.0.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
The backend adds the wheel dependency automatically:
> The `setuptools` package implements the `build_sdist` command and the `wheel` package implements the `build_wheel` command; the latter is a dependency of the former exposed via [**PEP 517**](https://peps.python.org/pep-0517/) hooks.

Listing it explicitly in the documentation was a historical mistake and has been fixed since in pypa/setuptools@f7d30a9.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
