### PR TITLE
Workflow to label PRs with "needs release notes"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+needs release notes:
+- all: ['!docs/release.rst']

--- a/.github/workflows/needs_release_notes.yml
+++ b/.github/workflows/needs_release_notes.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        sync-labels: true

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,6 +29,9 @@ Maintenance
 * Remove ``tox`` support
   By :user:`Saransh Chopra <Saransh-cpp>` :issue:`1219`.
 
+* Add workflow to label PRs with "needs release notes".
+  By :user:`Saransh Chopra <Saransh-cpp>` :issue:`1239`.
+
 * Simplify if/else statement.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1227`.
 


### PR DESCRIPTION
See https://github.com/zarr-developers/zarr-python/pull/1193#issuecomment-1298824828

This will -
- label a PR with "needs release notes" if `docs/release.rst` has not been edited
- remove the label as soon as `docs/release.rst` is edited

A working demo - https://github.com/Saransh-cpp/zarr-python/pull/1

This will encourage (or maybe require, depending on the maintainers) developers to update `release.rst` with every PR! 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
