### PR TITLE
Consolidate `.coveragerc` into `pyproject.toml`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[run]
-omit =
-    zarr/meta_v1.py
-    bench/compress_normal.py
-
-[report]
-exclude_lines =
-    pragma: no cover
-    pragma: ${PY_MAJOR_VERSION} no cover

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -74,7 +74,7 @@ jobs:
         conda activate zarr-env
         mkdir ~/blob_emulator
         azurite -l ~/blob_emulator --debug debug.log 2>&1 > stdouterr.log &
-        pytest --cov=zarr --cov-config=.coveragerc --doctest-plus --cov-report xml --cov=./ --timeout=300
+        pytest --cov=zarr --cov-config=pyproject.toml --doctest-plus --cov-report xml --cov=./ --timeout=300
     - uses: codecov/codecov-action@v3
       with:
         #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -214,7 +214,7 @@ Zarr maintains 100% test coverage under the latest Python stable release (curren
 Python 3.8). Both unit tests and docstring doctests are included when computing
 coverage. Running::
     
-    $ python -m pytest -v --cov=zarr --cov-config=.coveragerc zarr
+    $ python -m pytest -v --cov=zarr --cov-config=pyproject.toml zarr
     
 will automatically run the test suite with coverage and produce a coverage report.
 This should be 100% before code can be accepted into the main code base.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -23,6 +23,9 @@ Maintenance
 * Migrate to ``pyproject.toml`` and remove redundant infrastructure.
   By :user:`Saransh Chopra <Saransh-cpp>` :issue:`1158`.
 
+* Migrate coverage to ``pyproject.toml``.
+  By :user:`John Kirkham <jakirkham>` :issue:`1250`.
+
 .. _release_2.13.3:
 
 2.13.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,17 @@ Discussions = "https://github.com/zarr-developers/zarr-python/discussions"
 Documentation = "https://zarr.readthedocs.io/"
 Homepage = "https://github.com/zarr-developers/zarr-python"
 
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: ${PY_MAJOR_VERSION} no cover",
+]
+
+[tool.coverage.run]
+omit = [
+    "zarr/meta_v1.py",
+    "bench/compress_normal.py",
+]
 
 [tool.setuptools]
 packages = ["zarr", "zarr._storage", "zarr.tests"]


### PR DESCRIPTION
Following [the coverage configuration docs]( https://coverage.readthedocs.io/en/6.5.0/config.html#configuration-reference ) this moves `.coveragerc` into `pyproject.toml`.

<hr>

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
