### PR TITLE
Bump pypi action

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           name: releases
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,7 +14,18 @@ Release notes
     # .. warning::
     #    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
-.. _release_2.13.4:
+.. _release_2.13.6:
+
+2.13.6
+------
+
+Maintenance
+~~~~~~~~~~~
+
+* Bump gh-action-pypi-publish to 1.6.4.
+  By :user:`Josh Moore <joshmoore>` :issue:`1320`.
+
+.. _release_2.13.5:
 
 2.13.5
 ------
@@ -24,6 +35,8 @@ Bug fixes
 
 * Ensure ``zarr.create`` uses writeable mode to fix issue with :issue:`1304`.
   By :user:`James Bourbeau <jrbourbeau>` :issue:`1309`.
+
+.. _release_2.13.4:
 
 2.13.4
 ------


### PR DESCRIPTION
2.13.4 and 2.13.5 were not released due to the following error:

```
Error: Unable to resolve action `pypa/gh-action-pypi-publish@v1`, unable to find version `v1`
```

TODO:
* [x] Changes documented in docs/release.rst
