### PR TITLE
remove blosc warnings from n5 compressor handling

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -22,7 +22,9 @@ Major changes
   adding partial store read/write and storage transformers.
   By :user:`Jonathan Striebel <jstriebel>`; :issue:`1096`.
 
-
+* Remove warnings emitted when using N5Store or N5FSStore with a blosc-compressed array.
+  By :user:`Davis Bennett <d-v-b>`; :issue:`1331`.
+  
 Bug fixes
 ~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ addopts = [
 ]
 filterwarnings = [
     "error:::zarr.*",
-    "ignore:Not all N5 implementations support blosc compression.*:RuntimeWarning",
     "ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning",
     "ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning",
 ]

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -735,12 +735,6 @@ def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict
 
     elif codec_id == 'blosc':
 
-        warnings.warn(
-            "Not all N5 implementations support blosc compression (yet). You "
-            "might not be able to open the dataset with another N5 library.",
-            RuntimeWarning
-        )
-
         n5_config['cname'] = _compressor_config['cname']
         n5_config['clevel'] = _compressor_config['clevel']
         n5_config['shuffle'] = _compressor_config['shuffle']
@@ -753,11 +747,6 @@ def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict
         if _compressor_config['format'] == 1 and _compressor_config['check'] in [-1, 4]:
             n5_config['type'] = 'xz'
         else:
-            warnings.warn(
-                "Not all N5 implementations support lzma compression (yet). You "
-                "might not be able to open the dataset with another N5 library.",
-                RuntimeWarning
-            )
             n5_config['format'] = _compressor_config['format']
             n5_config['check'] = _compressor_config['check']
             n5_config['filters'] = _compressor_config['filters']

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -747,6 +747,11 @@ def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict
         if _compressor_config['format'] == 1 and _compressor_config['check'] in [-1, 4]:
             n5_config['type'] = 'xz'
         else:
+            warnings.warn(
+                "Not all N5 implementations support lzma compression (yet). You "
+                "might not be able to open the dataset with another N5 library.",
+                RuntimeWarning
+            )
             n5_config['format'] = _compressor_config['format']
             n5_config['check'] = _compressor_config['check']
             n5_config['filters'] = _compressor_config['filters']

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2022,9 +2022,7 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
             a1[:] = 1
             assert np.all(a1[:] == 1)
 
-        compressors_warn = [
-            Blosc()
-        ]
+        compressors_warn = []
         if LZMA:
             compressors_warn.append(LZMA(2))  # Try lzma.FORMAT_ALONE, which N5 doesn't support.
         for compressor in compressors_warn:


### PR DESCRIPTION
Now that `blosc` support has been in the `n5` ecosystem for a while now (https://github.com/saalfeldlab/n5-blosc), we can remove the warnings relating to creating arrays with blosc compression via `n5store` variants.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
