### PR TITLE
use store dimension separtor in DirectoryStore.listdir

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -28,6 +28,8 @@ Bug fixes
 
 * Ensure contiguous data is give to ``FSStore``. Only copying if needed.
   By :user:`Mads R. B. Kristensen <madsbk>` :issue:`1285`.
+* NestedDirectoryStore.listdir now returns chunk keys with the correct '/' dimension_separator.
+  By :user:`Brett Graham <braingram>` :issue:`1334`.
 
 .. _release_2.13.6:
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1204,7 +1204,9 @@ class DirectoryStore(Store):
                         for file_name in file_names:
                             file_path = os.path.join(dir_path, file_name)
                             rel_path = file_path.split(root_path + os.path.sep)[1]
-                            new_children.append(rel_path.replace(os.path.sep, '.'))
+                            new_children.append(rel_path.replace(
+                                os.path.sep,
+                                self._dimension_separator or '.'))
                 else:
                     new_children.append(entry)
             return sorted(new_children)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1442,6 +1442,13 @@ class TestNestedDirectoryStore(TestDirectoryStore):
         store[self.root + '42'] = b'zzz'
         assert b'zzz' == store[self.root + '42']
 
+    def test_listdir(self):
+        store = self.create_store()
+        z = zarr.zeros((10, 10), chunks=(5, 5), store=store)
+        z[:] = 1  # write to all chunks
+        for k in store.listdir():
+            assert store.get(k) is not None
+
 
 class TestNestedDirectoryStoreNone:
 


### PR DESCRIPTION
NestedDirectoryStore which inherits from DirectoryStore only supports '/' as a dimension separator. However listdir uses the parent DirectoryStore.listdir which produces keys with an incorrect separator '.'

Fixes #1334

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
