### PR TITLE
Add API reference for V3 Implementation in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,7 @@ API reference
     api/codecs
     api/attrs
     api/sync
+    api/v3
 
 Indices and tables
 ------------------

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -16,11 +16,11 @@ Code snippet for creating Zarr V3 arrays::
 
 	>>> import zarr
 	>>> z = zarr.create((10000, 10000),
-	>>>			chunks=(100, 100),
-	>>>			dtype='f8',
-	>>>			compressor='default',
-	>>>			path='path-where-you-want-zarr-v3-array',
-	>>>			zarr_version=3)
+	>>>		chunks=(100, 100),
+	>>>		dtype='f8',
+	>>>		compressor='default',
+	>>>		path='path-where-you-want-zarr-v3-array',
+	>>>		zarr_version=3)
 
 Further, you can use `z.info` to see details about the array you just created::
 

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -14,8 +14,8 @@ the regular Zarr namespace.
 
 Code snippet for creating Zarr V3 arrays::
 
-	>>>import zarr
-	>>>z = zarr.create((10000, 10000),
+	>>> import zarr
+	>>> z = zarr.create((10000, 10000),
                     chunks=(100, 100),
                     dtype='f8',
                     compressor='default',
@@ -24,7 +24,7 @@ Code snippet for creating Zarr V3 arrays::
 
 Further, you can use `z.info` to see details about the array you just created::
 
-	>>>z.info
+	>>> z.info
 	Name               : path-where-you-want-zarr-v3-array
 	Type               : zarr.core.Array
 	Data type          : float64

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -1,0 +1,58 @@
+V3 Specification Implementation(``zarr._storage.v3``)
+=====================================================
+
+This module contains the implementation of the `Zarr V3 Specification <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#zarr-core-specification-v3-0>`_.
+
+Since Zarr Python 2.12 release, this module provides experimental infrastructure for reading and
+writing the upcoming V3 spec of the Zarr format. Users wishing to prepare for the migration can set
+the environment variable ``ZARR_V3_EXPERIMENTAL_API=1`` to begin experimenting, however data
+written with this API should not yet be considered final.
+
+The new ``zarr._store.v3`` package has the necessary classes and functions for evaluating Zarr V3.
+Since the design is not finalised, the classes and functions are not automatically imported into
+the regular Zarr namespace.
+
+Code snippet for creating Zarr V3 arrays::
+
+	>>>import zarr
+	>>>z = zarr.create((10000, 10000),
+                    chunks=(100, 100),
+                    dtype='f8',
+                    compressor='default',
+                    path='path-where-you-want-zarr-v3-array',
+                    zarr_version=3)
+
+Further, you can use `z.info` to see details about the array you just created::
+
+	>>>z.info
+	Name               : path-where-you-want-zarr-v3-array
+	Type               : zarr.core.Array
+	Data type          : float64
+	Shape              : (10000, 10000)
+	Chunk shape        : (100, 100)
+	Order              : C
+	Read-only          : False
+	Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
+	Store type         : zarr._storage.v3.KVStoreV3
+	No. bytes          : 800000000 (762.9M)
+	No. bytes stored   : 557
+	Storage ratio      : 1436265.7
+	Chunks initialized : 0/10000
+
+You can also check ``Store type`` here (which indicates Zarr V3).
+
+.. module:: zarr._storage.v3
+
+.. autoclass:: RmdirV3
+.. autoclass:: KVStoreV3
+.. autoclass:: FSStoreV3
+.. autoclass:: MemoryStoreV3
+.. autoclass:: DirectoryStoreV3
+.. autoclass:: ZipStoreV3
+.. autoclass:: RedisStoreV3
+.. autoclass:: MongoDBStoreV3
+.. autoclass:: DBMStoreV3
+.. autoclass:: LMDBStoreV3
+.. autoclass:: SQLiteStoreV3
+.. autoclass:: LRUStoreCacheV3
+.. autoclass:: ConsolidatedMetadataStoreV3

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -75,3 +75,21 @@ The abstract base class for storage transformers is
 .. module:: zarr._storage.store
 
 .. autoclass:: StorageTransformer
+
+In v3 `storage transformers <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#id19>`_
+can be set via ``zarr.create(…, storage_transformers=[…])``.
+The experimental sharding storage transformer can be tested by setting
+the environment variable ``ZARR_V3_SHARDING=1``. Data written with this flag
+enabled should be expected to become stale until
+`ZEP 2 <https://zarr.dev/zeps/draft/ZEP0002.html>`_ is approved
+and fully implemented.
+
+.. module:: zarr._storage.v3_storage_transformers
+
+.. autoclass:: ShardingStorageTransformer
+
+The abstract base class for storage transformers is
+
+.. module:: zarr._storage.store
+
+.. autoclass:: StorageTransformer

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -1,7 +1,7 @@
 V3 Specification Implementation(``zarr._storage.v3``)
 =====================================================
 
-This module contains the implementation of the `Zarr V3 Specification <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#zarr-core-specification-v3-0>`_.
+This module contains the implementation of the `Zarr V3 Specification <https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html>`_.
 
 .. warning::
     Since Zarr Python 2.12 release, this module provides experimental infrastructure for reading and
@@ -58,25 +58,7 @@ You can also check ``Store type`` here (which indicates Zarr V3).
 .. autoclass:: LRUStoreCacheV3
 .. autoclass:: ConsolidatedMetadataStoreV3
 
-In v3 `storage transformers <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#id19>`_
-can be set via ``zarr.create(…, storage_transformers=[…])``.
-The experimental sharding storage transformer can be tested by setting
-the environment variable ``ZARR_V3_SHARDING=1``. Data written with this flag
-enabled should be expected to become stale until
-`ZEP 2 <https://zarr.dev/zeps/draft/ZEP0002.html>`_ is approved
-and fully implemented.
-
-.. module:: zarr._storage.v3_storage_transformers
-
-.. autoclass:: ShardingStorageTransformer
-
-The abstract base class for storage transformers is
-
-.. module:: zarr._storage.store
-
-.. autoclass:: StorageTransformer
-
-In v3 `storage transformers <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#id19>`_
+In v3 `storage transformers <https://zarr-specs.readthedocs.io/en/latest/v3/array-storage-transformers/sharding/v1.0.html>`_
 can be set via ``zarr.create(…, storage_transformers=[…])``.
 The experimental sharding storage transformer can be tested by setting
 the environment variable ``ZARR_V3_SHARDING=1``. Data written with this flag

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -3,10 +3,11 @@ V3 Specification Implementation(``zarr._storage.v3``)
 
 This module contains the implementation of the `Zarr V3 Specification <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#zarr-core-specification-v3-0>`_.
 
-Since Zarr Python 2.12 release, this module provides experimental infrastructure for reading and
-writing the upcoming V3 spec of the Zarr format. Users wishing to prepare for the migration can set
-the environment variable ``ZARR_V3_EXPERIMENTAL_API=1`` to begin experimenting, however data
-written with this API should not yet be considered final.
+.. warning::
+    Since Zarr Python 2.12 release, this module provides experimental infrastructure for reading and
+    writing the upcoming V3 spec of the Zarr format. Users wishing to prepare for the migration can set
+    the environment variable ``ZARR_V3_EXPERIMENTAL_API=1`` to begin experimenting, however data
+    written with this API should be expected to become stale, as the implementation will still change.
 
 The new ``zarr._store.v3`` package has the necessary classes and functions for evaluating Zarr V3.
 Since the design is not finalised, the classes and functions are not automatically imported into

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -16,11 +16,11 @@ Code snippet for creating Zarr V3 arrays::
 
 	>>> import zarr
 	>>> z = zarr.create((10000, 10000),
-                    chunks=(100, 100),
-                    dtype='f8',
-                    compressor='default',
-                    path='path-where-you-want-zarr-v3-array',
-                    zarr_version=3)
+	>>>			chunks=(100, 100),
+	>>>			dtype='f8',
+	>>>			compressor='default',
+	>>>			path='path-where-you-want-zarr-v3-array',
+	>>>			zarr_version=3)
 
 Further, you can use `z.info` to see details about the array you just created::
 

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -57,3 +57,21 @@ You can also check ``Store type`` here (which indicates Zarr V3).
 .. autoclass:: SQLiteStoreV3
 .. autoclass:: LRUStoreCacheV3
 .. autoclass:: ConsolidatedMetadataStoreV3
+
+In v3 `storage transformers <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html#id19>`_
+can be set via ``zarr.create(…, storage_transformers=[…])``.
+The experimental sharding storage transformer can be tested by setting
+the environment variable ``ZARR_V3_SHARDING=1``. Data written with this flag
+enabled should be expected to become stale until
+`ZEP 2 <https://zarr.dev/zeps/draft/ZEP0002.html>`_ is approved
+and fully implemented.
+
+.. module:: zarr._storage.v3_storage_transformers
+
+.. autoclass:: ShardingStorageTransformer
+
+The abstract base class for storage transformers is
+
+.. module:: zarr._storage.store
+
+.. autoclass:: StorageTransformer


### PR DESCRIPTION
Hi all. I've added the API reference for V3 implementation in the docs. This issue was raised in the [community meeting](https://zarr.dev/community-calls) on 2/8 this week.

Linking this from #1337. Preview available here: https://zarr--1345.org.readthedocs.build/en/1345/api/v3.html

Let me know what you think. Suggestions welcome.

CC: @joshmoore @grlee77 @jstriebel 

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)