### PR TITLE
Ensure `zarr.group` uses writable mode

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,6 +15,17 @@ Release notes
     # .. warning::
     #    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
+.. _release_2.14.2:
+
+2.14.2
+------
+
+Bug fixes
+~~~~~~~~~
+
+* Ensure ``zarr.group`` uses writeable mode to fix issue with :issue:`1304`.
+  By :user:`Brandur Thorgrimsson <swordcat>` :issue:`1354`.
+
 .. _release_2.14.1:
 
 2.14.1

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1336,7 +1336,7 @@ def group(store=None, overwrite=False, chunk_store=None,
     """
 
     # handle polymorphic store arg
-    store = _normalize_store_arg(store, zarr_version=zarr_version)
+    store = _normalize_store_arg(store, zarr_version=zarr_version, mode='w')
     if zarr_version is None:
         zarr_version = getattr(store, '_store_version', DEFAULT_ZARR_VERSION)
 

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1591,6 +1591,17 @@ def test_group(zarr_version):
     assert store is g.store
 
 
+@pytest.mark.skipif(have_fsspec is False, reason='needs fsspec')
+@pytest.mark.parametrize('zarr_version', _VERSIONS)
+def test_group_writeable_mode(zarr_version, tmp_path):
+    # Regression test for https://github.com/zarr-developers/zarr-python/issues/1353
+    import fsspec
+
+    store = fsspec.get_mapper(str(tmp_path))
+    zg = group(store=store)
+    assert zg.store.map == store
+
+
 @pytest.mark.parametrize('zarr_version', _VERSIONS)
 def test_open_group(zarr_version):
     # test the open_group() convenience function


### PR DESCRIPTION
Closes #1352 and #1353

cc @flamingbear @rabernat 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~
* [ ] ~~New/modified features documented in docs/tutorial.rst~~
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
