### PR TITLE
One more fix for missing directories

### DIFF
--- a/zarr/tests/test_attrs.py
+++ b/zarr/tests/test_attrs.py
@@ -57,7 +57,7 @@ class TestAttributes():
         testdir = fixdir / "utf8attrs"
         if not testdir.exists():  # pragma: no cover
             # store the data - should be one-time operation
-            testdir.mkdir()
+            testdir.mkdir(parents=True, exist_ok=True)
             with (testdir / ".zattrs").open("w", encoding="utf-8") as f:
                 f.write('{"foo": "た"}')
             with (testdir / ".zgroup").open("w", encoding="utf-8") as f:


### PR DESCRIPTION
Deal with "fixtures" being located under lib/python3.11/site-packages/ _and_ that the other fixtures have not run first.

see: #1312
see: #1347
see: #1348
see: #1364
see: https://github.com/conda-forge/zarr-feedstock/pull/74

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
