### PR TITLE
Remove metadata in dtype_decode function. It fixes gh-1152, because h…

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -55,6 +55,9 @@ Bug fixes
 * Fix ``normalize_fill_value`` for structured arrays.
   By :user:`Alan Du <alanhdu>` :issue:`1397`.
 
+* Remove h5py metadata in ``dtype_decode`` function.
+  By :user:`ninousf <ninousf>` :issue:`1368`.
+
 .. _release_2.14.2:
 
 2.14.2

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -187,6 +187,12 @@ class Metadata2:
     @classmethod
     def _decode_dtype_descr(cls, d) -> List[Any]:
         # need to convert list of lists to list of tuples
+
+        # remove metadata in descr
+        if isinstance(d, (list, tuple)) and len(d) == 2 and isinstance(
+                d[1], dict):
+            return d[0]
+
         if isinstance(d, list):
             # recurse to handle nested structures
             d = [(k[0], cls._decode_dtype_descr(k[1])) + tuple(k[2:]) for k in d]

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -931,7 +931,7 @@ class TestCopy:
         source_h5py = source.__module__.startswith('h5py.')
         if source_h5py:
             # dtype with no metadata
-            dt = np.dtype([('address', 'S4'), ('value','S8')])
+            dt = np.dtype([('address', 'S4'), ('value', 'S8')])
 
             # h5py puts internal keys in dtype metadata
             ds = source.create_dataset("toto", (1,), dtype=dt)

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -927,6 +927,19 @@ class TestCopy:
         with pytest.raises(TypeError):
             copy(source['foo'], dest, dry_run=True, log=True)
 
+    def test_drop_metadata(self, source):
+        source_h5py = source.__module__.startswith('h5py.')
+        if source_h5py:
+            # dtype with no metadata
+            dt = np.dtype([('address', 'S4'), ('value','S8')])
+
+            # h5py puts internal keys in dtype metadata
+            ds = source.create_dataset("toto", (1,), dtype=dt)
+            z_from_h5 = zarr.zeros(1, dtype=ds.dtype)
+
+            # zarr should not take this into account
+            assert z_from_h5.dtype == dt
+
 
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")
 class TestCopyV3(TestCopy):

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -630,4 +630,4 @@ def test_drop_metadata(tmpdir):
     descr = [('address', ('|S4', {'h5py_encoding': 'ascii'})),
              ('value', ('|S8', {'h5py_encoding': 'ascii'}))]
     dt = decode_dtype(descr)
-    assert dt.descr == [('address', '|S4'), ('value','|S8')]
+    assert dt.descr == [('address', '|S4'), ('value', '|S8')]

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -623,3 +623,11 @@ def test_metadata3_exceptions():
 
     with pytest.raises(MetadataError):
         Metadata3.decode_array_metadata(dict())
+
+
+def test_drop_metadata(tmpdir):
+    # dtype descr with metadata, typical example found in an hdf5 dataset
+    descr = [('address', ('|S4', {'h5py_encoding': 'ascii'})),
+             ('value', ('|S8', {'h5py_encoding': 'ascii'}))]
+    dt = decode_dtype(descr)
+    assert dt.descr == [('address', '|S4'), ('value','|S8')]


### PR DESCRIPTION
h5py puts metadata in dtypes which are not correctly managed in numpy

revival of #1349
fixes #1152