### PR TITLE
Update release.rst for the upcoming release - 2.15.0

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,8 +15,28 @@ Unreleased
     # .. warning::
     #    Pre-release! Use :command:`pip install --pre zarr` to evaluate this release.
 
+.. _release_2.15.0:
+
+2.15.0
+------
+
+Enhancements
+~~~~~~~~~~~~
+
 * Implement more extensive fallback of getitem/setitem for orthogonal indexing.
   By :user:`Andreas Albert <AndreasAlbertQC>` :issue:`1029`.
+
+Documentation
+~~~~~~~~~~~~~
+
+* Add API reference for V3 Implementation in the docs.
+  By :user:`Sanket Verma <MSanKeys963>` :issue:`1345`.
+
+Bug fixes
+~~~~~~~~~
+
+* Fix the conda-forge error. Read :issue:`1347` for detailed info.
+  By :user:`Josh Moore <joshmoore>` :issue:`1364` and :issue:`1367`.
 
 .. _release_2.14.2:
 


### PR DESCRIPTION
Updated the `release.rst` for the upcoming 2.15.0 release. Please have a look.

CC: @joshmoore 

TODO:
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
