### PR TITLE
fix for readonly error in _normalize_store_arg_v3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v2.2.2
     hooks:
       - id: codespell
-        args: ["-L", "ba,ihs,kake,nd,noe,nwo,te", "-S", "fixture"]
+        args: ["-L", "ba,ihs,kake,nd,noe,nwo,te,fo", "-S", "fixture"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,12 @@ Unreleased
 * Implement more extensive fallback of getitem/setitem for orthogonal indexing.
   By :user:`Andreas Albert <AndreasAlbertQC>` :issue:`1029`.
 
+Bug fixes
+~~~~~~~~~
+
+* Fix ``ReadOnlyError`` when opening V3 store via fsspec reference file system.
+  By :user:`Joe Hamman <jhamman>` :issue:`1383`.
+
 .. _release_2.14.2:
 
 2.14.2

--- a/zarr/_storage/v3.py
+++ b/zarr/_storage/v3.py
@@ -618,12 +618,10 @@ def _normalize_store_arg_v3(store: Any, storage_options=None, mode="r") -> BaseS
             # return N5StoreV3(store)
         else:
             store = DirectoryStoreV3(store)
-        # add default zarr.json metadata
-        store['zarr.json'] = store._metadata_class.encode_hierarchy_metadata(None)
-        return store
     else:
         store = StoreV3._ensure_store(store)
-        if 'zarr.json' not in store:
-            # add default zarr.json metadata
-            store['zarr.json'] = store._metadata_class.encode_hierarchy_metadata(None)
+
+    if 'zarr.json' not in store:
+        # add default zarr.json metadata
+        store['zarr.json'] = store._metadata_class.encode_hierarchy_metadata(None)
     return store

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -596,6 +596,16 @@ def test_normalize_store_arg_v3(tmpdir):
         store = normalize_store_arg(fsspec.get_mapper("file://" + path), zarr_version=3)
         assert isinstance(store, FSStoreV3)
 
+        # regression for https://github.com/zarr-developers/zarr-python/issues/1382
+        # contents of zarr.json are not important for this test
+        out = {"version": 1, "refs": {"zarr.json": "{...}"}}
+        store = normalize_store_arg(
+            "reference://",
+            storage_options={"fo": out, "remote_protocol": "memory"},
+            zarr_version=3
+        )
+        assert isinstance(store, FSStoreV3)
+
     fn = tmpdir.join('store.n5')
     with pytest.raises(NotImplementedError):
         normalize_store_arg(str(fn), zarr_version=3, mode='w')


### PR DESCRIPTION
Fixes readonly error in `_normalize_store_arg_v3`

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)

closes #1382
