### PR TITLE
`open_array()`: adding the `meta_array` argument

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -29,6 +29,9 @@ Enhancements
 * Getitems supports ``meta_array``.
   By :user:`Mads R. B. Kristensen <madsbk>` :issue:`1131`.
 
+* ``open_array()`` now takes the ``meta_array`` argument.
+  By :user:`Mads R. B. Kristensen <madsbk>` :issue:`1396`.
+
 Maintenance
 ~~~~~~~~~~~
 
@@ -168,7 +171,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-* Fix minor indexing errors in tutorial and specification examples of documentation. 
+* Fix minor indexing errors in tutorial and specification examples of documentation.
   By :user:`Kola Babalola <sprynt001>` :issue:`1277`.
 
 * Add `requirements_rtfd.txt` in `contributing.rst`.

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -424,6 +424,7 @@ def open_array(
     *,
     zarr_version=None,
     dimension_separator=None,
+    meta_array=None,
     **kwargs
 ):
     """Open an array using file-mode-like semantics.
@@ -498,6 +499,11 @@ def open_array(
         ('/') format. If None, the appropriate value will be read from `store`
         when present. Otherwise, defaults to '.' when ``zarr_version == 2``
         and `/` otherwise.
+    meta_array : array-like, optional
+        An array instance to use for determining arrays to create and return
+        to users. Use `numpy.empty(())` by default.
+
+        .. versionadded:: 2.13
 
     Returns
     -------
@@ -607,7 +613,7 @@ def open_array(
     # instantiate array
     z = Array(store, read_only=read_only, synchronizer=synchronizer,
               cache_metadata=cache_metadata, cache_attrs=cache_attrs, path=path,
-              chunk_store=chunk_store, write_empty_chunks=write_empty_chunks)
+              chunk_store=chunk_store, write_empty_chunks=write_empty_chunks, meta_array=meta_array)
 
     return z
 

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -503,7 +503,7 @@ def open_array(
         An array instance to use for determining arrays to create and return
         to users. Use `numpy.empty(())` by default.
 
-        .. versionadded:: 2.13
+        .. versionadded:: 2.15
 
     Returns
     -------

--- a/zarr/tests/test_meta_array.py
+++ b/zarr/tests/test_meta_array.py
@@ -8,7 +8,7 @@ from numcodecs.registry import get_codec, register_codec
 
 import zarr.codecs
 from zarr.core import Array
-from zarr.creation import array, empty, full, ones, zeros
+from zarr.creation import array, empty, full, ones, open_array, zeros
 from zarr.hierarchy import open_group
 from zarr.storage import DirectoryStore, MemoryStore, Store, ZipStore
 
@@ -147,6 +147,23 @@ def test_array(tmp_path, module, compressor, store_type):
     assert z.chunks == z2.chunks
     assert z.dtype == z2.dtype
     xp.testing.assert_array_equal(z[:], z2[:])
+
+    store = init_store(tmp_path / "open_array", store_type)
+    a = xp.arange(100)
+    z = open_array(
+        store,
+        shape=a.shape,
+        dtype=a.dtype,
+        chunks=10,
+        compressor=compressor,
+        meta_array=xp.empty(())
+    )
+    z[:] = a
+    assert a.shape == z.shape
+    assert a.dtype == z.dtype
+    assert isinstance(a, type(z[:]))
+    assert isinstance(z.meta_array, type(xp.empty(())))
+    xp.testing.assert_array_equal(a, z[:])
 
 
 @pytest.mark.parametrize("module, compressor", param_module_and_compressor)


### PR DESCRIPTION
Like the other creation functions, `open_array()` now takes the  `meta_array` argument.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
