### PR TITLE
Fix `normalize_fill_value` for structured arrays

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -49,6 +49,9 @@ Bug fixes
 * Fix ``ReadOnlyError`` when opening V3 store via fsspec reference file system.
   By :user:`Joe Hamman <jhamman>` :issue:`1383`.
 
+* Fix ``normalize_fill_value`` for structured arrays.
+  By :user:`Alan Du <alanhdu>` :issue:`1397`.
+
 .. _release_2.14.2:
 
 2.14.2

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -119,6 +119,7 @@ def test_normalize_fill_value():
     structured_dtype = np.dtype([('foo', 'S3'), ('bar', 'i4'), ('baz', 'f8')])
     expect = np.array((b'', 0, 0.), dtype=structured_dtype)[()]
     assert expect == normalize_fill_value(0, dtype=structured_dtype)
+    assert expect == normalize_fill_value(expect, dtype=structured_dtype)
     assert '' == normalize_fill_value(0, dtype=np.dtype('U1'))
 
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -295,7 +295,7 @@ def normalize_fill_value(fill_value, dtype: np.dtype):
     if fill_value is None or dtype.hasobject:
         # no fill value
         pass
-    elif fill_value == 0:
+    elif not isinstance(fill_value, np.void) and fill_value == 0:
         # this should be compatible across numpy versions for any array type, including
         # structured arrays
         fill_value = np.zeros((), dtype=dtype)[()]


### PR DESCRIPTION
The FutureWarning identified in https://github.com/zarr-developers/zarr-python/issues/552 is now a `TypeError` in the latest numpy release. We can fix this bu checking whether `isinstance(fill_value, np.void)` *before* checking whether `fill_value == 0` (that way, if `fill_value` is already a structured dtype, then we do not compare it with a scalar).


One symptom of this is that

```python
import numpy as np
import zarr

dtype = np.dtype([("a", np.float64), ("b", np.int64)])
zarr.open_array([], shape=1000, dtype=dtype
```

will crash with

```
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 zarr.open_array({}, shape=1000, dtype=dtype)

File ~/workspace/zarr-python/zarr/creation.py:586, in open_array(store, mode, shape, chunks, dtype, compressor, fill_value, order, synchronizer, filters, cache_metadata, cache_attrs, path, object_codec, chunk_store, storage_options, partial_decompress, write_empty_chunks, zarr_version, dimension_separator, **kwargs)
    584         if contains_group(store, path=path):
    585             raise ContainsGroupError(path)
--> 586         init_array(store, shape=shape, chunks=chunks, dtype=dtype,
    587                    compressor=compressor, fill_value=fill_value,
    588                    order=order, filters=filters, path=path,
    589                    object_codec=object_codec, chunk_store=chunk_store,
    590                    dimension_separator=dimension_separator)
    592 elif mode in ['w-', 'x']:
    593     if contains_group(store, path=path):

File ~/workspace/zarr-python/zarr/storage.py:438, in init_array(store, shape, chunks, dtype, compressor, fill_value, order, overwrite, path, chunk_store, filters, object_codec, dimension_separator, storage_transformers)
    435 if not compressor:
    436     # compatibility with legacy tests using compressor=[]
    437     compressor = None
--> 438 _init_array_metadata(store, shape=shape, chunks=chunks, dtype=dtype,
    439                      compressor=compressor, fill_value=fill_value,
    440                      order=order, overwrite=overwrite, path=path,
    441                      chunk_store=chunk_store, filters=filters,
    442                      object_codec=object_codec,
    443                      dimension_separator=dimension_separator,
    444                      storage_transformers=storage_transformers)

File ~/workspace/zarr-python/zarr/storage.py:515, in _init_array_metadata(store, shape, chunks, dtype, compressor, fill_value, order, overwrite, path, chunk_store, filters, object_codec, dimension_separator, storage_transformers)
    513 chunks = normalize_chunks(chunks, shape, dtype.itemsize)
    514 order = normalize_order(order)
--> 515 fill_value = normalize_fill_value(fill_value, dtype)
    517 # optional array metadata
    518 if dimension_separator is None and store_version == 2:

File ~/workspace/zarr-python/zarr/util.py:298, in normalize_fill_value(fill_value, dtype)
    295 if fill_value is None or dtype.hasobject:
    296     # no fill value
    297     pass
--> 298 elif fill_value == 0:
    299     # this should be compatible across numpy versions for any array type, including
    300     # structured arrays
    301     fill_value = np.zeros((), dtype=dtype)[()]
    303 elif dtype.kind == 'U':
    304     # special case unicode because of encoding issues on Windows if passed through numpy
    305     # https://github.com/alimanfoo/zarr/pull/172#issuecomment-343782713

TypeError: Cannot compare structured or void to non-void arrays.
```

Closes #552.