### PR TITLE
Avoid deprecated `product` in ``numpy=1.25``

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -34,6 +34,9 @@ Maintenance
 * Remove ``codecov`` from GitHub actions.
   By :user:`John A. Kirkham <jakirkham>` :issue:`1391`.
 
+* Replace ``np.product`` with ``np.prod`` due to deprecation.
+  By :user:`James Bourbeau <jrbourbeau>` :issue:`1405`.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1479,7 +1479,7 @@ class TestArray(unittest.TestCase):
         )
         for shape, chunks in params:
             z = self.create_array(shape=shape, chunks=chunks, dtype=int)
-            a = np.arange(np.product(shape)).reshape(shape)
+            a = np.arange(np.prod(shape)).reshape(shape)
             z[:] = a
             for expect, actual in zip_longest(a, z):
                 assert_array_equal(expect, actual)
@@ -1500,7 +1500,7 @@ class TestArray(unittest.TestCase):
         )
         for shape, chunks, start, end in params:
             z = self.create_array(shape=shape, chunks=chunks, dtype=int)
-            a = np.arange(np.product(shape)).reshape(shape)
+            a = np.arange(np.prod(shape)).reshape(shape)
             z[:] = a
             end_array = min(end, a.shape[0])
             for expect, actual in zip_longest(a[start:end_array],

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -111,7 +111,7 @@ def guess_chunks(shape: Tuple[int, ...], typesize: int) -> Tuple[int, ...]:
 
     # Determine the optimal chunk size in bytes using a PyTables expression.
     # This is kept as a float.
-    dset_size = np.product(chunks)*typesize
+    dset_size = np.prod(chunks)*typesize
     target_size = CHUNK_BASE * (2**np.log10(dset_size/(1024.*1024)))
 
     if target_size > CHUNK_MAX:
@@ -126,14 +126,14 @@ def guess_chunks(shape: Tuple[int, ...], typesize: int) -> Tuple[int, ...]:
         # 1b. We're within 50% of the target chunk size, AND
         # 2. The chunk is smaller than the maximum chunk size
 
-        chunk_bytes = np.product(chunks)*typesize
+        chunk_bytes = np.prod(chunks)*typesize
 
         if (chunk_bytes < target_size or
                 abs(chunk_bytes-target_size)/target_size < 0.5) and \
                 chunk_bytes < CHUNK_MAX:
             break
 
-        if np.product(chunks) == 1:
+        if np.prod(chunks) == 1:
             break  # Element size larger than CHUNK_MAX
 
         chunks[idx % ndims] = math.ceil(chunks[idx % ndims] / 2.0)


### PR DESCRIPTION
`np.product` will be deprecated in favor of `np.prod` in the upcoming `numpy=1.25` release (xref https://github.com/numpy/numpy/pull/23314). I noticed some [related warnings](https://github.com/dask/dask/actions/runs/4860114177/jobs/8663559847?pr=10245#step:5:24892
) being emitted from `zarr` over in the `dask` test suite. This PR just replaces `np.product` with `np.prod`, which should be backwards compatible with older version of `numpy`. 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
