### PR TITLE
Merge isinstance calls

### DIFF
--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -116,7 +116,7 @@ def is_pure_orthogonal_indexing(selection, ndim):
             sum(is_integer_list(elem) or is_integer_array(elem) for elem in selection) <= 1 and
             all(
                 is_integer_list(elem) or is_integer_array(elem)
-                or isinstance(elem, slice) or isinstance(elem, int) for
+                or isinstance(elem, (int, slice)) for
                 elem in selection)
     )
 


### PR DESCRIPTION
You can pass a tuple of types you want to check as the second argument to `isinstance`. Therefore, merge multiple consecutive `isinstance` calls into one. It is clearer and improves readability.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [X] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
