### PR TITLE
test(ci): Run tests against python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         numpy_version: ['>=1.22.0', '==1.20.*']
         exclude:
           - python-version: '3.10'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,6 +20,8 @@ jobs:
         exclude:
           - python-version: '3.10'
             numpy_version: '==1.20.*'
+          - python-version: '3.11'
+            numpy_version: '==1.20.*'
     services:
       redis:
         image: redis

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: True
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -37,6 +37,9 @@ Maintenance
 * Replace ``np.product`` with ``np.prod`` due to deprecation.
   By :user:`James Bourbeau <jrbourbeau>` :issue:`1405`.
 
+* Activate Py 3.11 builds.
+  By :user:`Joe Hamman <jhamman>` :issue:`1415`.
+
 Documentation
 ~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
 ]
 license = { text = "MIT" }
 


### PR DESCRIPTION
This adds Python 3.11 to the Zarr test suite. 

TODO:

* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
