### PR TITLE
io.open → open

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,12 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+
+    * Change occurrence of io.open() into open().
+      By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1421`.
+
 .. _release_2.16.1:
 
 2.16.1

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -1,5 +1,4 @@
 """Convenience functions for storing and loading data."""
-import io
 import itertools
 import os
 import re
@@ -28,6 +27,8 @@ from zarr.util import TreeViewer, buffer_size, normalize_storage_path
 from typing import Union
 
 StoreLike = Union[BaseStore, MutableMapping, str, None]
+
+_builtin_open = open  # builtin open is later shadowed by a local open function
 
 
 def _check_and_update_path(store: BaseStore, path):
@@ -491,7 +492,7 @@ class _LogWriter:
         elif callable(log):
             self.log_func = log
         elif isinstance(log, str):
-            self.log_file = io.open(log, mode="w")
+            self.log_file = _builtin_open(log, mode="w")
             self.needs_closing = True
         elif hasattr(log, "write"):
             self.log_file = log


### PR DESCRIPTION
In Python 3, `io.open()` is an alias for the builtin `open()` function:
https://docs.python.org/3/library/io.html#io.open

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
