### PR TITLE
Proper argument for numpy.reshape

### DIFF
--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1666,7 +1666,7 @@ def test_set_selections_with_fields():
         ),
         (
             (slice(0, 10, 1),),
-            np.arange(0, 10).reshape((10)),
+            np.arange(0, 10).reshape(10),
             [(0, 10, (slice(0, 10, 1),))],
         ),
         ((0,), np.arange(0, 100).reshape((10, 10)), [(0, 10, (slice(0, 1, 1),))]),
@@ -1678,7 +1678,7 @@ def test_set_selections_with_fields():
             np.arange(0, 100).reshape((10, 10)),
             [(0, 1, (slice(0, 1, 1), slice(0, 1, 1)))],
         ),
-        ((0,), np.arange(0, 10).reshape((10)), [(0, 1, (slice(0, 1, 1),))]),
+        ((0,), np.arange(0, 10).reshape(10), [(0, 1, (slice(0, 1, 1),))]),
         pytest.param(
             (slice(5, 8, 1), slice(2, 4, 1), slice(0, 5, 1)),
             np.arange(2, 100002).reshape((10, 1, 10000)),


### PR DESCRIPTION
`numpy.reshape` not only accepts a tuple of ints, but also a simple int.

Besides `(10)` is not a tuple and is identical to `10`, unlike `(10,)`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
