### PR TITLE
Support Block (Chunk) Indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -10,6 +10,8 @@ The Array class (``zarr.core``)
     .. automethod:: set_basic_selection
     .. automethod:: get_mask_selection
     .. automethod:: set_mask_selection
+    .. automethod:: get_block_selection
+    .. automethod:: set_block_selection
     .. automethod:: get_coordinate_selection
     .. automethod:: set_coordinate_selection
     .. automethod:: get_orthogonal_selection

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -31,6 +31,8 @@ Enhancements
 * ``open_array()`` now takes the ``meta_array`` argument.
   By :user:`Mads R. B. Kristensen <madsbk>` :issue:`1396`.
 
+* **Block Indexing**: Implemented blockwise (chunk blocks) indexing to ``zarr.Array``.
+  By :user:`Altay Sansal <tasansal>` :issue:`1428`
 Maintenance
 ~~~~~~~~~~~
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -11,6 +11,9 @@ Release notes
     Unreleased
     ----------
 
+    * **Block Indexing**: Implemented blockwise (chunk blocks) indexing to ``zarr.Array``.
+      By :user:`Altay Sansal <tasansal>` :issue:`1428`
+
 .. _release_2.15.0:
 
 2.15.0
@@ -31,8 +34,6 @@ Enhancements
 * ``open_array()`` now takes the ``meta_array`` argument.
   By :user:`Mads R. B. Kristensen <madsbk>` :issue:`1396`.
 
-* **Block Indexing**: Implemented blockwise (chunk blocks) indexing to ``zarr.Array``.
-  By :user:`Altay Sansal <tasansal>` :issue:`1428`
 Maintenance
 ~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -641,6 +641,84 @@ orthogonal indexing is also available directly on the array:
     >>> all(z.oindex[[0, 2], :] == z[[0, 2], :])
     True
 
+Block Indexing
+~~~~~~~~~~~~~~
+
+As of version 2.15, Zarr also support block indexing, which allows
+selections of whole chunks based on their logical indices along each dimension
+of an array. For example, this allows selecting a subset of chunk aligned rows and/or
+columns from a 2-dimensional array. E.g.::
+
+    >>> import zarr
+    >>> import numpy as np
+    >>> z = zarr.array(np.arange(100).reshape(10, 10), chunks=(3, 3))
+
+Retrieve items by specifying their block coordinates::
+
+    >>> z.get_block_selection(1)
+    array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+           [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+Equivalent slicing::
+
+    >>> z[3:6]
+    array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+           [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+
+For convenience, the block selection functionality is also available via the
+`blocks` property, e.g.::
+
+    >>> z.blocks[1]
+    array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+           [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+Block index arrays may be multidimensional to index multidimensional arrays.
+For example::
+
+    >>> z.blocks[0, 1:3]
+    array([[ 3,  4,  5,  6,  7,  8],
+           [13, 14, 15, 16, 17, 18],
+           [23, 24, 25, 26, 27, 28]])
+
+Data can also be modified. Let's start by a simple 2D array::
+
+    >>> import zarr
+    >>> import numpy as np
+    >>> z = zarr.zeros((6, 6), dtype=int, chunks=2)
+
+Set data for a selection of items::
+
+    >>> z.set_block_selection((1, 0), 1)
+    >>> z[...]
+    array([[0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0],
+           [1, 1, 0, 0, 0, 0],
+           [1, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0]])
+
+For convenience, this functionality is also available via the ``blocks`` property.
+E.g.::
+
+        >>> z.blocks[:, 2] = 7
+        >>> z[...]
+        array([[0, 0, 0, 0, 7, 7],
+               [0, 0, 0, 0, 7, 7],
+               [1, 1, 0, 0, 7, 7],
+               [1, 1, 0, 0, 7, 7],
+               [0, 0, 0, 0, 7, 7],
+               [0, 0, 0, 0, 7, 7]])
+
+Any combination of integer and slice can be used for block indexing::
+
+        >>> z.blocks[2, 1:3]
+        array([[0, 0, 7, 7],
+               [0, 0, 7, 7]])
+
 Indexing fields in structured arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -644,7 +644,7 @@ orthogonal indexing is also available directly on the array:
 Block Indexing
 ~~~~~~~~~~~~~~
 
-As of version 2.15, Zarr also support block indexing, which allows
+As of version 2.16.0, Zarr also support block indexing, which allows
 selections of whole chunks based on their logical indices along each dimension
 of an array. For example, this allows selecting a subset of chunk aligned rows and/or
 columns from a 2-dimensional array. E.g.::

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -22,6 +22,8 @@ from zarr.indexing import (
     OIndex,
     OrthogonalIndexer,
     VIndex,
+    BlockIndex,
+    BlockIndexer,
     PartialChunkIterator,
     check_fields,
     check_no_multi_fields,
@@ -139,6 +141,7 @@ class Array:
     info
     vindex
     oindex
+    blocks
     write_empty_chunks
     meta_array
 
@@ -154,6 +157,8 @@ class Array:
     set_mask_selection
     get_coordinate_selection
     set_coordinate_selection
+    get_block_selection
+    set_block_selection
     digest
     hexdigest
     resize
@@ -230,6 +235,7 @@ class Array:
         # initialize indexing helpers
         self._oindex = OIndex(self)
         self._vindex = VIndex(self)
+        self._blocks = BlockIndex(self)
 
     def _load_metadata(self):
         """(Re)load metadata from store."""
@@ -578,6 +584,12 @@ class Array:
         return self._vindex
 
     @property
+    def blocks(self):
+        """Shortcut for blocked chunked indexing, see :func:`get_block_selection` and
+        :func:`set_block_selection` for documentation and examples."""
+        return self._blocks
+
+    @property
     def write_empty_chunks(self) -> bool:
         """A Boolean, True if chunks composed of the array's fill value
         will be stored. If False, such chunks will not be stored.
@@ -814,7 +826,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
-        set_orthogonal_selection, vindex, oindex, __setitem__
+        set_orthogonal_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __setitem__
 
         """
         fields, pure_selection = pop_fields(selection)
@@ -933,7 +946,8 @@ class Array:
         --------
         set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
-        set_orthogonal_selection, vindex, oindex, __getitem__, __setitem__
+        set_orthogonal_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1089,7 +1103,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, set_orthogonal_selection,
-        vindex, oindex, __getitem__, __setitem__
+        get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1160,7 +1175,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_orthogonal_selection, set_orthogonal_selection, set_coordinate_selection,
-        vindex, oindex, __getitem__, __setitem__
+        get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1184,6 +1200,89 @@ class Array:
         out = out.reshape(indexer.sel_shape)
 
         return out
+
+    def get_block_selection(self, selection, out=None, fields=None):
+        """Retrieve a selection of individual chunk blocks, by providing the indices
+        (coordinates) for each chunk block.
+
+        Parameters
+        ----------
+        selection : tuple
+            An integer (coordinate) or slice for each dimension of the array.
+        out : ndarray, optional
+            If given, load the selected data directly into this array.
+        fields : str or sequence of str, optional
+            For arrays with a structured dtype, one or more fields can be specified to
+            extract data for.
+
+        Returns
+        -------
+        out : ndarray
+            A NumPy array containing the data for the requested selection.
+
+        Examples
+        --------
+        Setup a 2-dimensional array::
+
+            >>> import zarr
+            >>> import numpy as np
+            >>> z = zarr.array(np.arange(100).reshape(10, 10), chunks=(3, 3))
+
+        Retrieve items by specifying their block coordinates::
+
+            >>> z.get_block_selection((1, slice(None)))
+            array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+                   [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+                   [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+        Which is equivalent to:
+            >>> z[3:6, :]
+            array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+                   [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+                   [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+        For convenience, the block selection functionality is also available via the
+        `blocks` property, e.g.::
+
+            >>> z.blocks[1]
+            array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+                   [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+                   [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
+
+        Notes
+        -----
+        Block indexing is a convenience indexing method to work on individual chunks
+        with chunk index slicing. It has the same concept as Dask's `Array.blocks`
+        indexing.
+
+        Slices are supported. However, only with a step size of one.
+
+        Block index arrays may be multidimensional to index multidimensional arrays.
+        For example:
+
+            >>> z.blocks[0, 1:3]
+            array([[ 3,  4,  5,  6,  7,  8],
+                   [13, 14, 15, 16, 17, 18],
+                   [23, 24, 25, 26, 27, 28]])
+
+        See Also
+        --------
+        get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
+        get_orthogonal_selection, set_orthogonal_selection, get_coordinate_selection,
+        set_coordinate_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
+
+        """
+        if not self._cache_metadata:
+            self._load_metadata()
+
+        # check args
+        check_fields(fields, self._dtype)
+
+        # setup indexer
+        indexer = BlockIndexer(selection, self)
+
+        return self._get_selection(indexer=indexer, out=out, fields=fields)
 
     def get_mask_selection(self, selection, out=None, fields=None):
         """Retrieve a selection of individual items, by providing a Boolean array of the
@@ -1238,8 +1337,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, set_mask_selection,
         get_orthogonal_selection, set_orthogonal_selection, get_coordinate_selection,
-        set_coordinate_selection, vindex, oindex, __getitem__, __setitem__
-
+        set_coordinate_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
         """
 
         # refresh metadata
@@ -1376,7 +1475,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
-        set_orthogonal_selection, vindex, oindex, __getitem__
+        set_orthogonal_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__
 
         """
         fields, pure_selection = pop_fields(selection)
@@ -1464,7 +1564,8 @@ class Array:
         --------
         get_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
-        set_orthogonal_selection, vindex, oindex, __getitem__, __setitem__
+        set_orthogonal_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1555,7 +1656,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_coordinate_selection, set_coordinate_selection, get_orthogonal_selection,
-        vindex, oindex, __getitem__, __setitem__
+        get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1627,7 +1729,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
         get_orthogonal_selection, set_orthogonal_selection, get_coordinate_selection,
-        vindex, oindex, __getitem__, __setitem__
+        get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 
@@ -1651,6 +1754,89 @@ class Array:
                 value = np.array(value, like=self._meta_array)
         if hasattr(value, 'shape') and len(value.shape) > 1:
             value = value.reshape(-1)
+
+        self._set_selection(indexer, value, fields=fields)
+
+    def set_block_selection(self, selection, value, fields=None):
+        """Modify a selection of individual blocks, by providing the chunk indices
+        (coordinates) for each block to be modified.
+
+        Parameters
+        ----------
+        selection : tuple
+            An integer (coordinate) or slice for each dimension of the array.
+        value : scalar or array-like
+            Value to be stored into the array.
+        fields : str or sequence of str, optional
+            For arrays with a structured dtype, one or more fields can be specified to set
+            data for.
+
+        Examples
+        --------
+        Setup a 2-dimensional array::
+
+            >>> import zarr
+            >>> import numpy as np
+            >>> z = zarr.zeros((6, 6), dtype=int, chunks=2)
+
+        Set data for a selection of items::
+
+            >>> z.set_block_selection((1, 0), 1)
+            >>> z[...]
+            array([[0, 0, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0, 0],
+                   [1, 1, 0, 0, 0, 0],
+                   [1, 1, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0, 0]])
+
+        For convenience, this functionality is also available via the `blocks` property.
+        E.g.::
+
+            >>> z.blocks[2, 1] = 4
+            >>> z[...]
+            array([[0, 0, 0, 0, 0, 0],
+                   [0, 0, 0, 0, 0, 0],
+                   [1, 1, 0, 0, 0, 0],
+                   [1, 1, 0, 0, 0, 0],
+                   [0, 0, 4, 4, 0, 0],
+                   [0, 0, 4, 4, 0, 0]])
+
+            >>> z.blocks[:, 2] = 7
+            >>> z[...]
+            array([[0, 0, 0, 0, 7, 7],
+                   [0, 0, 0, 0, 7, 7],
+                   [1, 1, 0, 0, 7, 7],
+                   [1, 1, 0, 0, 7, 7],
+                   [0, 0, 4, 4, 7, 7],
+                   [0, 0, 4, 4, 7, 7]])
+
+        Notes
+        -----
+        Block indexing is a convenience indexing method to work on individual chunks
+        with chunk index slicing. It has the same concept as Dask's `Array.blocks`
+        indexing.
+
+        Slices are supported. However, only with a step size of one.
+
+        See Also
+        --------
+        get_basic_selection, set_basic_selection, get_mask_selection, set_mask_selection,
+        get_orthogonal_selection, set_orthogonal_selection, get_coordinate_selection,
+        get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
+
+        """
+        # guard conditions
+        if self._read_only:
+            raise ReadOnlyError()
+
+        # refresh metadata
+        if not self._cache_metadata:
+            self._load_metadata_nosync()
+
+        # setup indexer
+        indexer = BlockIndexer(selection, self)
 
         self._set_selection(indexer, value, fields=fields)
 
@@ -1712,7 +1898,8 @@ class Array:
         --------
         get_basic_selection, set_basic_selection, get_mask_selection,
         get_orthogonal_selection, set_orthogonal_selection, get_coordinate_selection,
-        set_coordinate_selection, vindex, oindex, __getitem__, __setitem__
+        set_coordinate_selection, get_block_selection, set_block_selection,
+        vindex, oindex, blocks, __getitem__, __setitem__
 
         """
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1235,7 +1235,8 @@ class Array:
                    [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
                    [50, 51, 52, 53, 54, 55, 56, 57, 58, 59]])
 
-        Which is equivalent to:
+        Which is equivalent to::
+
             >>> z[3:6, :]
             array([[30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
                    [40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
@@ -1258,7 +1259,7 @@ class Array:
         Slices are supported. However, only with a step size of one.
 
         Block index arrays may be multidimensional to index multidimensional arrays.
-        For example:
+        For example::
 
             >>> z.blocks[0, 1:3]
             array([[ 3,  4,  5,  6,  7,  8],
@@ -1773,7 +1774,7 @@ class Array:
 
         Examples
         --------
-        Setup a 2-dimensional array::
+        Set up a 2-dimensional array::
 
             >>> import zarr
             >>> import numpy as np

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -811,6 +811,8 @@ class TestArray(unittest.TestCase):
         with pytest.raises(PermissionError):
             z.vindex[[0, 1, 2]] = 42
         with pytest.raises(PermissionError):
+            z.blocks[...] = 42
+        with pytest.raises(PermissionError):
             z.set_mask_selection(np.ones(z.shape, dtype=bool), 42)
 
         z.store.close()

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -340,7 +340,7 @@ class TestArray(unittest.TestCase):
         assert_array_equal(a[bix], z.vindex[bix])
         assert_array_equal(a[200:400], z.get_block_selection(slice(2, 4)))
         assert_array_equal(a[200:400], z.blocks[2:4])
-        
+
         # set
         z.set_orthogonal_selection(slice(50, 150), 1)
         assert_array_equal(1, z[50:150])


### PR DESCRIPTION
Closes #518, #543, #545, #991.

This feature has been requested many times.
This adds the basic functionality of Dask's [`dask.array.Array.blocks`](https://docs.dask.org/en/stable/generated/dask.array.Array.blocks.html) indexing.

I explained the implementation in detail in #991. Please see details there.

This PR implements #991 and adds tests, tutorial, and docs.

This does allow integer and slice (with step of 1) block indexing, or a mix of the two, for Zarr arrays.

**QUESTION**
* I wasn't exactly sure where to put it in the change log. Currently its in 2.15.0, however, should I move that to Unreleased section??

TODO:
* [X] Add unit tests and/or doctests in docstrings
* [X] Add docstrings and API docs for any new/modified user-facing classes and functions
* [X] New/modified features documented in docs/tutorial.rst
* [X] Changes documented in docs/release.rst
* [X] GitHub Actions have all passed
* [X] Test coverage is 100% (Codecov passes)
