### PR TITLE
[V3] Allow for incomplete codec metadata using numcodecs.get_codec

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,10 +13,13 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
-    .. _unreleased:
+.. _unreleased:
 
-    Unreleased
-    ----------
+Unreleased
+----------
+
+* Allow for partial codec specification in V3 array metadata.
+  By :user:`Joe Hamman <jhamman>` :issue:`1443`.
 
 .. _release_2.15.0:
 

--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -14,7 +14,7 @@ types-setuptools
 pymongo==4.4.0
 # optional test requirements
 coverage
-pytest-cov==4.0.0
+pytest-cov==4.1.0
 pytest-doctestplus==0.13.0
 pytest-timeout==2.1.0
 h5py==3.9.0

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -441,25 +441,21 @@ class Metadata3(Metadata2):
         uri = 'https://purl.org/zarr/spec/codec/'
         conf = meta['configuration']
         if meta['codec'].startswith(uri + 'gzip/'):
-            codec = numcodecs.GZip(level=conf['level'])
+            conf["id"] = "gzip"
         elif meta['codec'].startswith(uri + 'zlib/'):
-            codec = numcodecs.Zlib(level=conf['level'])
+            conf["id"] = "zlib"
         elif meta['codec'].startswith(uri + 'blosc/'):
-            codec = numcodecs.Blosc(clevel=conf['clevel'],
-                                    shuffle=conf['shuffle'],
-                                    blocksize=conf['blocksize'],
-                                    cname=conf['cname'])
+            conf["id"] = "blosc"
         elif meta['codec'].startswith(uri + 'bz2/'):
-            codec = numcodecs.BZ2(level=conf['level'])
+            conf["id"] = "bz2"
         elif meta['codec'].startswith(uri + 'lz4/'):
-            codec = numcodecs.LZ4(acceleration=conf['acceleration'])
+            conf["id"] = "lz4"
         elif meta['codec'].startswith(uri + 'lzma/'):
-            codec = numcodecs.LZMA(format=conf['format'],
-                                   check=conf['check'],
-                                   preset=conf['preset'],
-                                   filters=conf['filters'])
+            conf["id"] = "lzma"
         else:
             raise NotImplementedError
+
+        codec = numcodecs.get_codec(conf)
 
         return codec
 

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -313,6 +313,7 @@ def test_encode_decode_array_dtype_shape_v3():
     assert meta_dec['fill_value'] is None
     assert 'filters' not in meta_dec
 
+
 @pytest.mark.parametrize("comp_id", ["gzip", "zlib", "blosc", "bz2", "lz4", "lzma"])
 def test_decode_metadata_implicit_compressor_config_v3(comp_id):
     meta = {
@@ -332,7 +333,7 @@ def test_decode_metadata_implicit_compressor_config_v3(comp_id):
         "data_type": "<f8",
         "extensions": [],
         "fill_value": None,
-        "shape": [100, 10, 10 ]
+        "shape": [100, 10, 10]
     }
     meta_json = json.dumps(meta)
 

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -313,6 +313,33 @@ def test_encode_decode_array_dtype_shape_v3():
     assert meta_dec['fill_value'] is None
     assert 'filters' not in meta_dec
 
+@pytest.mark.parametrize("comp_id", ["gzip", "zlib", "blosc", "bz2", "lz4", "lzma"])
+def test_decode_metadata_implicit_compressor_config_v3(comp_id):
+    meta = {
+        "attributes": {},
+        "chunk_grid": {
+            "chunk_shape": [10],
+            "separator": "/",
+            "type": "regular"
+        },
+        "chunk_memory_layout": "C",
+        "compressor": {
+            "codec": f"https://purl.org/zarr/spec/codec/{comp_id}/1.0",
+            "configuration": {
+                # intentionally left empty
+            }
+        },
+        "data_type": "<f8",
+        "extensions": [],
+        "fill_value": None,
+        "shape": [100, 10, 10 ]
+    }
+    meta_json = json.dumps(meta)
+
+    # test decoding
+    meta_dec = Metadata3.decode_array_metadata(meta_json)
+    assert meta_dec['compressor'].codec_id == comp_id
+
 
 def test_encode_decode_array_structured():
 


### PR DESCRIPTION
This PR refactors how codecs are instantiated in the current V3 implementation. This allows for default parameters to be omitted.

TODO:
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)

closes #1443