### PR TITLE
Add __contains__ method to KVStore

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,10 +13,15 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
-    .. _unreleased:
+.. _unreleased:
 
-    Unreleased
-    ----------
+Unreleased
+----------
+
+Bug fixes
+~~~~~~~~~
+
+* Add ``__contains__`` method to ``KVStore``. By :user:`Christoph Gohlke <cgohlke>` :issue:`1454`.
 
 .. _release_2.15.0:
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -744,6 +744,9 @@ class KVStore(Store):
     def __delitem__(self, key):
         del self._mutable_mapping[key]
 
+    def __contains__(self, key):
+        return key in self._mutable_mapping
+
     def get(self, key, default=None):
         return self._mutable_mapping.get(key, default)
 


### PR DESCRIPTION
Over at https://github.com/bayer-science-for-a-better-life/tiffslide/issues/72, we noticed that reading from a `tifffile.ZarrTiffStore` calls the store's `__getitem__` member function twice for each chunk. This is due to `k in self` below being routed through `KVStore.__getitem__`. 

https://github.com/zarr-developers/zarr-python/blob/8c98f4518ea20251c8ef3258276860a3cbef9eeb/zarr/_storage/store.py#L160

This patch adds a `KVStore.__contains__` member function, which does not require reading and decoding chunks for the membership test.

Using this patch, performance almost doubled using the benchmarks in the linked issue.

TODO:
* [ ] ~Add unit tests and/or doctests in docstrings~
* [ ] ~Add docstrings and API docs for any new/modified user-facing classes and functions~
* [ ] ~New/modified features documented in docs/tutorial.rst~
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
