### PR TITLE
Ensure that chunks is tuple of ints upon array creation

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -39,6 +39,9 @@ Maintenance
 * Style the codebase with ``ruff`` and ``black``.
   By :user:`Davis Bennett` <d-v-b> :issue:`1459`
 
+* Ensure that chunks is tuple of ints upon array creation.
+  By :user:`Philipp Hanslovsky` <hanslovsky> :issue:`1461`
+
 .. _release_2.15.0:
 
 2.15.0

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -767,10 +767,18 @@ def test_create_with_storage_transformers(at_root):
                           ((1.0,), None, (1,), (1,)),))
 def test_shape_chunk_ints(init_shape, init_chunks, shape, chunks):
     g = open_group()
-    array = g.create_dataset('ds', shape=init_shape, chunks=init_chunks, dtype=np.uint8)
+    array = g.create_dataset(
+        'ds',
+        shape=init_shape,
+        chunks=init_chunks,
+        dtype=np.uint8
+        )
 
-    assert all(isinstance(s, int) for s in array.shape), f'Expected shape to be all ints but found {array.shape=}.'
-    assert all(isinstance(c, int) for c in array.chunks), f'Expected chunks to be all ints but found {array.chunks=}.'
-    assert array.shape == shape, f'Expected {shape=} but found {array.shape=}.'
-    assert array.chunks == chunks, f'Expected {chunks=} but found {array.chunks=}.'
-
+    assert all(isinstance(s, int) for s in array.shape), \
+        f'Expected shape to be all ints but found {array.shape=}.'
+    assert all(isinstance(c, int) for c in array.chunks), \
+        f'Expected chunks to be all ints but found {array.chunks=}.'
+    assert array.shape == shape, \
+        f'Expected {shape=} but found {array.shape=}.'
+    assert array.chunks == chunks, \
+        f'Expected {chunks=} but found {array.chunks=}.'

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -757,3 +757,20 @@ def test_create_with_storage_transformers(at_root):
     z = create(1000000000, chunks=True, storage_transformers=[transformer], **kwargs)
     assert isinstance(z.chunk_store, DummyStorageTransfomer)
     assert z.chunk_store.test_value == DummyStorageTransfomer.TEST_CONSTANT
+
+
+@pytest.mark.parametrize(('init_shape', 'init_chunks', 'shape', 'chunks'),
+                         (((1,), (1,), (1,), (1,)),
+                          ((1.0,), (1.0,), (1,), (1,)),
+                          ((1.0,), False, (1,), (1,)),
+                          ((1.0,), True, (1,), (1,)),
+                          ((1.0,), None, (1,), (1,)),))
+def test_shape_chunk_ints(init_shape, init_chunks, shape, chunks):
+    g = open_group()
+    array = g.create_dataset('ds', shape=init_shape, chunks=init_chunks, dtype=np.uint8)
+
+    assert all(isinstance(s, int) for s in array.shape), f'Expected shape to be all ints but found {array.shape=}.'
+    assert all(isinstance(c, int) for c in array.chunks), f'Expected chunks to be all ints but found {array.chunks=}.'
+    assert array.shape == shape, f'Expected {shape=} but found {array.shape=}.'
+    assert array.chunks == chunks, f'Expected {chunks=} but found {array.chunks=}.'
+

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -759,26 +759,25 @@ def test_create_with_storage_transformers(at_root):
     assert z.chunk_store.test_value == DummyStorageTransfomer.TEST_CONSTANT
 
 
-@pytest.mark.parametrize(('init_shape', 'init_chunks', 'shape', 'chunks'),
-                         (((1,), (1,), (1,), (1,)),
-                          ((1.0,), (1.0,), (1,), (1,)),
-                          ((1.0,), False, (1,), (1,)),
-                          ((1.0,), True, (1,), (1,)),
-                          ((1.0,), None, (1,), (1,)),))
+@pytest.mark.parametrize(
+    ("init_shape", "init_chunks", "shape", "chunks"),
+    (
+        ((1,), (1,), (1,), (1,)),
+        ((1.0,), (1.0,), (1,), (1,)),
+        ((1.0,), False, (1,), (1,)),
+        ((1.0,), True, (1,), (1,)),
+        ((1.0,), None, (1,), (1,)),
+    ),
+)
 def test_shape_chunk_ints(init_shape, init_chunks, shape, chunks):
     g = open_group()
-    array = g.create_dataset(
-        'ds',
-        shape=init_shape,
-        chunks=init_chunks,
-        dtype=np.uint8
-        )
+    array = g.create_dataset("ds", shape=init_shape, chunks=init_chunks, dtype=np.uint8)
 
-    assert all(isinstance(s, int) for s in array.shape), \
-        f'Expected shape to be all ints but found {array.shape=}.'
-    assert all(isinstance(c, int) for c in array.chunks), \
-        f'Expected chunks to be all ints but found {array.chunks=}.'
-    assert array.shape == shape, \
-        f'Expected {shape=} but found {array.shape=}.'
-    assert array.chunks == chunks, \
-        f'Expected {chunks=} but found {array.chunks=}.'
+    assert all(
+        isinstance(s, int) for s in array.shape
+    ), f"Expected shape to be all ints but found {array.shape=}."
+    assert all(
+        isinstance(c, int) for c in array.chunks
+    ), f"Expected chunks to be all ints but found {array.chunks=}."
+    assert array.shape == shape, f"Expected {shape=} but found {array.shape=}."
+    assert array.chunks == chunks, f"Expected {chunks=} but found {array.chunks=}."

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -175,7 +175,10 @@ def normalize_chunks(chunks: Any, shape: Tuple[int, ...], typesize: int) -> Tupl
     if -1 in chunks or None in chunks:
         chunks = tuple(s if c == -1 or c is None else int(c) for s, c in zip(shape, chunks))
 
-    return tuple(chunks)
+    # There are multiple early returns in this function.
+    # The other return branches already ensure that the chunks are all int.
+    # Another (better?) approach would be to decorate normalize_chunks with int cast.
+    return tuple(int(c) for c in chunks)
 
 
 def normalize_dtype(dtype: Union[str, np.dtype], object_codec) -> Tuple[np.dtype, Any]:

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -5,7 +5,6 @@ import numbers
 from textwrap import TextWrapper
 import mmap
 import time
-from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -76,18 +75,6 @@ def json_loads(s: Union[bytes, str]) -> Dict[str, Any]:
     return json.loads(ensure_text(s, "utf-8"))
 
 
-def _as_int_tuple(func: Callable) -> Callable:
-    """Wrap a function that returns a tuple and cast the return value to tuple of ints."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs) -> Tuple[int, ...]:
-        returned_tuple = func(*args, **kwargs)
-        return tuple(int(t) for t in returned_tuple)
-
-    return wrapper
-
-
-@_as_int_tuple
 def normalize_shape(shape: Union[int, Tuple[int, ...], None]) -> Tuple[int, ...]:
     """Convenience function to normalize the `shape` argument."""
 
@@ -157,7 +144,6 @@ def guess_chunks(shape: Tuple[int, ...], typesize: int) -> Tuple[int, ...]:
     return tuple(int(x) for x in chunks)
 
 
-@_as_int_tuple
 def normalize_chunks(chunks: Any, shape: Tuple[int, ...], typesize: int) -> Tuple[int, ...]:
     """Convenience function to normalize the `chunks` argument for an array
     with the given `shape`."""
@@ -189,6 +175,7 @@ def normalize_chunks(chunks: Any, shape: Tuple[int, ...], typesize: int) -> Tupl
     if -1 in chunks or None in chunks:
         chunks = tuple(s if c == -1 or c is None else int(c) for s, c in zip(shape, chunks))
 
+    chunks = tuple(int(c) for c in chunks)
     return chunks
 
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -76,9 +76,9 @@ def json_loads(s: Union[bytes, str]) -> Dict[str, Any]:
     return json.loads(ensure_text(s, "utf-8"))
 
 
-def _as_int_tuple(func: Callable[[...], tuple]):
+def _as_int_tuple(func: Callable) -> Callable:
     @wraps(func)
-    def wrapper(*args, **kwargs) -> tuple[int, ...]:
+    def wrapper(*args, **kwargs) -> Tuple[int, ...]:
         returned_tuple = func(*args, **kwargs)
         return tuple(int(t) for t in returned_tuple)
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -77,6 +77,8 @@ def json_loads(s: Union[bytes, str]) -> Dict[str, Any]:
 
 
 def _as_int_tuple(func: Callable) -> Callable:
+    """Wrap a function that returns a tuple and cast the return value to tuple of ints."""
+
     @wraps(func)
     def wrapper(*args, **kwargs) -> Tuple[int, ...]:
         returned_tuple = func(*args, **kwargs)


### PR DESCRIPTION
[Description of PR]

This PR will make sure that chunks of an array are created as `tuple[int, ..]`, even if provided as `tuple[float, ...]` (#1461). This is already the case for shape and this PR ensures that the behavior is the same between those two.

I opened this as a draft PR with a failing test to ensure that github actions fail as expected. I will add the fix and push separately. Please feel free to squash as needed upon merge of the PR.

Fixes #1461 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in docs/tutorial.rst **N/A**
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
