### PR TITLE
Add "Generate release notes" to release process

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -379,6 +379,8 @@ Set the description of the release to::
 replacing the correct version numbers. For pre-release versions,
 the URL should omit the pre-release suffix, e.g. "a1" or "rc1".
 
+Click on "Generate release notes" to auto-file the description.
+
 After creating the release, the documentation will be built on
 https://readthedocs.io. Full releases will be available under
 `/stable <https://zarr.readthedocs.io/en/stable>`_ while


### PR DESCRIPTION
cc: @rabernat

Starting a hand-full of versions ago, GitHub added a "Generate release notes" button. This generates links to all PRs as well as to new contributors. I've updated the 2.16.0 release, but I'd be for always clicking this button when making a release.

<img width="1123" alt="image" src="https://github.com/zarr-developers/zarr-python/assets/88113/959281f4-a43b-45c8-bae9-a53524a25d10">
