### PR TITLE
Require `setuptools_scm` version `1.5.4`+

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,12 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+
+* Require ``setuptools_scm`` version ``1.5.4``\+
+  By :user:`John A. Kirkham <jakirkham>` :issue:`1477`.
+
 .. _release_2.16.0:
 
 2.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "setuptools_scm>1.5.4"]
+requires = ["setuptools>=64.0.0", "setuptools-scm>1.5.4"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "setuptools-scm"]
+requires = ["setuptools>=64.0.0", "setuptools_scm>1.5.4"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
This use to be a requirement in `setup.py`, but it got lost in the `pyproject.yaml` migration

https://github.com/zarr-developers/zarr-python/blob/d6e35a5641c66bcc668ee1a666086ea04837b9db/setup.py#L28

So readding it here

Also this lines up with [the conda-forge recipe requirement on `setuptools_scm`]( https://github.com/conda-forge/zarr-feedstock/blob/3e4ae21cd8d2e9e909e21ffea8f246b8ad24b50b/recipe/meta.yaml#L24 )

<hr>

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
