### PR TITLE
Improve LRU Store Cache Performance by Partial Key Cache Update

### DIFF
--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -2201,31 +2201,28 @@ class TestLRUStoreCache(StoreTests):
         assert 0 == store.counter["__iter__"]
         assert 1 == store.counter["keys"]
 
-        # cache should be cleared if store is modified - crude but simple for now
+        # Cache should update when a key is added or updated
         cache[baz_key] = b"zzz"
         keys = sorted(cache.keys())
-        assert keys == [bar_key, baz_key, foo_key]
-        assert 2 == store.counter["keys"]
-        # keys should now be cached
-        assert keys == sorted(cache.keys())
-        assert 2 == store.counter["keys"]
+        assert 1 == store.counter["keys"]
+        assert baz_key in keys
 
         # manually invalidate keys
         cache.invalidate_keys()
         keys = sorted(cache.keys())
         assert keys == [bar_key, baz_key, foo_key]
-        assert 3 == store.counter["keys"]
+        assert 2 == store.counter["keys"]
         assert 0 == store.counter["__contains__", foo_key]
         assert 0 == store.counter["__iter__"]
         cache.invalidate_keys()
         keys = sorted(cache)
         assert keys == [bar_key, baz_key, foo_key]
-        assert 4 == store.counter["keys"]
+        assert 3 == store.counter["keys"]
         assert 0 == store.counter["__contains__", foo_key]
         assert 0 == store.counter["__iter__"]
         cache.invalidate_keys()
         assert foo_key in cache
-        assert 5 == store.counter["keys"]
+        assert 4 == store.counter["keys"]
         assert 0 == store.counter["__contains__", foo_key]
         assert 0 == store.counter["__iter__"]
 


### PR DESCRIPTION
When data is added/updated in an LRU store, the `keys_cache` and `contains_cache` are invalidated. In my case this causes a large slowdown due to occasional writes and many reads because my underlying store has a slow `keys()` function.

To address this problem, I propose introducing a `_update_key` function that will be called from the `__setitem__` function. This new function will specifically add the key to the key/contains cache, without wiping the entire cache. By doing so, we can avoid unnecessary cache invalidations and reduce the slowdown associated with occasional writes.

Furthermore, I believe a similar enhancement can be made to the `__delitem__` function. This would allow us to remove a key from the key/contains cache, without invalidating it.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
