### PR TITLE
`zarr.group` now accept the `meta_array` argument

### DIFF
--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1360,7 +1360,8 @@ def group(
     synchronizer=None,
     path=None,
     *,
-    zarr_version=None
+    zarr_version=None,
+    meta_array=None
 ):
     """Create a group.
 
@@ -1382,6 +1383,11 @@ def group(
         Array synchronizer.
     path : string, optional
         Group path within store.
+    meta_array : array-like, optional
+        An array instance to use for determining arrays to create and return
+        to users. Use `numpy.empty(())` by default.
+
+        .. versionadded:: 2.16.1
 
     Returns
     -------
@@ -1432,6 +1438,7 @@ def group(
         synchronizer=synchronizer,
         path=path,
         zarr_version=zarr_version,
+        meta_array=meta_array,
     )
 
 

--- a/zarr/tests/test_meta_array.py
+++ b/zarr/tests/test_meta_array.py
@@ -9,7 +9,7 @@ from numcodecs.registry import get_codec, register_codec
 import zarr.codecs
 from zarr.core import Array
 from zarr.creation import array, empty, full, ones, open_array, zeros
-from zarr.hierarchy import open_group
+from zarr.hierarchy import open_group, group
 from zarr.storage import DirectoryStore, MemoryStore, Store, ZipStore
 
 
@@ -234,12 +234,13 @@ def test_full(module, compressor):
     assert np.all(np.isnan(z[:]))
 
 
+@pytest.mark.parametrize("group_create_function", [group, open_group])
 @pytest.mark.parametrize("module, compressor", param_module_and_compressor)
 @pytest.mark.parametrize("store_type", [None, DirectoryStore, MemoryStore, ZipStore])
-def test_group(tmp_path, module, compressor, store_type):
+def test_group(tmp_path, group_create_function, module, compressor, store_type):
     xp = ensure_module(module)
     store = init_store(tmp_path, store_type)
-    g = open_group(store, meta_array=xp.empty(()))
+    g = group_create_function(store, meta_array=xp.empty(()))
     g.ones("data", shape=(10, 11), dtype=int, compressor=compressor)
     a = g["data"]
     assert a.shape == (10, 11)


### PR DESCRIPTION
Now `zarr.group` forwards the `meta_array` argument to `zarr.Group`. Fixes #1484.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
