### PR TITLE
Prepare for 2.16.1 release

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,11 @@ Release notes
 Unreleased
 ----------
 
+.. _release_2.16.1:
+
+2.16.1
+------
+
 Maintenance
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This bumps the version number in the docs in anticipation of releasing 2.16.1.  This release will contain 3 PRs:

- #1477
- #1494 
- #1499