### PR TITLE
Disable pre-commit.ci's PR autofixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
+  autofix_prs: false
 default_stages: [commit, push]
 default_language_version:
   python: python3


### PR DESCRIPTION
As observed in the past, pre-commit.ci automatically pushes changes to PRs (even when not requested). This has caused issues in some cases ( https://github.com/zarr-developers/zarr-python/pull/1459 ). This disables automatic pushes by pre-commit in PRs (based on [the `autofix_prs` config parameter]( https://pre-commit.ci/#configuration-autofix_prs )). It is still possible to ask pre-commit to push a changed, but at least in that case it is an option (and not done without a user request)

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
