### PR TITLE
Clarify data type docs in v2 spec page

### DIFF
--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -140,7 +140,7 @@ consists of 3 parts:
   ``"M"``: datetime; ``"S"``: string (fixed-length sequence of char); ``"U"``: unicode
   (fixed-length sequence of Py_UNICODE); ``"V"``: other (void * – each item is a
   fixed-size chunk of memory))
-* An integer specifying the number of bytes the type uses.
+* An integer specifying the number of bytes the type uses (Exceptions: for ``"U"``, this is the number of characters; multiply by four to obtain the number of bytes. for object type ``"O"``, a number is not included here.).
 
 The byte order MUST be specified. E.g., ``"<f8"``, ``">i4"``, ``"|b1"`` and
 ``"|S12"`` are valid data type encodings.

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -140,7 +140,7 @@ consists of 3 parts:
   ``"M"``: datetime; ``"S"``: string (fixed-length sequence of char); ``"U"``: unicode
   (fixed-length sequence of Py_UNICODE); ``"V"``: other (void * – each item is a
   fixed-size chunk of memory))
-* An integer specifying the number of bytes the type uses (Exceptions: for ``"U"``, this is the number of characters; multiply by four to obtain the number of bytes. for object type ``"O"``, a number is not included here.).
+* An integer specifying the number of bytes the type uses (Exceptions: For unicode type ``"U"``, this is the number of characters; multiply by four to obtain the number of bytes. For object type ``"O"``, a number is not included here.).
 
 The byte order MUST be specified. E.g., ``"<f8"``, ``">i4"``, ``"|b1"`` and
 ``"|S12"`` are valid data type encodings.


### PR DESCRIPTION
Hi, while implementing a Zarr package for R, I ran into the issue that for `"U"` data types, the number in the dtype string seems to be the number of characters (rather than the number of bytes as specified here).

Related, it can be clarified here that for object data types there is not a number included in the dtype string. This may be useful when writing regexes to parse the data type information out of the dtype string.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
