### PR TITLE
Minor edits in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ zarr/version.py
 #doesnotexist
 #test_sync*
 data/*
+
+.DS_Store

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ main_doc = "index"
 
 # General information about the project.
 project = "zarr"
-copyright = "2022, Zarr Developers"
+copyright = "2023, Zarr Developers"
 author = "Zarr Developers"
 
 version = zarr.__version__

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -4,7 +4,7 @@ Specifications
 ==============
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 1
 
     spec/v3
     spec/v2

--- a/docs/spec/v1.rst
+++ b/docs/spec/v1.rst
@@ -1,6 +1,6 @@
 .. _spec_v1:
 
-Zarr storage specification version 1
+Zarr Storage Specification Version 1
 ====================================
 
 This document provides a technical specification of the protocol and

--- a/docs/spec/v2.rst
+++ b/docs/spec/v2.rst
@@ -1,6 +1,6 @@
 .. _spec_v2:
 
-Zarr storage specification version 2
+Zarr Storage Specification Version 2
 ====================================
 
 This document provides a technical specification of the protocol and format

--- a/docs/spec/v3.rst
+++ b/docs/spec/v3.rst
@@ -1,7 +1,7 @@
 .. _spec_v3:
 
-Zarr storage specification version 3 (under development)
-========================================================
+Zarr Storage Specification Version 3
+=======================================================
 
-The v3 specification has been migrated to its own website,
+The V3 Specification has been migrated to its website →
 https://zarr-specs.readthedocs.io/.


### PR DESCRIPTION
Hi everyone! 👋🏻 

I've made minor changes to the documentation. They are as follows:

- Change `Copyright` year; 2022 → 2023
- Currently, the [Specifications](https://zarr.readthedocs.io/en/stable/spec.html) page lists out the whole index of V2 and V1 spec. It looks messy. I changed it to display the titles which, upon clicking, would open the respective specification documents.
- Removed `Under development` from V3 specification.

Please review. Thanks!

CC: @zarr-developers/python-core-devs 

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
