### PR TITLE
Tiny tweak: Extend copyright notice to 2023

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2022 Zarr Developers <https://github.com/zarr-developers>
+Copyright (c) 2015-2023 Zarr Developers <https://github.com/zarr-developers>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The world's smallest PR :slightly_smiling_face:. All I've done is to change `Copyright (c) 2015-2022` to `Copyright (c) 2015-2023` in `LICENSE.txt`.
