### PR TITLE
Unnecessary list literal → set literal

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,6 +21,9 @@ Unreleased
 Maintenance
 ~~~~~~~~~~~
 
+* Initialise some sets in tests with set literals instead of list literals.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1534`.
+
 * Allow ``black`` code formatter to be run with any Python version.
   By :user:`David Stansby <dstansby>` :issue:`1549`
 

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1166,9 +1166,9 @@ class TestFSStore(StoreTests):
         if self.version == 2:
             assert set(store.listdir()) == {".zgroup", "bar"}
         else:
-            assert set(store.listdir()) == set(["data", "meta", "zarr.json"])
-            assert set(store.listdir("meta/root/" + path)) == set(["bar", "bar.group.json"])
-            assert set(store.listdir("data/root/" + path)) == set(["bar"])
+            assert set(store.listdir()) == {"data", "meta", "zarr.json"}
+            assert set(store.listdir("meta/root/" + path)) == {"bar", "bar.group.json"}
+            assert set(store.listdir("data/root/" + path)) == {"bar"}
         assert foo["bar"]["baz"][(0, 0, 0)] == 1
 
     def test_not_fsspec(self):


### PR DESCRIPTION
Why use a list literal to initialise a set? Just use a set literal.

It's also consistent with the previous line:
https://github.com/zarr-developers/zarr-python/blob/6ec746ef1242dd9fec26b128cc0b3455d28ad6f0/zarr/tests/test_storage.py#L1167

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
