### PR TITLE
Automatically document Array members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/_autoapi/
 
 # PyBuilder
 target/

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -2,23 +2,4 @@ The Array class (``zarr.core``)
 ===============================
 .. module:: zarr.core
 
-.. autoclass:: Array
-
-    .. automethod:: __getitem__
-    .. automethod:: __setitem__
-    .. automethod:: get_basic_selection
-    .. automethod:: set_basic_selection
-    .. automethod:: get_mask_selection
-    .. automethod:: set_mask_selection
-    .. automethod:: get_block_selection
-    .. automethod:: set_block_selection
-    .. automethod:: get_coordinate_selection
-    .. automethod:: set_coordinate_selection
-    .. automethod:: get_orthogonal_selection
-    .. automethod:: set_orthogonal_selection
-    .. automethod:: digest
-    .. automethod:: hexdigest
-    .. automethod:: resize
-    .. automethod:: append
-    .. automethod:: view
-    .. automethod:: astype
+.. automodsumm:: zarr.core

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -1,5 +1,5 @@
 The Array class (``zarr.core``)
 ===============================
-.. module:: zarr.core
 
-.. automodsumm:: zarr.core
+.. automodapi:: zarr.core
+   :no-heading:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "sphinx_automodapi.automodapi",
     "numpydoc",
     "sphinx_issues",
     "sphinx_copybutton",
@@ -51,6 +52,9 @@ extensions = [
 numpydoc_show_class_members = False
 numpydoc_class_members_toctree = False
 issues_github_path = "zarr-developers/zarr-python"
+
+automodapi_inheritance_diagram = False
+automodapi_toctreedirnm = "_autoapi"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ jupyter = [
 ]
 docs = [
     'sphinx',
+    'sphinx-automodapi',
     'sphinx_design',
     'sphinx-issues',
     'sphinx-copybutton',

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -60,6 +60,8 @@ from zarr.util import (
     ensure_ndarray_like,
 )
 
+__all__ = ["Array"]
+
 
 # noinspection PyUnresolvedReferences
 class Array:
@@ -110,62 +112,6 @@ class Array:
         to users. Use `numpy.empty(())` by default.
 
         .. versionadded:: 2.13
-
-
-    Attributes
-    ----------
-    store
-    path
-    name
-    read_only
-    chunk_store
-    shape
-    chunks
-    dtype
-    compression
-    compression_opts
-    dimension_separator
-    fill_value
-    order
-    synchronizer
-    filters
-    attrs
-    size
-    itemsize
-    nbytes
-    nbytes_stored
-    cdata_shape
-    nchunks
-    nchunks_initialized
-    is_view
-    info
-    vindex
-    oindex
-    blocks
-    write_empty_chunks
-    meta_array
-
-    Methods
-    -------
-    __getitem__
-    __setitem__
-    get_basic_selection
-    set_basic_selection
-    get_orthogonal_selection
-    set_orthogonal_selection
-    get_mask_selection
-    set_mask_selection
-    get_coordinate_selection
-    set_coordinate_selection
-    get_block_selection
-    set_block_selection
-    digest
-    hexdigest
-    resize
-    append
-    view
-    astype
-
     """
 
     def __init__(


### PR DESCRIPTION
This PR uses the [automodapi sphinx extension](https://sphinx-automodapi.readthedocs.io/en/latest/#) to automatically document members of the `Array` class. Previously these were manually listed, meaning they have to be manually updated every time the actual method or property is updated in the code. Now they are autogenerated.

Fixes https://github.com/zarr-developers/zarr-python/issues/1546

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
