### PR TITLE
Fail doc build on warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   install:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,7 @@ html_theme_options = {
         },
     ],
     "collapse_navigation": True,
+    "navigation_with_keys": False,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ Zarr is a file storage format for chunked, compressed, N-dimensional arrays base
         +++
 
         .. button-ref:: tutorial
+            :ref-type: ref
             :expand:
             :color: dark
             :click-parent:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -161,10 +161,12 @@ Major changes
 
 * Improve Zarr V3 support, adding partial store read/write and storage transformers.
   Add new features from the `v3 spec <https://zarr-specs.readthedocs.io/en/latest/core/v3.0.html>`_:
+
     * storage transformers
     * `get_partial_values` and `set_partial_values`
     * efficient `get_partial_values` implementation for `FSStoreV3`
     * sharding storage transformer
+
   By :user:`Jonathan Striebel <jstriebel>`; :issue:`1096`, :issue:`1111`.
 
 * N5 nows supports Blosc.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,13 @@ Release notes
 Unreleased
 ----------
 
+Docs
+~~~~
+
+* The documentation build now fails if there are any warnings.
+  By :user:`David Stansby <dstansby>` :issue:`1548`.
+
+
 Maintenance
 ~~~~~~~~~~~
 


### PR DESCRIPTION
I noticed that the documentation build allows warnings through - these can include things like broken links, broken RST, or duplicate references. I've enabled the `-W` flag by default in the makefile so these get caught, and fixed the few existing warnings.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
