### PR TITLE
Allow black to be run on any Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
     rev: 22.12.0
     hooks:
     - id: black
-      language_version: python3.8
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.5
     hooks:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -22,7 +22,7 @@ Maintenance
 ~~~~~~~~~~~
 
 * Allow ``black`` code formatter to be run with any Python version.
-  By :user: `David Stansby <dstansby>` :issue:`1549`
+  By :user:`David Stansby <dstansby>` :issue:`1549`
 
 .. _release_2.16.1:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,12 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+
+* Allow ``black`` code formatter to be run with any Python version.
+  By :user: `David Stansby <dstansby>` :issue:`1549`
+
 .. _release_2.16.1:
 
 2.16.1


### PR DESCRIPTION
This removes the limitation of running `black` via `pre-commit` on Python 3.8. The python version that black is run on doesn't actually affect the output, so this change doesn't make a difference to what black does.

Fixes https://github.com/zarr-developers/zarr-python/issues/1545

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
