### PR TITLE
DOC: Minor tweak to advanced indexing example in tutorial

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -85,9 +85,9 @@ Creating a development environment
 To work with the Zarr source code, it is recommended to set up a Python virtual
 environment and install all Zarr dependencies using the same versions as are used by
 the core developers and continuous integration services. Assuming you have a Python
-3 interpreter already installed, and have also installed the virtualenv package, and
-you have cloned the Zarr source code and your current working directory is the root of
-the repository, you can do something like the following::
+3 interpreter already installed, and you have cloned the Zarr source code and your
+current working directory is the root of the repository, you can do something like
+the following::
 
     $ mkdir -p ~/pyenv/zarr-dev
     $ python -m venv ~/pyenv/zarr-dev

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -480,17 +480,17 @@ Indexing with coordinate arrays
 Items from a Zarr array can be extracted by providing an integer array of
 coordinates. E.g.::
 
-    >>> z = zarr.array(np.arange(10))
+    >>> z = zarr.array(np.arange(10) ** 2)
     >>> z[:]
-    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    >>> z.get_coordinate_selection([1, 4])
-    array([1, 4])
+    array([ 0,  1,  4,  9, 16, 25, 36, 49, 64, 81])
+    >>> z.get_coordinate_selection([2, 5])
+    array([ 4, 25])
 
 Coordinate arrays can also be used to update data, e.g.::
 
-    >>> z.set_coordinate_selection([1, 4], [-1, -2])
+    >>> z.set_coordinate_selection([2, 5], [-1, -2])
     >>> z[:]
-    array([ 0, -1,  2,  3, -2,  5,  6,  7,  8,  9])
+    array([ 0,  1, -1,  9, 16, -2, 36, 49, 64, 81])
 
 For multidimensional arrays, coordinates must be provided for each dimension,
 e.g.::
@@ -534,17 +534,17 @@ Indexing with a mask array
 
 Items can also be extracted by providing a Boolean mask. E.g.::
 
-    >>> z = zarr.array(np.arange(10))
+    >>> z = zarr.array(np.arange(10) ** 2)
     >>> z[:]
-    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    array([ 0,  1,  4,  9, 16, 25, 36, 49, 64, 81])
     >>> sel = np.zeros_like(z, dtype=bool)
-    >>> sel[1] = True
-    >>> sel[4] = True
+    >>> sel[2] = True
+    >>> sel[5] = True
     >>> z.get_mask_selection(sel)
-    array([1, 4])
+    array([ 4, 25])
     >>> z.set_mask_selection(sel, [-1, -2])
     >>> z[:]
-    array([ 0, -1,  2,  3, -2,  5,  6,  7,  8,  9])
+    array([ 0,  1, -1,  9, 16, -2, 36, 49, 64, 81])
 
 Here's a multidimensional example::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -986,7 +986,7 @@ It is also possible to initialize the filesystem outside of Zarr and then pass
 it through. This requires creating an :class:`zarr.storage.FSStore` object
 explicitly. For example::
 
-    >>> import s3fs  * doctest: +SKIP
+    >>> import s3fs  # doctest: +SKIP
     >>> fs = s3fs.S3FileSystem(anon=True)  # doctest: +SKIP
     >>> store = zarr.storage.FSStore('/zarr-demo/store', fs=fs)  # doctest: +SKIP
     >>> g = zarr.open_group(store)  # doctest: +SKIP


### PR DESCRIPTION
I just wanted to make a very minor suggestion I had while reading through the tutorial (which is very nice, thank you for that!):

In the advanced indexing section, the array used in the 1D examples is `np.arange(10)`. This means that the indices and corresponding values are the same. There's nothing wrong with this of course, but I thought the example might be more immediately grokkable if a different example array were used where the values were different than the indices. I arbitrarily chose `np.arange(10) ** 2`, but any other choice would be equally valid. This is of course a very minor point and pretty subjective, so please feel free to ignore!

I also added two other minor commits that popped up while running through the contributor guide to make the PR:
 - I noticed `virtualenv` was referenced, but the example uses the built-in `venv` module, so I removed it, and
 - Fixed a failing doctest due to a malformed comment.

Again - nothing major; please feel free to ignore/cherry-pick as you see fit!