### PR TITLE
Use list comprehension where applicable

### DIFF
--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -1754,17 +1754,15 @@ def test_accessed_chunks(shape, chunks, ops):
     for ii, (optype, slices) in enumerate(ops):
 
         # Resolve the slices into the accessed chunks for each dimension
-        chunks_per_dim = []
-        for N, C, sl in zip(shape, chunks, slices):
-            chunk_ind = np.arange(N, dtype=int)[sl] // C
-            chunks_per_dim.append(np.unique(chunk_ind))
+        chunks_per_dim = [
+            np.unique(np.arange(N, dtype=int)[sl] // C) for N, C, sl in zip(shape, chunks, slices)
+        ]
 
         # Combine and generate the cartesian product to determine the chunks keys that
         # will be accessed
-        chunks_accessed = []
-        for comb in itertools.product(*chunks_per_dim):
-            chunks_accessed.append(".".join([str(ci) for ci in comb]))
-
+        chunks_accessed = (
+            ".".join([str(ci) for ci in comb]) for comb in itertools.product(*chunks_per_dim)
+        )
         counts_before = store.counter.copy()
 
         # Perform the operation


### PR DESCRIPTION
Even if this is only a test, list comprehensions are faster than repeatedly call `append()`.

Also use tuple instead of list when possible.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
