### PR TITLE
Bump version of black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       # Respect `exclude` and `extend-exclude` settings.
       args: ["--force-exclude"]
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.10.1
     hooks:
     - id: black
   - repo: https://github.com/codespell-project/codespell

--- a/bench/compress_normal.py
+++ b/bench/compress_normal.py
@@ -8,7 +8,6 @@ import zarr
 from zarr import blosc
 
 if __name__ == "__main__":
-
     sys.path.insert(0, "..")
 
     # setup

--- a/zarr/_storage/absstore.py
+++ b/zarr/_storage/absstore.py
@@ -87,7 +87,7 @@ class ABSStore(Store):
                 "https://{}.blob.core.windows.net/".format(account_name),
                 container,
                 credential=account_key,
-                **blob_service_kwargs
+                **blob_service_kwargs,
             )
 
         self.client = client
@@ -240,7 +240,6 @@ class ABSStoreV3(ABSStore, StoreV3):
         super().__setitem__(key, value)
 
     def rmdir(self, path=None):
-
         if not path:
             # Currently allowing clear to delete everything as in v2
 

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -629,7 +629,6 @@ def _rmdir_from_keys(store: StoreLike, path: Optional[str] = None) -> None:
 
 
 def _rmdir_from_keys_v3(store: StoreV3, path: str = "") -> None:
-
     meta_dir = meta_root + path
     meta_dir = meta_dir.rstrip("/")
     _rmdir_from_keys(store, meta_dir)

--- a/zarr/_storage/v3.py
+++ b/zarr/_storage/v3.py
@@ -118,7 +118,6 @@ def _get_files_and_dirs_from_path(store, path):
 
 
 class FSStoreV3(FSStore, StoreV3):
-
     # FSStoreV3 doesn't use this (FSStore uses it within _normalize_key)
     _META_KEYS = ()
 

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -26,7 +26,6 @@ class Attributes(MutableMapping):
     """
 
     def __init__(self, store, key=".zattrs", read_only=False, cache=True, synchronizer=None):
-
         self._version = getattr(store, "_store_version", 2)
         _Store = Store if self._version == 2 else StoreV3
         self.store = _Store._ensure_store(store)
@@ -73,7 +72,6 @@ class Attributes(MutableMapping):
         return self.asdict()[item]
 
     def _write_op(self, f, *args, **kwargs):
-
         # guard condition
         if self.read_only:
             raise PermissionError("attributes are read-only")
@@ -89,7 +87,6 @@ class Attributes(MutableMapping):
         self._write_op(self._setitem_nosync, item, value)
 
     def _setitem_nosync(self, item, value):
-
         # load existing data
         d = self._get_nosync()
 
@@ -106,7 +103,6 @@ class Attributes(MutableMapping):
         self._write_op(self._delitem_nosync, item)
 
     def _delitem_nosync(self, key):
-
         # load existing data
         d = self._get_nosync()
 
@@ -128,7 +124,6 @@ class Attributes(MutableMapping):
             self._write_op(self._put_nosync, dict(attributes=d))
 
     def _put_nosync(self, d):
-
         d_to_check = d if self._version == 2 else d["attributes"]
         if not all(isinstance(item, str) for item in d_to_check):
             # TODO: Raise an error for non-string keys
@@ -178,7 +173,6 @@ class Attributes(MutableMapping):
         self._write_op(self._update_nosync, *args, **kwargs)
 
     def _update_nosync(self, *args, **kwargs):
-
         # load existing data
         d = self._get_nosync()
 

--- a/zarr/convenience.py
+++ b/zarr/convenience.py
@@ -675,10 +675,8 @@ def copy_store(
 
     # setup logging
     with _LogWriter(log) as log:
-
         # iterate over source keys
         for source_key in sorted(source.keys()):
-
             # filter to keys under source path
             if source_store_version == 2:
                 if not source_key.startswith(source_path):
@@ -757,7 +755,7 @@ def copy(
     log=None,
     if_exists="raise",
     dry_run=False,
-    **create_kws
+    **create_kws,
 ):
     """Copy the `source` array or group into the `dest` group.
 
@@ -878,7 +876,6 @@ def copy(
 
     # setup logging
     with _LogWriter(log) as log:
-
         # do the copying
         n_copied, n_skipped, n_bytes_copied = _copy(
             log,
@@ -890,7 +887,7 @@ def copy(
             without_attrs=without_attrs,
             if_exists=if_exists,
             dry_run=dry_run,
-            **create_kws
+            **create_kws,
         )
 
         # log a final message with a summary of what happened
@@ -948,12 +945,10 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists, dry_
 
         # take action
         if do_copy:
-
             # log a message about what we're going to do
             log("copy {} {} {}".format(source.name, source.shape, source.dtype))
 
             if not dry_run:
-
                 # clear the way
                 if exists:
                     del dest[name]
@@ -1038,12 +1033,10 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists, dry_
 
         # take action
         if do_copy:
-
             # log action
             log("copy {}".format(source.name))
 
             if not dry_run:
-
                 # clear the way
                 if exists_array:
                     del dest[name]
@@ -1056,7 +1049,6 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists, dry_
                     grp.attrs.update(source.attrs)
 
             else:
-
                 # setup for dry run without creating any groups in the
                 # destination
                 if dest is not None:
@@ -1076,7 +1068,7 @@ def _copy(log, source, dest, name, root, shallow, without_attrs, if_exists, dry_
                     without_attrs=without_attrs,
                     if_exists=if_exists,
                     dry_run=dry_run,
-                    **create_kws
+                    **create_kws,
                 )
                 n_copied += c
                 n_skipped += s
@@ -1099,7 +1091,7 @@ def copy_all(
     log=None,
     if_exists="raise",
     dry_run=False,
-    **create_kws
+    **create_kws,
 ):
     """Copy all children of the `source` group into the `dest` group.
 
@@ -1189,7 +1181,6 @@ def copy_all(
 
     # setup logging
     with _LogWriter(log) as log:
-
         for k in source.keys():
             c, s, b = _copy(
                 log,
@@ -1201,7 +1192,7 @@ def copy_all(
                 without_attrs=without_attrs,
                 if_exists=if_exists,
                 dry_run=dry_run,
-                **create_kws
+                **create_kws,
             )
             n_copied += c
             n_skipped += s
@@ -1262,7 +1253,6 @@ def consolidate_metadata(store: BaseStore, metadata_key=".zmetadata", *, path=""
             return key.endswith(".zarray") or key.endswith(".zgroup") or key.endswith(".zattrs")
 
     else:
-
         assert_zarr_v3_api_available()
 
         sfx = _get_metadata_suffix(store)  # type: ignore

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -234,7 +234,6 @@ def create(
 
 
 def _kwargs_compat(compressor, fill_value, kwargs):
-
     # to be compatible with h5py, as well as backwards-compatible with Zarr
     # 1.x, accept 'compression' and 'compression_opts' keyword arguments
 
@@ -697,7 +696,6 @@ def open_array(
 
 
 def _like_args(a, kwargs):
-
     shape, chunks = _get_shape_chunks(a)
     if shape is not None:
         kwargs.setdefault("shape", shape)

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -145,7 +145,7 @@ class Group(MutableMapping):
         synchronizer=None,
         zarr_version=None,
         *,
-        meta_array=None
+        meta_array=None,
     ):
         store: BaseStore = _normalize_store_arg(store, zarr_version=zarr_version)
         if zarr_version is None:
@@ -919,7 +919,6 @@ class Group(MutableMapping):
         return TreeViewer(self, expand=expand, level=level)
 
     def _write_op(self, f, *args, **kwargs):
-
         # guard condition
         if self._read_only:
             raise ReadOnlyError()
@@ -1094,7 +1093,6 @@ class Group(MutableMapping):
         return self._write_op(self._create_dataset_nosync, name, **kwargs)
 
     def _create_dataset_nosync(self, name, data=None, **kwargs):
-
         assert "mode" not in kwargs
         path = self._item_path(name)
 
@@ -1138,11 +1136,9 @@ class Group(MutableMapping):
         )
 
     def _require_dataset_nosync(self, name, shape, dtype=None, exact=False, **kwargs):
-
         path = self._item_path(name)
 
         if contains_array(self._store, path):
-
             # array already exists at path, validate that it is the right shape and type
 
             synchronizer = kwargs.get("synchronizer", self._synchronizer)
@@ -1235,7 +1231,7 @@ class Group(MutableMapping):
             path=path,
             chunk_store=self._chunk_store,
             fill_value=fill_value,
-            **kwargs
+            **kwargs,
         )
 
     def array(self, name, data, **kwargs):
@@ -1361,7 +1357,7 @@ def group(
     path=None,
     *,
     zarr_version=None,
-    meta_array=None
+    meta_array=None,
 ):
     """Create a group.
 
@@ -1452,7 +1448,7 @@ def open_group(
     storage_options=None,
     *,
     zarr_version=None,
-    meta_array=None
+    meta_array=None,
 ):
     """Open a group using file-mode-like semantics.
 

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -111,7 +111,6 @@ def is_pure_orthogonal_indexing(selection, ndim):
 
 
 def normalize_integer_selection(dim_sel, dim_len):
-
     # normalize type to int
     dim_sel = int(dim_sel)
 
@@ -145,7 +144,6 @@ dim_out_sel
 
 class IntDimIndexer:
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
-
         # normalize
         dim_sel = normalize_integer_selection(dim_sel, dim_len)
 
@@ -169,7 +167,6 @@ def ceildiv(a, b):
 
 class SliceDimIndexer:
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
-
         # normalize
         self.start, self.stop, self.step = dim_sel.indices(dim_len)
         if self.step < 1:
@@ -182,14 +179,12 @@ class SliceDimIndexer:
         self.nchunks = ceildiv(self.dim_len, self.dim_chunk_len)
 
     def __iter__(self):
-
         # figure out the range of chunks we need to visit
         dim_chunk_ix_from = self.start // self.dim_chunk_len
         dim_chunk_ix_to = ceildiv(self.stop, self.dim_chunk_len)
 
         # iterate over chunks in range
         for dim_chunk_ix in range(dim_chunk_ix_from, dim_chunk_ix_to):
-
             # compute offsets for chunk within overall array
             dim_offset = dim_chunk_ix * self.dim_chunk_len
             dim_limit = min(self.dim_len, (dim_chunk_ix + 1) * self.dim_chunk_len)
@@ -237,7 +232,6 @@ def check_selection_length(selection, shape):
 
 
 def replace_ellipsis(selection, shape):
-
     selection = ensure_tuple(selection)
 
     # count number of ellipsis present
@@ -330,14 +324,12 @@ def is_basic_selection(selection):
 # noinspection PyProtectedMember
 class BasicIndexer:
     def __init__(self, selection, array):
-
         # handle ellipsis
         selection = replace_ellipsis(selection, array._shape)
 
         # setup per-dimension indexers
         dim_indexers = []
         for dim_sel, dim_len, dim_chunk_len in zip(selection, array._shape, array._chunks):
-
             if is_integer(dim_sel):
                 dim_indexer = IntDimIndexer(dim_sel, dim_len, dim_chunk_len)
 
@@ -358,7 +350,6 @@ class BasicIndexer:
 
     def __iter__(self):
         for dim_projections in itertools.product(*self.dim_indexers):
-
             chunk_coords = tuple(p.dim_chunk_ix for p in dim_projections)
             chunk_selection = tuple(p.dim_chunk_sel for p in dim_projections)
             out_selection = tuple(
@@ -370,7 +361,6 @@ class BasicIndexer:
 
 class BoolArrayDimIndexer:
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
-
         # check number of dimensions
         if not is_bool_array(dim_sel, 1):
             raise IndexError(
@@ -402,10 +392,8 @@ class BoolArrayDimIndexer:
         self.dim_chunk_ixs = np.nonzero(self.chunk_nitems)[0]
 
     def __iter__(self):
-
         # iterate over chunks with at least one item
         for dim_chunk_ix in self.dim_chunk_ixs:
-
             # find region in chunk
             dim_offset = dim_chunk_ix * self.dim_chunk_len
             dim_chunk_sel = self.dim_sel[dim_offset : dim_offset + self.dim_chunk_len]
@@ -472,7 +460,6 @@ class IntArrayDimIndexer:
         boundscheck=True,
         order=Order.UNKNOWN,
     ):
-
         # ensure 1d array
         dim_sel = np.asanyarray(dim_sel)
         if not is_integer_array(dim_sel, 1):
@@ -526,9 +513,7 @@ class IntArrayDimIndexer:
         self.chunk_nitems_cumsum = np.cumsum(self.chunk_nitems)
 
     def __iter__(self):
-
         for dim_chunk_ix in self.dim_chunk_ixs:
-
             # find region in output
             if dim_chunk_ix == 0:
                 start = 0
@@ -602,7 +587,6 @@ def oindex_set(a, selection, value):
 # noinspection PyProtectedMember
 class OrthogonalIndexer:
     def __init__(self, selection, array):
-
         # handle ellipsis
         selection = replace_ellipsis(selection, array._shape)
 
@@ -612,7 +596,6 @@ class OrthogonalIndexer:
         # setup per-dimension indexers
         dim_indexers = []
         for dim_sel, dim_len, dim_chunk_len in zip(selection, array._shape, array._chunks):
-
             if is_integer(dim_sel):
                 dim_indexer = IntDimIndexer(dim_sel, dim_len, dim_chunk_len)
 
@@ -649,7 +632,6 @@ class OrthogonalIndexer:
 
     def __iter__(self):
         for dim_projections in itertools.product(*self.dim_indexers):
-
             chunk_coords = tuple(p.dim_chunk_ix for p in dim_projections)
             chunk_selection = tuple(p.dim_chunk_sel for p in dim_projections)
             out_selection = tuple(
@@ -658,7 +640,6 @@ class OrthogonalIndexer:
 
             # handle advanced indexing arrays orthogonally
             if self.is_advanced:
-
                 # N.B., numpy doesn't support orthogonal indexing directly as yet,
                 # so need to work around via np.ix_. Also np.ix_ does not support a
                 # mixture of arrays and slices or integers, so need to convert slices
@@ -692,7 +673,6 @@ class OIndex:
 # noinspection PyProtectedMember
 class BlockIndexer:
     def __init__(self, selection, array):
-
         # handle ellipsis
         selection = replace_ellipsis(selection, array._shape)
 
@@ -794,7 +774,6 @@ def is_mask_selection(selection, array):
 # noinspection PyProtectedMember
 class CoordinateIndexer:
     def __init__(self, selection, array):
-
         # some initial normalization
         selection = ensure_tuple(selection)
         selection = tuple([i] if is_integer(i) else i for i in selection)
@@ -810,7 +789,6 @@ class CoordinateIndexer:
 
         # handle wraparound, boundscheck
         for dim_sel, dim_len in zip(selection, array.shape):
-
             # handle wraparound
             wraparound_indices(dim_sel, dim_len)
 
@@ -861,10 +839,8 @@ class CoordinateIndexer:
         self.chunk_mixs = np.unravel_index(self.chunk_rixs, array._cdata_shape)
 
     def __iter__(self):
-
         # iterate over chunks
         for i, chunk_rix in enumerate(self.chunk_rixs):
-
             chunk_coords = tuple(m[i] for m in self.chunk_mixs)
             if chunk_rix == 0:
                 start = 0
@@ -891,7 +867,6 @@ class CoordinateIndexer:
 # noinspection PyProtectedMember
 class MaskIndexer(CoordinateIndexer):
     def __init__(self, selection, array):
-
         # some initial normalization
         selection = ensure_tuple(selection)
         selection = replace_lists(selection)

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -89,7 +89,6 @@ class Metadata2:
 
     @classmethod
     def parse_metadata(cls, s: Union[MappingType, bytes, str]) -> MappingType[str, Any]:
-
         # Here we allow that a store may return an already-parsed metadata object,
         # or a string of JSON that we will parse here. We allow for an already-parsed
         # object to accommodate a consolidated metadata store, where all the metadata for

--- a/zarr/n5.py
+++ b/zarr/n5.py
@@ -72,21 +72,18 @@ class N5Store(NestedDirectoryStore):
 
     def __getitem__(self, key: str) -> bytes:
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, n5_attrs_key)
             value = group_metadata_to_zarr(self._load_n5_attrs(key_new))
 
             return json_dumps(value)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, n5_attrs_key)
             top_level = key == zarr_array_meta_key
             value = array_metadata_to_zarr(self._load_n5_attrs(key_new), top_level=top_level)
             return json_dumps(value)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, n5_attrs_key)
             value = attrs_to_zarr(self._load_n5_attrs(key_new))
 
@@ -104,9 +101,7 @@ class N5Store(NestedDirectoryStore):
         return super().__getitem__(key_new)
 
     def __setitem__(self, key: str, value: Any):
-
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, n5_attrs_key)
 
             n5_attrs = self._load_n5_attrs(key_new)
@@ -115,7 +110,6 @@ class N5Store(NestedDirectoryStore):
             value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, n5_attrs_key)
             top_level = key == zarr_array_meta_key
             n5_attrs = self._load_n5_attrs(key_new)
@@ -123,7 +117,6 @@ class N5Store(NestedDirectoryStore):
             value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, n5_attrs_key)
 
             n5_attrs = self._load_n5_attrs(key_new)
@@ -166,9 +159,7 @@ class N5Store(NestedDirectoryStore):
         super().__delitem__(key_new)
 
     def __contains__(self, key):
-
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, n5_attrs_key)
             if key_new not in self:
                 return False
@@ -176,18 +167,15 @@ class N5Store(NestedDirectoryStore):
             return "dimensions" not in self._load_n5_attrs(key_new)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, n5_attrs_key)
             # array if attributes contain 'dimensions'
             return "dimensions" in self._load_n5_attrs(key_new)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, n5_attrs_key)
             return self._contains_attrs(key_new)
 
         elif is_chunk_key(key):
-
             key_new = invert_chunk_coords(key)
         else:
             key_new = key
@@ -198,7 +186,6 @@ class N5Store(NestedDirectoryStore):
         return isinstance(other, N5Store) and self.path == other.path
 
     def listdir(self, path: Optional[str] = None):
-
         if path is not None:
             path = invert_chunk_coords(path)
         path = cast(str, path)
@@ -208,7 +195,6 @@ class N5Store(NestedDirectoryStore):
         children = super().listdir(path=path)
 
         if self._is_array(path):
-
             # replace n5 attribute file with respective zarr attribute files
             children.remove(n5_attrs_key)
             children.append(zarr_array_meta_key)
@@ -234,7 +220,6 @@ class N5Store(NestedDirectoryStore):
             return sorted(new_children)
 
         elif self._is_group(path):
-
             # replace n5 attribute file with respective zarr attribute files
             children.remove(n5_attrs_key)
             children.append(zarr_group_meta_key)
@@ -244,7 +229,6 @@ class N5Store(NestedDirectoryStore):
             return sorted(children)
 
         else:
-
             return children
 
     def _load_n5_attrs(self, path: str) -> Dict[str, Any]:
@@ -255,7 +239,6 @@ class N5Store(NestedDirectoryStore):
             return {}
 
     def _is_group(self, path: str):
-
         if path is None:
             attrs_key = n5_attrs_key
         else:
@@ -265,7 +248,6 @@ class N5Store(NestedDirectoryStore):
         return len(n5_attrs) > 0 and "dimensions" not in n5_attrs
 
     def _is_array(self, path: str):
-
         if path is None:
             attrs_key = n5_attrs_key
         else:
@@ -274,7 +256,6 @@ class N5Store(NestedDirectoryStore):
         return "dimensions" in self._load_n5_attrs(attrs_key)
 
     def _contains_attrs(self, path: str):
-
         if path is None:
             attrs_key = n5_attrs_key
         else:
@@ -376,21 +357,18 @@ class N5FSStore(FSStore):
 
     def __getitem__(self, key: str) -> bytes:
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, self._group_meta_key)
             value = group_metadata_to_zarr(self._load_n5_attrs(key_new))
 
             return json_dumps(value)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, self._array_meta_key)
             top_level = key == zarr_array_meta_key
             value = array_metadata_to_zarr(self._load_n5_attrs(key_new), top_level=top_level)
             return json_dumps(value)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, self._attrs_key)
             value = attrs_to_zarr(self._load_n5_attrs(key_new))
 
@@ -409,7 +387,6 @@ class N5FSStore(FSStore):
 
     def __setitem__(self, key: str, value: Any):
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, self._group_meta_key)
 
             n5_attrs = self._load_n5_attrs(key_new)
@@ -418,7 +395,6 @@ class N5FSStore(FSStore):
             value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, self._array_meta_key)
             top_level = key == zarr_array_meta_key
             n5_attrs = self._load_n5_attrs(key_new)
@@ -427,7 +403,6 @@ class N5FSStore(FSStore):
             value = json_dumps(n5_attrs)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, self._attrs_key)
 
             n5_attrs = self._load_n5_attrs(key_new)
@@ -456,7 +431,6 @@ class N5FSStore(FSStore):
         super().__setitem__(key_new, value)
 
     def __delitem__(self, key: str):
-
         if key.endswith(zarr_group_meta_key):
             key_new = key.replace(zarr_group_meta_key, self._group_meta_key)
         elif key.endswith(zarr_array_meta_key):
@@ -471,7 +445,6 @@ class N5FSStore(FSStore):
 
     def __contains__(self, key: Any):
         if key.endswith(zarr_group_meta_key):
-
             key_new = key.replace(zarr_group_meta_key, self._group_meta_key)
             if key_new not in self:
                 return False
@@ -479,13 +452,11 @@ class N5FSStore(FSStore):
             return "dimensions" not in self._load_n5_attrs(key_new)
 
         elif key.endswith(zarr_array_meta_key):
-
             key_new = key.replace(zarr_array_meta_key, self._array_meta_key)
             # array if attributes contain 'dimensions'
             return "dimensions" in self._load_n5_attrs(key_new)
 
         elif key.endswith(zarr_attrs_key):
-
             key_new = key.replace(zarr_attrs_key, self._attrs_key)
             return self._contains_attrs(key_new)
 
@@ -508,7 +479,6 @@ class N5FSStore(FSStore):
         # doesn't provide.
         children = super().listdir(path=path)
         if self._is_array(path):
-
             # replace n5 attribute file with respective zarr attribute files
             children.remove(self._array_meta_key)
             children.append(zarr_array_meta_key)
@@ -532,7 +502,6 @@ class N5FSStore(FSStore):
             return sorted(new_children)
 
         elif self._is_group(path):
-
             # replace n5 attribute file with respective zarr attribute files
             children.remove(self._group_meta_key)
             children.append(zarr_group_meta_key)
@@ -550,7 +519,6 @@ class N5FSStore(FSStore):
             return {}
 
     def _is_group(self, path: Optional[str]):
-
         if path is None:
             attrs_key = self._attrs_key
         else:
@@ -560,7 +528,6 @@ class N5FSStore(FSStore):
         return len(n5_attrs) > 0 and "dimensions" not in n5_attrs
 
     def _is_array(self, path: Optional[str]):
-
         if path is None:
             attrs_key = self._attrs_key
         else:
@@ -569,7 +536,6 @@ class N5FSStore(FSStore):
         return "dimensions" in self._load_n5_attrs(attrs_key)
 
     def _contains_attrs(self, path: Optional[str]):
-
         if path is None:
             attrs_key = self._attrs_key
         else:
@@ -712,7 +678,6 @@ def attrs_to_zarr(attrs: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-
     if compressor_config is None:
         return {"type": "raw"}
     else:
@@ -726,19 +691,16 @@ def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict
     n5_config = {"type": codec_id}
 
     if codec_id == "bz2":
-
         n5_config["type"] = "bzip2"
         n5_config["blockSize"] = _compressor_config["level"]
 
     elif codec_id == "blosc":
-
         n5_config["cname"] = _compressor_config["cname"]
         n5_config["clevel"] = _compressor_config["clevel"]
         n5_config["shuffle"] = _compressor_config["shuffle"]
         n5_config["blocksize"] = _compressor_config["blocksize"]
 
     elif codec_id == "lzma":
-
         # Switch to XZ for N5 if we are using the default XZ format.
         # Note: 4 is the default, which is lzma.CHECK_CRC64.
         if _compressor_config["format"] == 1 and _compressor_config["check"] in [-1, 4]:
@@ -760,50 +722,42 @@ def compressor_config_to_n5(compressor_config: Optional[Dict[str, Any]]) -> Dict
             n5_config["preset"] = 6
 
     elif codec_id == "zlib":
-
         n5_config["type"] = "gzip"
         n5_config["level"] = _compressor_config["level"]
         n5_config["useZlib"] = True
 
     elif codec_id == "gzip":
-
         n5_config["type"] = "gzip"
         n5_config["level"] = _compressor_config["level"]
         n5_config["useZlib"] = False
 
     else:
-
         n5_config.update({k: v for k, v in _compressor_config.items() if k != "type"})
 
     return n5_config
 
 
 def compressor_config_to_zarr(compressor_config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-
     codec_id = compressor_config["type"]
     zarr_config = {"id": codec_id}
 
     if codec_id == "bzip2":
-
         zarr_config["id"] = "bz2"
         zarr_config["level"] = compressor_config["blockSize"]
 
     elif codec_id == "blosc":
-
         zarr_config["cname"] = compressor_config["cname"]
         zarr_config["clevel"] = compressor_config["clevel"]
         zarr_config["shuffle"] = compressor_config["shuffle"]
         zarr_config["blocksize"] = compressor_config["blocksize"]
 
     elif codec_id == "lzma":
-
         zarr_config["format"] = compressor_config["format"]
         zarr_config["check"] = compressor_config["check"]
         zarr_config["preset"] = compressor_config["preset"]
         zarr_config["filters"] = compressor_config["filters"]
 
     elif codec_id == "xz":
-
         zarr_config["id"] = "lzma"
         zarr_config["format"] = 1  # lzma.FORMAT_XZ
         zarr_config["check"] = -1
@@ -811,7 +765,6 @@ def compressor_config_to_zarr(compressor_config: Dict[str, Any]) -> Optional[Dic
         zarr_config["filters"] = None
 
     elif codec_id == "gzip":
-
         if "useZlib" in compressor_config and compressor_config["useZlib"]:
             zarr_config["id"] = "zlib"
             zarr_config["level"] = compressor_config["level"]
@@ -820,22 +773,18 @@ def compressor_config_to_zarr(compressor_config: Dict[str, Any]) -> Optional[Dic
             zarr_config["level"] = compressor_config["level"]
 
     elif codec_id == "raw":
-
         return None
 
     else:
-
         zarr_config.update({k: v for k, v in compressor_config.items() if k != "type"})
 
     return zarr_config
 
 
 class N5ChunkWrapper(Codec):
-
     codec_id = "n5_wrapper"
 
     def __init__(self, dtype, chunk_shape, compressor_config=None, compressor=None):
-
         self.dtype = np.dtype(dtype)
         self.chunk_shape = tuple(chunk_shape)
         # is the dtype a little endian format?
@@ -860,7 +809,6 @@ class N5ChunkWrapper(Codec):
         return config
 
     def encode(self, chunk):
-
         assert chunk.flags.c_contiguous
 
         header = self._create_header(chunk)
@@ -872,12 +820,10 @@ class N5ChunkWrapper(Codec):
             return header + chunk.tobytes(order="A")
 
     def decode(self, chunk, out=None) -> bytes:
-
         len_header, chunk_shape = self._read_header(chunk)
         chunk = chunk[len_header:]
 
         if out is not None:
-
             # out should only be used if we read a complete chunk
             assert chunk_shape == self.chunk_shape, "Expected chunk of shape {}, found {}".format(
                 self.chunk_shape, chunk_shape
@@ -895,7 +841,6 @@ class N5ChunkWrapper(Codec):
             return out
 
         else:
-
             if self._compressor:
                 chunk = self._compressor.decode(chunk)
 
@@ -915,7 +860,6 @@ class N5ChunkWrapper(Codec):
 
     @staticmethod
     def _create_header(chunk):
-
         mode = struct.pack(">H", 0)
         num_dims = struct.pack(">H", len(chunk.shape))
         shape = b"".join(struct.pack(">I", d) for d in chunk.shape[::-1])
@@ -924,7 +868,6 @@ class N5ChunkWrapper(Codec):
 
     @staticmethod
     def _read_header(chunk):
-
         num_dims = struct.unpack(">H", chunk[2:4])[0]
         shape = tuple(
             struct.unpack(">I", chunk[i : i + 4])[0] for i in range(4, num_dims * 4 + 4, 4)

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -482,7 +482,6 @@ def _init_array_metadata(
     dimension_separator=None,
     storage_transformers=(),
 ):
-
     store_version = getattr(store, "_store_version", 2)
 
     path = normalize_storage_path(path)
@@ -687,7 +686,6 @@ def _init_group_metadata(
     path: Optional[str] = None,
     chunk_store: Optional[StoreLike] = None,
 ):
-
     store_version = getattr(store, "_store_version", 2)
     path = normalize_storage_path(path)
 
@@ -1055,7 +1053,6 @@ class DirectoryStore(Store):
     """
 
     def __init__(self, path, normalize_keys=False, dimension_separator=None):
-
         # guard conditions
         path = os.path.abspath(path)
         if os.path.exists(path) and not os.path.isdir(path):
@@ -1415,7 +1412,6 @@ class FSStore(Store):
     def getitems(
         self, keys: Sequence[str], *, contexts: Mapping[str, Context]
     ) -> Mapping[str, Any]:
-
         keys_transformed = [self._normalize_key(key) for key in keys]
         results = self.map.getitems(keys_transformed, on_error="omit")
         # The function calling this method may not recognize the transformed keys
@@ -1768,7 +1764,6 @@ class ZipStore(Store):
         mode="a",
         dimension_separator=None,
     ):
-
         # store properties
         path = os.path.abspath(path)
         self.path = path

--- a/zarr/tests/test_attrs.py
+++ b/zarr/tests/test_attrs.py
@@ -30,7 +30,6 @@ class TestAttributes:
         return Attributes(store, key=root + "attrs", read_only=read_only, cache=cache)
 
     def test_storage(self, zarr_version):
-
         store = _init_store(zarr_version)
         root = ".z" if zarr_version == 2 else meta_root
         attrs_key = root + "attrs"
@@ -50,7 +49,6 @@ class TestAttributes:
         assert dict(foo="bar", baz=42) == d
 
     def test_utf8_encoding(self, zarr_version):
-
         project_root = pathlib.Path(zarr.__file__).resolve().parent.parent
         fixdir = project_root / "fixture"
         testdir = fixdir / "utf8attrs"
@@ -67,7 +65,6 @@ class TestAttributes:
         assert fixture["utf8attrs"].attrs.asdict() == dict(foo="た")
 
     def test_get_set_del_contains(self, zarr_version):
-
         store = _init_store(zarr_version)
         a = self.init_attributes(store, zarr_version=zarr_version)
         assert "foo" not in a
@@ -84,7 +81,6 @@ class TestAttributes:
             a["foo"]
 
     def test_update_put(self, zarr_version):
-
         store = _init_store(zarr_version)
         a = self.init_attributes(store, zarr_version=zarr_version)
         assert "foo" not in a
@@ -102,7 +98,6 @@ class TestAttributes:
         assert "baz" not in a
 
     def test_iterators(self, zarr_version):
-
         store = _init_store(zarr_version)
         a = self.init_attributes(store, zarr_version=zarr_version)
         assert 0 == len(a)
@@ -232,7 +227,6 @@ class TestAttributes:
         assert get_cnt == store.counter["__getitem__", attrs_key]
 
     def test_caching_off(self, zarr_version):
-
         # setup store
         store = CountingDict() if zarr_version == 2 else CountingDictV3()
         attrs_key = ".zattrs" if zarr_version == 2 else "meta/root/attrs"

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -57,7 +57,6 @@ def _init_creation_kwargs(zarr_version):
 
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 def test_open_array(path_type, zarr_version):
-
     store = tempfile.mkdtemp()
     atexit.register(atexit_rmtree, store)
     store = path_type(store)
@@ -86,7 +85,6 @@ def test_open_array(path_type, zarr_version):
 
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 def test_open_group(path_type, zarr_version):
-
     store = tempfile.mkdtemp()
     atexit.register(atexit_rmtree, store)
     store = path_type(store)
@@ -210,7 +208,6 @@ def test_tree(zarr_version):
 def test_consolidate_metadata(
     with_chunk_store, zarr_version, listable, monkeypatch, stores_from_path
 ):
-
     # setup initial data
     if stores_from_path:
         store = tempfile.mkdtemp()
@@ -399,7 +396,6 @@ def test_save_array_separator(tmpdir, options):
 
 
 class TestCopyStore(unittest.TestCase):
-
     _version = 2
 
     def setUp(self):
@@ -536,7 +532,6 @@ class TestCopyStore(unittest.TestCase):
 
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")
 class TestCopyStoreV3(TestCopyStore):
-
     _version = 3
 
     def setUp(self):
@@ -557,7 +552,6 @@ class TestCopyStoreV3(TestCopyStore):
 
 
 def check_copied_array(original, copied, without_attrs=False, expect_props=None):
-
     # setup
     source_h5py = original.__module__.startswith("h5py.")
     dest_h5py = copied.__module__.startswith("h5py.")
@@ -621,7 +615,6 @@ def check_copied_array(original, copied, without_attrs=False, expect_props=None)
 
 
 def check_copied_group(original, copied, without_attrs=False, expect_props=None, shallow=False):
-
     # setup
     if expect_props is None:
         expect_props = dict()

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -74,7 +74,6 @@ def _init_creation_kwargs(zarr_version, at_root=True):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_array(zarr_version, at_root):
-
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
     kwargs = _init_creation_kwargs(zarr_version, at_root)
 
@@ -213,7 +212,6 @@ def test_full_additional_dtypes(zarr_version):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_open_array(zarr_version, at_root, dimension_separator):
-
     store = "data/array.zarr"
     kwargs = _init_creation_kwargs(zarr_version, at_root)
 
@@ -329,7 +327,6 @@ def test_open_array(zarr_version, at_root, dimension_separator):
 
 
 def test_open_array_none():
-
     # open with both store and zarr_version = None
     z = open_array(mode="w", shape=100, chunks=10)
     assert isinstance(z, Array)
@@ -339,7 +336,6 @@ def test_open_array_none():
 @pytest.mark.parametrize("dimension_separator", [".", "/", None])
 @pytest.mark.parametrize("zarr_version", _VERSIONS2)
 def test_open_array_infer_separator_from_store(zarr_version, dimension_separator):
-
     if zarr_version == 3:
         StoreClass = DirectoryStoreV3
         path = "data"
@@ -370,7 +366,6 @@ def test_open_array_infer_separator_from_store(zarr_version, dimension_separator
 # TODO: N5 support for v3
 @pytest.mark.parametrize("zarr_version", [None, 2])
 def test_open_array_n5(zarr_version):
-
     store = "data/array.zarr"
     kwargs = _init_creation_kwargs(zarr_version)
 
@@ -409,7 +404,6 @@ def test_open_array_n5(zarr_version):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_open_array_dict_store(zarr_version, at_root):
-
     # dict will become a KVStore
     store = dict()
     kwargs = _init_creation_kwargs(zarr_version, at_root)
@@ -503,7 +497,6 @@ def test_empty_like(zarr_version, at_root):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_zeros_like(zarr_version, at_root):
-
     kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
@@ -529,7 +522,6 @@ def test_zeros_like(zarr_version, at_root):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_ones_like(zarr_version, at_root):
-
     kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 
@@ -556,7 +548,6 @@ def test_ones_like(zarr_version, at_root):
 @pytest.mark.parametrize("zarr_version", _VERSIONS)
 @pytest.mark.parametrize("at_root", [False, True])
 def test_full_like(zarr_version, at_root):
-
     kwargs = _init_creation_kwargs(zarr_version, at_root)
     expected_zarr_version = DEFAULT_ZARR_VERSION if zarr_version is None else zarr_version
 

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -46,7 +46,6 @@ def dataset(tmpdir, request):
         static = project_root / "fixture" / suffix
 
         if not static.exists():  # pragma: no cover
-
             if "nested" in which:
                 # No way to reproduce the nested_legacy file via code
                 generator = NestedDirectoryStore

--- a/zarr/tests/test_filters.py
+++ b/zarr/tests/test_filters.py
@@ -30,7 +30,6 @@ else:
 
 
 def test_array_with_delta_filter():
-
     # setup
     astype = "u1"
     dtype = "i8"
@@ -38,7 +37,6 @@ def test_array_with_delta_filter():
     data = np.arange(100, dtype=dtype)
 
     for compressor in compressors:
-
         a = array(data, chunks=10, compressor=compressor, filters=filters)
 
         # check round-trip
@@ -57,7 +55,6 @@ def test_array_with_delta_filter():
 
 
 def test_array_with_astype_filter():
-
     # setup
     encode_dtype = "i1"
     decode_dtype = "i8"
@@ -68,7 +65,6 @@ def test_array_with_astype_filter():
     data = np.arange(shape, dtype=decode_dtype)
 
     for compressor in compressors:
-
         a = array(data, chunks=chunks, compressor=compressor, filters=filters)
 
         # check round-trip
@@ -88,7 +84,6 @@ def test_array_with_astype_filter():
 
 
 def test_array_with_scaleoffset_filter():
-
     # setup
     astype = "u1"
     dtype = "f8"
@@ -97,7 +92,6 @@ def test_array_with_scaleoffset_filter():
     data = np.linspace(1000, 1001, 34, dtype="f8")
 
     for compressor in compressors:
-
         a = array(data, chunks=5, compressor=compressor, filters=filters)
 
         # check round-trip
@@ -116,7 +110,6 @@ def test_array_with_scaleoffset_filter():
 
 
 def test_array_with_quantize_filter():
-
     # setup
     dtype = "f8"
     digits = 3
@@ -125,7 +118,6 @@ def test_array_with_quantize_filter():
     data = np.linspace(0, 1, 34, dtype=dtype)
 
     for compressor in compressors:
-
         a = array(data, chunks=5, compressor=compressor, filters=filters)
 
         # check round-trip
@@ -144,14 +136,12 @@ def test_array_with_quantize_filter():
 
 
 def test_array_with_packbits_filter():
-
     # setup
     flt = PackBits()
     filters = [flt]
     data = np.random.randint(0, 2, size=100, dtype=bool)
 
     for compressor in compressors:
-
         a = array(data, chunks=5, compressor=compressor, filters=filters)
 
         # check round-trip
@@ -170,14 +160,12 @@ def test_array_with_packbits_filter():
 
 
 def test_array_with_categorize_filter():
-
     # setup
     data = np.random.choice(["foo", "bar", "baz"], size=100)
     flt = Categorize(dtype=data.dtype, labels=["foo", "bar", "baz"])
     filters = [flt]
 
     for compressor in compressors:
-
         a = array(data, chunks=5, compressor=compressor, filters=filters)
 
         # check round-trip

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1085,7 +1085,6 @@ class TestGroup(unittest.TestCase):
         g1.store.close()
 
     def test_pickle(self):
-
         # setup group
         g = self.create_group()
         d = g.create_dataset("foo/bar", shape=100, chunks=10)
@@ -1113,7 +1112,6 @@ class TestGroup(unittest.TestCase):
         g2.store.close()
 
     def test_context_manager(self):
-
         with self.create_group() as g:
             d = g.create_dataset("foo/bar", shape=100, chunks=10)
             d[:] = np.arange(100)
@@ -1375,7 +1373,6 @@ class TestGroupWithZipStore(TestGroup):
         return store, None
 
     def test_context_manager(self):
-
         with self.create_group() as g:
             store = g.store
             d = g.create_dataset("foo/bar", shape=100, chunks=10)

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -17,7 +17,6 @@ from zarr.tests.util import CountingDict
 
 
 def test_normalize_integer_selection():
-
     assert 1 == normalize_integer_selection(1, 100)
     assert 99 == normalize_integer_selection(-1, 100)
     with pytest.raises(IndexError):
@@ -29,7 +28,6 @@ def test_normalize_integer_selection():
 
 
 def test_replace_ellipsis():
-
     # 1D, single item
     assert (0,) == replace_ellipsis(0, (100,))
 
@@ -68,7 +66,6 @@ def test_replace_ellipsis():
 
 
 def test_get_basic_selection_0d():
-
     # setup
     a = np.array(42)
     z = zarr.create(shape=a.shape, dtype=a.dtype, fill_value=None)
@@ -191,7 +188,6 @@ def _test_get_basic_selection(a, z, selection):
 
 # noinspection PyStatementEffect
 def test_get_basic_selection_1d():
-
     # setup
     a = np.arange(1050, dtype=int)
     z = zarr.create(shape=a.shape, chunks=100, dtype=a.dtype)
@@ -264,7 +260,6 @@ basic_selections_2d_bad = [
 
 # noinspection PyStatementEffect
 def test_get_basic_selection_2d():
-
     # setup
     a = np.arange(10000, dtype=int).reshape(1000, 10)
     z = zarr.create(shape=a.shape, chunks=(300, 3), dtype=a.dtype)
@@ -423,7 +418,6 @@ def test_fancy_indexing_doesnt_mix_with_implicit_slicing():
 
 
 def test_set_basic_selection_0d():
-
     # setup
     v = np.array(42)
     a = np.zeros_like(v)
@@ -479,7 +473,6 @@ def _test_get_orthogonal_selection(a, z, selection):
 
 # noinspection PyStatementEffect
 def test_get_orthogonal_selection_1d_bool():
-
     # setup
     a = np.arange(1050, dtype=int)
     z = zarr.create(shape=a.shape, chunks=100, dtype=a.dtype)
@@ -502,7 +495,6 @@ def test_get_orthogonal_selection_1d_bool():
 
 # noinspection PyStatementEffect
 def test_get_orthogonal_selection_1d_int():
-
     # setup
     a = np.arange(1050, dtype=int)
     z = zarr.create(shape=a.shape, chunks=100, dtype=a.dtype)
@@ -561,7 +553,6 @@ def _test_get_orthogonal_selection_2d(a, z, ix0, ix1):
 
 # noinspection PyStatementEffect
 def test_get_orthogonal_selection_2d():
-
     # setup
     a = np.arange(10000, dtype=int).reshape(1000, 10)
     z = zarr.create(shape=a.shape, chunks=(300, 3), dtype=a.dtype)
@@ -570,7 +561,6 @@ def test_get_orthogonal_selection_2d():
     np.random.seed(42)
     # test with different degrees of sparseness
     for p in 0.5, 0.1, 0.01:
-
         # boolean arrays
         ix0 = np.random.binomial(1, p, size=a.shape[0]).astype(bool)
         ix1 = np.random.binomial(1, 0.5, size=a.shape[1]).astype(bool)
@@ -641,7 +631,6 @@ def _test_get_orthogonal_selection_3d(a, z, ix0, ix1, ix2):
 
 
 def test_get_orthogonal_selection_3d():
-
     # setup
     a = np.arange(100000, dtype=int).reshape(200, 50, 10)
     z = zarr.create(shape=a.shape, chunks=(60, 20, 3), dtype=a.dtype)
@@ -650,7 +639,6 @@ def test_get_orthogonal_selection_3d():
     np.random.seed(42)
     # test with different degrees of sparseness
     for p in 0.5, 0.1, 0.01:
-
         # boolean arrays
         ix0 = np.random.binomial(1, p, size=a.shape[0]).astype(bool)
         ix1 = np.random.binomial(1, 0.5, size=a.shape[1]).astype(bool)
@@ -673,7 +661,6 @@ def test_get_orthogonal_selection_3d():
 
 
 def test_orthogonal_indexing_edge_cases():
-
     a = np.arange(6).reshape(1, 2, 3)
     z = zarr.create(shape=a.shape, chunks=(1, 2, 3), dtype=a.dtype)
     z[:] = a
@@ -706,7 +693,6 @@ def _test_set_orthogonal_selection(v, a, z, selection):
 
 
 def test_set_orthogonal_selection_1d():
-
     # setup
     v = np.arange(1050, dtype=int)
     a = np.empty(v.shape, dtype=int)
@@ -715,7 +701,6 @@ def test_set_orthogonal_selection_1d():
     # test with different degrees of sparseness
     np.random.seed(42)
     for p in 0.5, 0.1, 0.01:
-
         # boolean arrays
         ix = np.random.binomial(1, p, size=a.shape[0]).astype(bool)
         _test_set_orthogonal_selection(v, a, z, ix)
@@ -734,7 +719,6 @@ def test_set_orthogonal_selection_1d():
 
 
 def _test_set_orthogonal_selection_2d(v, a, z, ix0, ix1):
-
     selections = [
         # index both axes with array
         (ix0, ix1),
@@ -749,7 +733,6 @@ def _test_set_orthogonal_selection_2d(v, a, z, ix0, ix1):
 
 
 def test_set_orthogonal_selection_2d():
-
     # setup
     v = np.arange(10000, dtype=int).reshape(1000, 10)
     a = np.empty_like(v)
@@ -758,7 +741,6 @@ def test_set_orthogonal_selection_2d():
     np.random.seed(42)
     # test with different degrees of sparseness
     for p in 0.5, 0.1, 0.01:
-
         # boolean arrays
         ix0 = np.random.binomial(1, p, size=a.shape[0]).astype(bool)
         ix1 = np.random.binomial(1, 0.5, size=a.shape[1]).astype(bool)
@@ -780,7 +762,6 @@ def test_set_orthogonal_selection_2d():
 
 
 def _test_set_orthogonal_selection_3d(v, a, z, ix0, ix1, ix2):
-
     selections = (
         # single value
         (84, 42, 4),
@@ -807,7 +788,6 @@ def _test_set_orthogonal_selection_3d(v, a, z, ix0, ix1, ix2):
 
 
 def test_set_orthogonal_selection_3d():
-
     # setup
     v = np.arange(100000, dtype=int).reshape(200, 50, 10)
     a = np.empty_like(v)
@@ -816,7 +796,6 @@ def test_set_orthogonal_selection_3d():
     np.random.seed(42)
     # test with different degrees of sparseness
     for p in 0.5, 0.1, 0.01:
-
         # boolean arrays
         ix0 = np.random.binomial(1, p, size=a.shape[0]).astype(bool)
         ix1 = np.random.binomial(1, 0.5, size=a.shape[1]).astype(bool)
@@ -888,7 +867,6 @@ coordinate_selections_1d_bad = [
 
 # noinspection PyStatementEffect
 def test_get_coordinate_selection_1d():
-
     # setup
     a = np.arange(1050, dtype=int)
     z = zarr.create(shape=a.shape, chunks=100, dtype=a.dtype)
@@ -932,7 +910,6 @@ def test_get_coordinate_selection_1d():
 
 
 def test_get_coordinate_selection_2d():
-
     # setup
     a = np.arange(10000, dtype=int).reshape(1000, 10)
     z = zarr.create(shape=a.shape, chunks=(300, 3), dtype=a.dtype)
@@ -1027,7 +1004,6 @@ def test_set_coordinate_selection_1d():
 
 
 def test_set_coordinate_selection_2d():
-
     # setup
     v = np.arange(10000, dtype=int).reshape(1000, 10)
     a = np.empty_like(v)
@@ -1258,7 +1234,6 @@ mask_selections_1d_bad = [
 
 # noinspection PyStatementEffect
 def test_get_mask_selection_1d():
-
     # setup
     a = np.arange(1050, dtype=int)
     z = zarr.create(shape=a.shape, chunks=100, dtype=a.dtype)
@@ -1285,7 +1260,6 @@ def test_get_mask_selection_1d():
 
 # noinspection PyStatementEffect
 def test_get_mask_selection_2d():
-
     # setup
     a = np.arange(10000, dtype=int).reshape(1000, 10)
     z = zarr.create(shape=a.shape, chunks=(300, 3), dtype=a.dtype)
@@ -1318,7 +1292,6 @@ def _test_set_mask_selection(v, a, z, selection):
 
 
 def test_set_mask_selection_1d():
-
     # setup
     v = np.arange(1050, dtype=int)
     a = np.empty_like(v)
@@ -1338,7 +1311,6 @@ def test_set_mask_selection_1d():
 
 
 def test_set_mask_selection_2d():
-
     # setup
     v = np.arange(10000, dtype=int).reshape(1000, 10)
     a = np.empty_like(v)
@@ -1352,7 +1324,6 @@ def test_set_mask_selection_2d():
 
 
 def test_get_selection_out():
-
     # basic selections
     a = np.arange(1050)
     z = zarr.create(shape=1050, chunks=100, dtype=a.dtype)
@@ -1426,7 +1397,6 @@ def test_get_selection_out():
 
 
 def test_get_selections_with_fields():
-
     a = [("aaa", 1, 4.2), ("bbb", 2, 8.4), ("ccc", 3, 12.6)]
     a = np.array(a, dtype=[("foo", "S3"), ("bar", "i4"), ("baz", "f8")])
     z = zarr.create(shape=a.shape, chunks=2, dtype=a.dtype, fill_value=None)
@@ -1444,7 +1414,6 @@ def test_get_selections_with_fields():
     ]
 
     for fields in fields_fixture:
-
         # total selection
         expect = a[fields]
         actual = z.get_basic_selection(Ellipsis, fields=fields)
@@ -1534,7 +1503,6 @@ def test_get_selections_with_fields():
 
 
 def test_set_selections_with_fields():
-
     v = [("aaa", 1, 4.2), ("bbb", 2, 8.4), ("ccc", 3, 12.6)]
     v = np.array(v, dtype=[("foo", "S3"), ("bar", "i4"), ("baz", "f8")])
     a = np.empty_like(v)
@@ -1553,7 +1521,6 @@ def test_set_selections_with_fields():
     ]
 
     for fields in fields_fixture:
-
         # currently multi-field assignment is not supported in numpy, so we won't support
         # it either
         if isinstance(fields, list) and len(fields) > 1:
@@ -1567,7 +1534,6 @@ def test_set_selections_with_fields():
                 z.set_mask_selection([True, False, True], v, fields=fields)
 
         else:
-
             if isinstance(fields, list) and len(fields) == 1:
                 # work around numpy does not support multi-field assignment even if there
                 # is only one field
@@ -1752,7 +1718,6 @@ def test_accessed_chunks(shape, chunks, ops):
     z = zarr.create(shape=shape, chunks=chunks, store=store)
 
     for ii, (optype, slices) in enumerate(ops):
-
         # Resolve the slices into the accessed chunks for each dimension
         chunks_per_dim = []
         for N, C, sl in zip(shape, chunks, slices):

--- a/zarr/tests/test_info.py
+++ b/zarr/tests/test_info.py
@@ -7,7 +7,6 @@ from zarr.util import InfoReporter
 
 @pytest.mark.parametrize("array_size", [10, 15000])
 def test_info(array_size):
-
     # setup
     g = zarr.group(store=dict(), chunk_store=dict(), synchronizer=zarr.ThreadSynchronizer())
     g.create_group("foo")

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -34,7 +34,6 @@ def assert_json_equal(expect, actual):
 
 
 def test_encode_decode_array_1():
-
     meta = dict(
         shape=(100,),
         chunks=(10,),
@@ -76,7 +75,6 @@ def test_encode_decode_array_1():
 
 
 def test_encode_decode_array_2():
-
     # some variations
     df = Delta(astype="<u2", dtype="V14")
     compressor = Blosc(cname="lz4", clevel=3, shuffle=2)
@@ -131,7 +129,6 @@ def test_encode_decode_array_2():
 
 
 def test_encode_decode_array_complex():
-
     # some variations
     for k in ["c8", "c16"]:
         compressor = Blosc(cname="lz4", clevel=3, shuffle=2)
@@ -189,7 +186,6 @@ def test_encode_decode_array_complex():
 
 
 def test_encode_decode_array_datetime_timedelta():
-
     # some variations
     for k in ["m8[s]", "M8[s]"]:
         compressor = Blosc(cname="lz4", clevel=3, shuffle=2)
@@ -247,7 +243,6 @@ def test_encode_decode_array_datetime_timedelta():
 
 
 def test_encode_decode_array_dtype_shape():
-
     meta = dict(
         shape=(100,),
         chunks=(10,),
@@ -291,7 +286,6 @@ def test_encode_decode_array_dtype_shape():
 
 
 def test_encode_decode_array_dtype_shape_v3():
-
     meta = dict(
         shape=(100,),
         chunk_grid=dict(type="regular", chunk_shape=(10,), separator=("/")),
@@ -363,7 +357,6 @@ def test_decode_metadata_implicit_compressor_config_v3(comp_id):
 
 
 def test_encode_decode_array_structured():
-
     meta = dict(
         shape=(100,),
         chunks=(10,),
@@ -407,7 +400,6 @@ def test_encode_decode_array_structured():
 
 
 def test_encode_decode_fill_values_nan():
-
     fills = (
         (np.nan, "NaN", np.isnan),
         (np.NINF, "-Infinity", np.isneginf),
@@ -415,7 +407,6 @@ def test_encode_decode_fill_values_nan():
     )
 
     for v, s, f in fills:
-
         meta = dict(
             shape=(100,),
             chunks=(10,),
@@ -451,12 +442,10 @@ def test_encode_decode_fill_values_nan():
 
 
 def test_encode_decode_fill_values_bytes():
-
     dtype = np.dtype("S10")
     fills = b"foo", bytes(10)
 
     for v in fills:
-
         # setup and encode metadata
         meta = dict(
             shape=(100,),
@@ -497,7 +486,6 @@ def test_encode_decode_fill_values_bytes():
 
 
 def test_decode_array_unsupported_format():
-
     # unsupported format
     meta_json = """{
         "zarr_format": %s,
@@ -515,7 +503,6 @@ def test_decode_array_unsupported_format():
 
 
 def test_decode_array_missing_fields():
-
     # missing fields
     meta_json = (
         """{
@@ -528,7 +515,6 @@ def test_decode_array_missing_fields():
 
 
 def test_encode_decode_dtype():
-
     for dt in ["f8", [("a", "f8")], [("a", "f8"), ("b", "i1")]]:
         e = encode_dtype(np.dtype(dt))
         s = json.dumps(e)  # check JSON serializable
@@ -538,7 +524,6 @@ def test_encode_decode_dtype():
 
 
 def test_decode_group():
-
     # typical
     b = (
         """{
@@ -577,7 +562,6 @@ def test_decode_group():
     ],
 )
 def test_encode_fill_value(fill_value, dtype, object_codec, result):
-
     # normalize metadata (copied from _init_array_metadata)
     dtype, object_codec = normalize_dtype(dtype, object_codec)
     dtype = dtype.base
@@ -609,7 +593,6 @@ def test_encode_fill_value(fill_value, dtype, object_codec, result):
     ],
 )
 def test_decode_fill_value(fill_value, dtype, object_codec, result):
-
     # normalize metadata (copied from _init_array_metadata)
     dtype, object_codec = normalize_dtype(dtype, object_codec)
     dtype = dtype.base
@@ -640,7 +623,6 @@ def test_get_extended_dtype_info():
         assert "fallback" in info
 
     class invalid_dtype:
-
         str = "unknown_type"
 
     with pytest.raises(ValueError):
@@ -648,7 +630,6 @@ def test_get_extended_dtype_info():
 
 
 def test_metadata3_exceptions():
-
     with pytest.raises(KeyError):
         # dict must have a key named 'type'
         Metadata3.decode_dtype({})

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -288,7 +288,6 @@ class StoreTests:
         store.close()
 
     def test_pickle(self):
-
         # setup store
         store = self.create_store()
         store[self.root + "foo"] = b"bar"
@@ -483,7 +482,6 @@ class StoreTests:
         store.close()
 
     def test_init_array(self, dimension_separator_fixture):
-
         pass_dim_sep, want_dim_sep = dimension_separator_fixture
 
         store = self.create_store(dimension_separator=pass_dim_sep)
@@ -1023,7 +1021,6 @@ class TestDirectoryStore(StoreTests):
         return store
 
     def test_filesystem_path(self):
-
         # test behaviour with path that does not exist
         path = "data/store"
         if os.path.exists(path):
@@ -1102,7 +1099,6 @@ class TestDirectoryStore(StoreTests):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStore(StoreTests):
     def create_store(self, normalize_keys=False, dimension_separator=".", path=None, **kwargs):
-
         if path is None:
             path = tempfile.mkdtemp()
             atexit.register(atexit_rmtree, path)
@@ -1345,7 +1341,6 @@ class TestFSStore(StoreTests):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStoreWithKeySeparator(StoreTests):
     def create_store(self, normalize_keys=False, key_separator=".", **kwargs):
-
         # Since the user is passing key_separator, that will take priority.
         skip_if_nested_chunks(**kwargs)
 
@@ -1613,7 +1608,6 @@ class TestN5Store(TestNestedDirectoryStore):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestN5FSStore(TestFSStore):
     def create_store(self, normalize_keys=False, path=None, **kwargs):
-
         if path is None:
             path = tempfile.mkdtemp()
             atexit.register(atexit_rmtree, path)
@@ -1722,7 +1716,6 @@ class TestN5FSStore(TestFSStore):
         self._test_init_group_overwrite_chunk_store("C")
 
     def test_dimension_separator(self):
-
         with pytest.warns(UserWarning, match="dimension_separator"):
             self.create_store(dimension_separator="/")
 
@@ -1787,7 +1780,6 @@ class TestTempStore(StoreTests):
 
 
 class TestZipStore(StoreTests):
-
     ZipStoreClass = ZipStore
 
     def create_store(self, **kwargs):
@@ -1965,7 +1957,6 @@ class TestSQLiteStoreInMemory(TestSQLiteStore):
         return store
 
     def test_pickle(self):
-
         # setup store
         store = self.create_store()
         store[self.root + "foo"] = b"bar"
@@ -2001,7 +1992,6 @@ class TestRedisStore(StoreTests):
 
 
 class TestLRUStoreCache(StoreTests):
-
     CountingClass = CountingDict
     LRUStoreClass = LRUStoreCache
 
@@ -2011,7 +2001,6 @@ class TestLRUStoreCache(StoreTests):
         return self.LRUStoreClass(dict(), max_size=2**27)
 
     def test_cache_values_no_max_size(self):
-
         # setup store
         store = self.CountingClass()
         foo_key = self.root + "foo"
@@ -2077,7 +2066,6 @@ class TestLRUStoreCache(StoreTests):
         assert 1 == store.counter["__setitem__", bar_key]
 
     def test_cache_values_with_max_size(self):
-
         # setup store
         store = self.CountingClass()
         foo_key = self.root + "foo"
@@ -2175,7 +2163,6 @@ class TestLRUStoreCache(StoreTests):
         assert 2 == cache.misses
 
     def test_cache_keys(self):
-
         # setup
         store = self.CountingClass()
         foo_key = self.root + "foo"
@@ -2324,7 +2311,6 @@ def test_migrate_1to2(dict_store):
 
 
 def test_format_compatibility():
-
     # This test is intended to catch any unintended changes that break the ability to
     # read data stored with a previous minor version (which should be format-compatible).
 
@@ -2380,7 +2366,6 @@ def test_format_compatibility():
     ]
 
     for i, (arr, chunks) in enumerate(arrays_chunks):
-
         if arr.flags.f_contiguous:
             order = "F"
         else:
@@ -2415,7 +2400,6 @@ def test_format_compatibility():
 
 @skip_test_env_var("ZARR_TEST_ABS")
 class TestABSStore(StoreTests):
-
     ABSStoreClass = ABSStore
 
     def create_store(self, prefix=None, **kwargs):
@@ -2486,7 +2470,6 @@ class TestABSStore(StoreTests):
 
 
 class TestConsolidatedMetadataStore:
-
     version = 2
     ConsolidatedMetadataClass = ConsolidatedMetadataStore
 
@@ -2495,7 +2478,6 @@ class TestConsolidatedMetadataStore:
         return ".zmetadata"
 
     def test_bad_format(self):
-
         # setup store with consolidated metadata
         store = dict()
         consolidated = {
@@ -2513,7 +2495,6 @@ class TestConsolidatedMetadataStore:
             self.ConsolidatedMetadataClass(KVStoreV3(dict()))
 
     def test_read_write(self):
-
         # setup store with consolidated metadata
         store = dict()
         consolidated = {
@@ -2584,7 +2565,6 @@ def test_normalize_store_arg(tmpdir):
 
 
 def test_meta_prefix_6853():
-
     fixture = pathlib.Path(zarr.__file__).resolve().parent.parent / "fixture"
     meta = fixture / "meta"
     if not meta.exists():  # pragma: no cover

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -183,7 +183,6 @@ def test_validate_key():
 
 
 class StoreV3Tests(_StoreTests):
-
     version = 3
     root = meta_root
 
@@ -219,7 +218,6 @@ class StoreV3Tests(_StoreTests):
         store.close()
 
     def test_init_array(self, dimension_separator_fixture_v3):
-
         pass_dim_sep, want_dim_sep = dimension_separator_fixture_v3
 
         store = self.create_store()
@@ -253,7 +251,6 @@ class StoreV3Tests(_StoreTests):
         store.close()
 
     def test_list_prefix(self):
-
         store = self.create_store()
         path = "arr1"
         init_array(store, path=path, shape=1000, chunks=100)
@@ -372,7 +369,6 @@ class TestDirectoryStoreV3(_TestDirectoryStore, StoreV3Tests):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStoreV3(_TestFSStore, StoreV3Tests):
     def create_store(self, normalize_keys=False, dimension_separator=".", path=None, **kwargs):
-
         if path is None:
             path = tempfile.mkdtemp()
             atexit.register(atexit_rmtree, path)
@@ -400,7 +396,6 @@ class TestFSStoreV3(_TestFSStore, StoreV3Tests):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStoreV3WithKeySeparator(StoreV3Tests):
     def create_store(self, normalize_keys=False, key_separator=".", **kwargs):
-
         # Since the user is passing key_separator, that will take priority.
         skip_if_nested_chunks(**kwargs)
 
@@ -415,7 +410,6 @@ class TestFSStoreV3WithKeySeparator(StoreV3Tests):
 
 
 class TestZipStoreV3(_TestZipStore, StoreV3Tests):
-
     ZipStoreClass = ZipStoreV3
 
     def create_store(self, **kwargs):
@@ -567,19 +561,16 @@ class TestStorageTransformerV3(TestMappingStoreV3):
 
 
 class TestLRUStoreCacheV3(_TestLRUStoreCache, StoreV3Tests):
-
     CountingClass = CountingDictV3
     LRUStoreClass = LRUStoreCacheV3
 
 
 @skip_test_env_var("ZARR_TEST_ABS")
 class TestABSStoreV3(_TestABSStore, StoreV3Tests):
-
     ABSStoreClass = ABSStoreV3
 
 
 def test_normalize_store_arg_v3(tmpdir):
-
     fn = tmpdir.join("store.zip")
     store = normalize_store_arg(str(fn), zarr_version=3, mode="w")
     assert isinstance(store, ZipStoreV3)
@@ -622,7 +613,6 @@ def test_normalize_store_arg_v3(tmpdir):
 
 
 class TestConsolidatedMetadataStoreV3(_TestConsolidatedMetadataStore):
-
     version = 3
     ConsolidatedMetadataClass = ConsolidatedMetadataStoreV3
 

--- a/zarr/tests/test_sync.py
+++ b/zarr/tests/test_sync.py
@@ -223,7 +223,6 @@ def _require_group(arg):
 
 class MixinGroupSyncTests:
     def test_parallel_create_group(self):
-
         # setup
         g = self.create_group()
         pool = self.create_pool()
@@ -242,7 +241,6 @@ class MixinGroupSyncTests:
         pool.terminate()
 
     def test_parallel_require_group(self):
-
         # setup
         g = self.create_group()
         pool = self.create_pool()

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -72,7 +72,6 @@ def test_normalize_chunks():
 
 
 def test_is_total_slice():
-
     # 1D
     assert is_total_slice(Ellipsis, (100,))
     assert is_total_slice(slice(None), (100,))
@@ -95,7 +94,6 @@ def test_is_total_slice():
 
 
 def test_normalize_resize_args():
-
     # 1D
     assert (200,) == normalize_resize_args((100,), 200)
     assert (200,) == normalize_resize_args((100,), (200,))

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -180,7 +180,6 @@ def normalize_chunks(chunks: Any, shape: Tuple[int, ...], typesize: int) -> Tupl
 
 
 def normalize_dtype(dtype: Union[str, np.dtype], object_codec) -> Tuple[np.dtype, Any]:
-
     # convenience API for object arrays
     if inspect.isclass(dtype):
         dtype = dtype.__name__  # type: ignore
@@ -245,7 +244,6 @@ def is_total_slice(item, shape: Tuple[int]) -> bool:
 
 
 def normalize_resize_args(old_shape, *args):
-
     # normalize new shape argument
     if len(args) == 1:
         new_shape = args[0]
@@ -294,7 +292,6 @@ def normalize_dimension_separator(sep: Optional[str]) -> Optional[str]:
 
 
 def normalize_fill_value(fill_value, dtype: np.dtype):
-
     if fill_value is None or dtype.hasobject:
         # no fill value
         pass
@@ -332,7 +329,6 @@ def normalize_fill_value(fill_value, dtype: np.dtype):
 
 
 def normalize_storage_path(path: Union[str, bytes, None]) -> str:
-
     # handle bytes
     if isinstance(path, bytes):
         path = str(path, "ascii")
@@ -342,7 +338,6 @@ def normalize_storage_path(path: Union[str, bytes, None]) -> str:
         path = str(path)
 
     if path:
-
         # convert backslash to forward slash
         path = path.replace("\\", "/")
 
@@ -506,7 +501,6 @@ def tree_widget(group, expand, level):
 
 class TreeViewer:
     def __init__(self, group, expand=False, level=None):
-
         self.group = group
         self.expand = expand
         self.level = level


### PR DESCRIPTION
Pulled out of https://github.com/zarr-developers/zarr-python/pull/1448, and I added the fixes that the new version of `black` makes. Hopefully this makes for slightly easier review than doing all the pre-commit version bumps in one go.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
