### PR TITLE
DOC: Enable offline formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,5 @@ python:
       path: .
       extra_requirements:
         - docs
+
+formats: all

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Zarr-Python
 
 **Version**: |version|
 
-**Download documentation**: `Zipped HTML <https://zarr.readthedocs.io/_/downloads/en/stable/htmlzip/>`_
+**Download documentation**: `PDF/Zipped HTML/EPUB <https://readthedocs.org/projects/zarr/downloads/>`_
 
 **Useful links**:
 `Installation <installation.html>`_ |


### PR DESCRIPTION
Fixed #1551.

xref: https://docs.readthedocs.io/en/stable/config-file/v2.html#formats

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
