### PR TITLE
Update release.rst

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,14 +21,30 @@ Unreleased
 Docs
 ~~~~
 
+* Minor correction and changes in documentation.
+  By :user:`Sanket Verma <MSanKeys963>` :issue:`1509`.
+
+* Fix typo in documentation.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1554`
+
 * The documentation build now fails if there are any warnings.
   By :user:`David Stansby <dstansby>` :issue:`1548`.
 
 * Add links to ``numcodecs`` docs in the tutorial.
   By :user:`David Stansby <dstansby>` :issue:`1535`.
 
+* Enable offline formats for documentation builds.
+  By :user:`Sanket Verma <MSanKeys963>` :issue:`1551`.
+
+* Minor tweak to advanced indexing tutorial examples.
+  By :user:`Ross Barnowski <rossbar>` :issue:`1550`.
+
+
 Maintenance
 ~~~~~~~~~~~
+
+* Extend copyright notice to 2023.
+  By :user:`Jack Kelly <JackKelly>` :issue:`1528`.
 
 * Change occurrence of ``io.open()`` into ``open()``.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1421`.
@@ -42,6 +58,8 @@ Maintenance
 * Allow ``black`` code formatter to be run with any Python version.
   By :user:`David Stansby <dstansby>` :issue:`1549`.
 
+* Remove ``sphinx-rtd-theme`` dependency from ``pyproject.toml``.
+  By :user:`Sanket Verma <MSanKeys963>` :issue:`1563`.
 
 
 .. _release_2.16.1:


### PR DESCRIPTION
Hi all. 👋🏻 

This PR updates the [release.rst](https://github.com/zarr-developers/zarr-python/blob/main/docs/release.rst) to the latest version. 

Please note that I have not updated it under a new release, i.e. **2.16.2**. If we plan to go with **2.16.2** with current updates, I'm happy to modify the `release.rst` accordingly.

Please review. Thanks!

TODO:
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
