### PR TITLE
Cache result of FSStore._fsspec_installed()

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -43,6 +43,9 @@ Docs
 Maintenance
 ~~~~~~~~~~~
 
+* Cache result of ``FSStore._fsspec_installed()``.
+  By :user:`Janick Martinez Esturo <ph03>` :issue:`1581`.
+
 * Extend copyright notice to 2023.
   By :user:`Jack Kelly <JackKelly>` :issue:`1528`.
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -28,6 +28,7 @@ import warnings
 import zipfile
 from collections import OrderedDict
 from collections.abc import MutableMapping
+from functools import lru_cache
 from os import scandir
 from pickle import PicklingError
 from threading import Lock, RLock
@@ -1540,6 +1541,7 @@ class FSStore(Store):
         self.map.clear()
 
     @classmethod
+    @lru_cache(maxsize=None)
     def _fsspec_installed(cls):
         """Returns true if fsspec is installed"""
         import importlib.util


### PR DESCRIPTION
`FSStore._fsspec_installed()` is run in a lot of hierarchy operations, and has a significant runtime overhead for each invocation. Given the result will not change between invocations, cache the very first invocation for subsequent runs.

Example profiling of effects without (`main`) behaviour (6sec total runtime)

![image](https://github.com/zarr-developers/zarr-python/assets/390527/09396479-e6c6-49c0-93f5-d9c49d71af9b)

and with caching the invocation (2sec total runtime)

![image](https://github.com/zarr-developers/zarr-python/assets/390527/1a3656e3-4bbd-407f-8b23-34c8eb33638a)

Most of the runtime is spent in the repeated lookup of `FSStore._fsspec_installed()`
![image](https://github.com/zarr-developers/zarr-python/assets/390527/819f4160-c93b-4cf4-832c-82c94e8f0161)


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
