### PR TITLE
Don't import from tests

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,8 @@ Release notes
 Unreleased (v3)
 ---------------
 
+Maintenance
+~~~~~~~~~~~
 
 * Remedy a situation where ``zarr-python`` was importing ``DummyStorageTransformer`` from the test suite. 
   The dependency relationship is now reversed: the test suite imports this class from ``zarr-python``.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,10 +13,20 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
+.. _unreleased(v3):
+
+Unreleased (v3)
+---------------
+
+
+* Remedy a situation where ``zarr-python`` was importing ``DummyStorageTransformer`` from the test suite. 
+  The dependency relationship is now reversed: the test suite imports this class from ``zarr-python``.
+  By :user:`Davis Bennett <d-v-b>` :issue:`1601`.
+
 .. _unreleased:
 
-Unreleased
-----------
+Unreleased (v2)
+---------------
 
 Docs
 ~~~~
@@ -60,10 +70,6 @@ Maintenance
 
 * Remove ``sphinx-rtd-theme`` dependency from ``pyproject.toml``.
   By :user:`Sanket Verma <MSanKeys963>` :issue:`1563`.
-
-* Remedy a situation where ``zarr-python`` was importing ``DummyStorageTransformer`` from the test suite. 
-  The dependency relationship is now reversed: the test suite imports this class from ``zarr-python``.
-  By :user:`Davis Bennett <d-v-b>` :issue:`1601`.
 
 .. _release_2.16.1:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -61,6 +61,9 @@ Maintenance
 * Remove ``sphinx-rtd-theme`` dependency from ``pyproject.toml``.
   By :user:`Sanket Verma <MSanKeys963>` :issue:`1563`.
 
+* Remedy a situation where ``zarr-python`` was importing ``DummyStorageTransformer`` from the test suite. 
+  The dependency relationship is now reversed: the test suite imports this class from ``zarr-python``.
+  By :user:`Davis Bennett <d-v-b>` :issue:`1601`.
 
 .. _release_2.16.1:
 

--- a/zarr/_storage/v3_storage_transformers.py
+++ b/zarr/_storage/v3_storage_transformers.py
@@ -81,6 +81,22 @@ class _ShardIndex(NamedTuple):
         )
 
 
+class DummyStorageTransfomer(StorageTransformer):
+    """For testing purposes. This class was previously defined in the test suite and imported
+    into Zarr, but now it has been moved here and the test suite will import it like any other part
+    of the Zarr library."""
+
+    TEST_CONSTANT = "test1234"
+
+    extension_uri = "https://purl.org/zarr/spec/storage_transformers/dummy/1.0"
+    valid_types = ["dummy_type"]
+
+    def __init__(self, _type, test_value) -> None:
+        super().__init__(_type)
+        assert test_value == self.TEST_CONSTANT
+        self.test_value = test_value
+
+
 class ShardingStorageTransformer(StorageTransformer):  # lgtm[py/missing-equals]
     """Implements sharding as a storage transformer, as described in the spec:
     https://zarr-specs.readthedocs.io/en/latest/extensions/storage-transformers/sharding/v1.0.html

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -459,8 +459,10 @@ class Metadata3(Metadata2):
 
     @classmethod
     def _decode_storage_transformer_metadata(cls, meta: Mapping) -> "StorageTransformer":
-        from zarr.tests.test_storage_v3 import DummyStorageTransfomer
-        from zarr._storage.v3_storage_transformers import ShardingStorageTransformer
+        from zarr._storage.v3_storage_transformers import (
+            ShardingStorageTransformer,
+            DummyStorageTransfomer,
+        )
 
         # This might be changed to a proper registry in the future
         KNOWN_STORAGE_TRANSFORMERS = [DummyStorageTransfomer, ShardingStorageTransformer]

--- a/zarr/tests/test_attrs.py
+++ b/zarr/tests/test_attrs.py
@@ -8,7 +8,7 @@ from zarr._storage.store import meta_root
 from zarr.attrs import Attributes
 from zarr.storage import KVStore, DirectoryStore
 from zarr._storage.v3 import KVStoreV3
-from zarr.tests.util import CountingDict, CountingDictV3
+from .util import CountingDict, CountingDictV3
 from zarr.hierarchy import group
 
 

--- a/zarr/tests/test_convenience.py
+++ b/zarr/tests/test_convenience.py
@@ -43,7 +43,7 @@ from zarr._storage.v3 import (
     MemoryStoreV3,
     SQLiteStoreV3,
 )
-from zarr.tests.util import have_fsspec
+from .util import have_fsspec
 
 _VERSIONS = (2, 3) if v3_api_available else (2,)
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -35,7 +35,11 @@ from zarr._storage.store import (
     BaseStore,
     v3_api_available,
 )
-from .._storage.v3_storage_transformers import ShardingStorageTransformer, v3_sharding_available
+from .._storage.v3_storage_transformers import (
+    DummyStorageTransfomer,
+    ShardingStorageTransformer,
+    v3_sharding_available,
+)
 from zarr.core import Array
 from zarr.errors import ArrayNotFoundError, ContainsGroupError
 from zarr.meta import json_loads
@@ -70,7 +74,7 @@ from zarr._storage.v3 import (
     SQLiteStoreV3,
     StoreV3,
 )
-from zarr.tests.test_storage_v3 import DummyStorageTransfomer
+
 from zarr.util import buffer_size
 from zarr.tests.util import abs_container, skip_test_env_var, have_fsspec, mktemp
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -76,7 +76,7 @@ from zarr._storage.v3 import (
 )
 
 from zarr.util import buffer_size
-from zarr.tests.util import abs_container, skip_test_env_var, have_fsspec, mktemp
+from .util import abs_container, skip_test_env_var, have_fsspec, mktemp
 
 # noinspection PyMethodMayBeStatic
 

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from zarr._storage.store import DEFAULT_ZARR_VERSION
+from zarr._storage.v3_storage_transformers import DummyStorageTransfomer
 from zarr.codecs import Zlib
 from zarr.core import Array
 from zarr.creation import (
@@ -30,7 +31,6 @@ from zarr.storage import DirectoryStore, KVStore
 from zarr._storage.store import v3_api_available
 from zarr._storage.v3 import DirectoryStoreV3, KVStoreV3
 from zarr.sync import ThreadSynchronizer
-from zarr.tests.test_storage_v3 import DummyStorageTransfomer
 from zarr.tests.util import mktemp, have_fsspec
 
 

--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -31,7 +31,7 @@ from zarr.storage import DirectoryStore, KVStore
 from zarr._storage.store import v3_api_available
 from zarr._storage.v3 import DirectoryStoreV3, KVStoreV3
 from zarr.sync import ThreadSynchronizer
-from zarr.tests.util import mktemp, have_fsspec
+from .util import mktemp, have_fsspec
 
 
 _VERSIONS = (None, 2, 3) if v3_api_available else (None, 2)

--- a/zarr/tests/test_dim_separator.py
+++ b/zarr/tests/test_dim_separator.py
@@ -7,7 +7,7 @@ from functools import partial
 import zarr
 from zarr.core import Array
 from zarr.storage import DirectoryStore, NestedDirectoryStore, FSStore
-from zarr.tests.util import have_fsspec
+from .util import have_fsspec
 
 
 needs_fsspec = pytest.mark.skipif(not have_fsspec, reason="needs fsspec")

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -57,7 +57,7 @@ from zarr._storage.v3 import (
     LRUStoreCacheV3,
 )
 from zarr.util import InfoReporter, buffer_size
-from zarr.tests.util import skip_test_env_var, have_fsspec, abs_container, mktemp
+from .util import skip_test_env_var, have_fsspec, abs_container, mktemp
 
 
 _VERSIONS = (2, 3) if v3_api_available else (2,)

--- a/zarr/tests/test_indexing.py
+++ b/zarr/tests/test_indexing.py
@@ -13,7 +13,7 @@ from zarr.indexing import (
     PartialChunkIterator,
 )
 
-from zarr.tests.util import CountingDict
+from .util import CountingDict
 
 
 def test_normalize_integer_selection():

--- a/zarr/tests/test_n5.py
+++ b/zarr/tests/test_n5.py
@@ -9,7 +9,7 @@ from typing import Tuple
 import json
 import atexit
 
-from zarr.tests.util import have_fsspec
+from .util import have_fsspec
 
 
 def test_make_n5_chunk_wrapper():

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -59,7 +59,7 @@ from zarr.storage import (
 )
 from zarr.storage import FSStore, rename, listdir
 from zarr._storage.v3 import KVStoreV3
-from zarr.tests.util import CountingDict, have_fsspec, skip_test_env_var, abs_container, mktemp
+from .util import CountingDict, have_fsspec, skip_test_env_var, abs_container, mktemp
 from zarr.util import ConstantMap, json_dumps
 
 

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -44,7 +44,7 @@ from zarr._storage.v3 import (
     StoreV3,
     ZipStoreV3,
 )
-from zarr.tests.util import CountingDictV3, have_fsspec, skip_test_env_var, mktemp
+from .util import CountingDictV3, have_fsspec, skip_test_env_var, mktemp
 
 # pytest will fail to run if the following fixtures aren't imported here
 from .test_storage import StoreTests as _StoreTests

--- a/zarr/tests/test_storage_v3.py
+++ b/zarr/tests/test_storage_v3.py
@@ -10,7 +10,11 @@ import pytest
 
 import zarr
 from zarr._storage.store import _get_hierarchy_metadata, v3_api_available, StorageTransformer
-from zarr._storage.v3_storage_transformers import ShardingStorageTransformer, v3_sharding_available
+from zarr._storage.v3_storage_transformers import (
+    DummyStorageTransfomer,
+    ShardingStorageTransformer,
+    v3_sharding_available,
+)
 from zarr.core import Array
 from zarr.meta import _default_entry_point_metadata_v3
 from zarr.storage import (
@@ -106,18 +110,6 @@ class InvalidDummyStore:
 
     def keys(self):
         """keys"""
-
-
-class DummyStorageTransfomer(StorageTransformer):
-    TEST_CONSTANT = "test1234"
-
-    extension_uri = "https://purl.org/zarr/spec/storage_transformers/dummy/1.0"
-    valid_types = ["dummy_type"]
-
-    def __init__(self, _type, test_value) -> None:
-        super().__init__(_type)
-        assert test_value == self.TEST_CONSTANT
-        self.test_value = test_value
 
 
 def test_ensure_store_v3():

--- a/zarr/tests/test_sync.py
+++ b/zarr/tests/test_sync.py
@@ -16,9 +16,9 @@ from zarr.storage import DirectoryStore, KVStore, atexit_rmtree, init_array, ini
 from zarr.sync import ProcessSynchronizer, ThreadSynchronizer
 
 # zarr_version fixture must be imported although not used directly here
-from zarr.tests.test_attrs import TestAttributes, zarr_version  # noqa
-from zarr.tests.test_core import TestArray
-from zarr.tests.test_hierarchy import TestGroup
+from .test_attrs import TestAttributes, zarr_version  # noqa
+from .test_core import TestArray
+from .test_hierarchy import TestGroup
 
 
 class TestAttributesWithThreadSynchronizer(TestAttributes):


### PR DESCRIPTION
In `main`, `DummyStorageTransformer` is defined in the test suite and imported by `zarr/storage/v3_storage_transformers`. Because the distributed version of `zarr` should not be importing code from the tests, I moved the definition of `DummyStorageTransformer` to `zarr/storage/v3_storage_transformers`, and now the tests that use this class can import it like any other zarr code.

In the test suite, I also changed imports of the form `from zarr.test.module.. import bla` to `from .module import bla`. 

Both of these changes are necessary for moving to a `src/zarr` layout.

xref: #1592 