### PR TITLE
Make sure fs exceptions are raised if not MissingFs exceptions (clone)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -49,6 +49,9 @@ Docs
 Maintenance
 ~~~~~~~~~~~
 
+* FSStore now raises rather than return bad data.
+  By :user:`Martin Durant <martindurant>` and :user:`Ian Carroll <itcarroll>` :issue:`1604`.
+
 * Cache result of ``FSStore._fsspec_installed()``.
   By :user:`Janick Martinez Esturo <ph03>` :issue:`1581`.
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1415,13 +1415,14 @@ class FSStore(Store):
     ) -> Mapping[str, Any]:
         keys_transformed = [self._normalize_key(key) for key in keys]
         results = self.map.getitems(keys_transformed, on_error="return")
-        # The function calling this method may not recognize the transformed keys
-        # So we send the values returned by self.map.getitems back into the original key space.
+        # Only recognized errors will prompt KeyErrors in the function calling this method
         for k, v in results.copy().items():
             if isinstance(v, self.exceptions):
                 results.pop(k)
             elif isinstance(v, Exception):
                 raise v
+        # The function calling this method may not recognize the transformed keys, so we
+        # send the values returned by self.map.getitems back into the original key space.
         return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
 
     def __getitem__(self, key):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1414,9 +1414,14 @@ class FSStore(Store):
         self, keys: Sequence[str], *, contexts: Mapping[str, Context]
     ) -> Mapping[str, Any]:
         keys_transformed = [self._normalize_key(key) for key in keys]
-        results = self.map.getitems(keys_transformed, on_error="omit")
+        results = self.map.getitems(keys_transformed, on_error="return")
         # The function calling this method may not recognize the transformed keys
         # So we send the values returned by self.map.getitems back into the original key space.
+        for k, v in results.copy().items():
+            if isinstance(v, self.exceptions):
+                results.pop(k)
+            elif isinstance(v, Exception):
+                raise v
         return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
 
     def __getitem__(self, key):

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1413,17 +1413,23 @@ class FSStore(Store):
     def getitems(
         self, keys: Sequence[str], *, contexts: Mapping[str, Context]
     ) -> Mapping[str, Any]:
-        keys_transformed = [self._normalize_key(key) for key in keys]
-        results = self.map.getitems(keys_transformed, on_error="return")
-        # Only recognized errors will prompt KeyErrors in the function calling this method
-        for k, v in results.copy().items():
+        keys_transformed = {self._normalize_key(key): key for key in keys}
+        results_transformed = self.map.getitems(list(keys_transformed), on_error="return")
+        results = {}
+        for k, v in results_transformed.items():
             if isinstance(v, self.exceptions):
-                results.pop(k)
+                # Cause recognized exceptions to prompt a KeyError in the
+                # function calling this method
+                continue
             elif isinstance(v, Exception):
+                # Raise any other exception
                 raise v
-        # The function calling this method may not recognize the transformed keys, so we
-        # send the values returned by self.map.getitems back into the original key space.
-        return {keys[keys_transformed.index(rk)]: rv for rk, rv in results.items()}
+            else:
+                # The function calling this method may not recognize the transformed
+                # keys, so we send the values returned by self.map.getitems back into
+                # the original key space.
+                results[keys_transformed[k]] = v
+        return results
 
     def __getitem__(self, key):
         key = self._normalize_key(key)

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1339,8 +1339,9 @@ class TestFSStore(StoreTests):
 
     def test_exceptions(self):
         import fsspec
+
         m = fsspec.filesystem("memory")
-        g = zarr.open_group("memory://test/out.zarr", mode='w')
+        g = zarr.open_group("memory://test/out.zarr", mode="w")
         arr = g.create_dataset("data", data=[1, 2, 3, 4], dtype="i4", compression=None, chunks=[2])
         m.store["/test/out.zarr/data/0"] = None
         del m.store["/test/out.zarr/data/1"]
@@ -1351,6 +1352,8 @@ class TestFSStore(StoreTests):
         with pytest.raises(Exception):
             # None is bad data, as opposed to missing
             arr[:]
+        # clear the global memory filesystem's store for use in other tests
+        m.store.clear()
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1347,11 +1347,12 @@ class TestFSStore(StoreTests):
         del m.store["/test/out.zarr/data/1"]
         assert g.store.getitems(["data/1"]) == {}  # not found
         with pytest.raises(Exception):
-            # None is bad daa, as opposed to missing
+            # None is bad data, as opposed to missing
             g.store.getitems(["data/0", "data/1"])
         with pytest.raises(Exception):
-            # None is bad daa, as opposed to missing
+            # None is bad data, as opposed to missing
             arr[:]
+
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStoreWithKeySeparator(StoreTests):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1337,6 +1337,21 @@ class TestFSStore(StoreTests):
         )
         assert (a[:] == -np.ones((8, 8, 8))).all()
 
+    def test_exceptions(self):
+        import fsspec
+        m = fsspec.filesystem("memory")
+        g = zarr.open_group("memory://test/out.zarr", mode='w')
+        arr = g.create_dataset("data", data=[1, 2, 3, 4],
+                               dtype="i4", compression=None, chunks=[2])
+        m.store["/test/out.zarr/data/0"] = None
+        del m.store["/test/out.zarr/data/1"]
+        assert g.store.getitems(["data/1"]) == {}  # not found
+        with pytest.raises(Exception):
+            # None is bad daa, as opposed to missing
+            g.store.getitems(["data/0", "data/1"])
+        with pytest.raises(Exception):
+            # None is bad daa, as opposed to missing
+            arr[:]
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 class TestFSStoreWithKeySeparator(StoreTests):

--- a/zarr/tests/test_storage.py
+++ b/zarr/tests/test_storage.py
@@ -1341,14 +1341,13 @@ class TestFSStore(StoreTests):
         import fsspec
         m = fsspec.filesystem("memory")
         g = zarr.open_group("memory://test/out.zarr", mode='w')
-        arr = g.create_dataset("data", data=[1, 2, 3, 4],
-                               dtype="i4", compression=None, chunks=[2])
+        arr = g.create_dataset("data", data=[1, 2, 3, 4], dtype="i4", compression=None, chunks=[2])
         m.store["/test/out.zarr/data/0"] = None
         del m.store["/test/out.zarr/data/1"]
-        assert g.store.getitems(["data/1"]) == {}  # not found
+        assert g.store.getitems(["data/1"], contexts={}) == {}  # not found
         with pytest.raises(Exception):
             # None is bad data, as opposed to missing
-            g.store.getitems(["data/0", "data/1"])
+            g.store.getitems(["data/0", "data/1"], contexts={})
         with pytest.raises(Exception):
             # None is bad data, as opposed to missing
             arr[:]


### PR DESCRIPTION
**note**: This PR is a copy of PR #1237 which had become stale. Description from @martindurant is:

> (for v2 for now)
> 
> When FSStore gets exceptions, these correctly become the fill value when they are translated to KeyError. However, some exceptions do not equate to missing keys but to other permanent problems such as PermissionError. This change makes sure they are correctly raised to the caller even within getitems (getitem already was correct).

TODO:
* [x] Add unit tests and/or doctests in docstrings
* (NA) Add docstrings and API docs for any new/modified user-facing classes and functions
* (NA) New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
