### PR TITLE
Add typing to dimension separator arguments

### DIFF
--- a/zarr/_storage/absstore.py
+++ b/zarr/_storage/absstore.py
@@ -1,9 +1,12 @@
 """This module contains storage classes related to Azure Blob Storage (ABS)"""
 
+from typing import Optional
 import warnings
+
 from numcodecs.compat import ensure_bytes
 from zarr.util import normalize_storage_path
 from zarr._storage.store import _get_metadata_suffix, data_root, meta_root, Store, StoreV3
+from zarr.types import DIMENSION_SEPARATOR
 
 __doctest_requires__ = {
     ("ABSStore", "ABSStore.*"): ["azure.storage.blob"],
@@ -67,7 +70,7 @@ class ABSStore(Store):
         account_name=None,
         account_key=None,
         blob_service_kwargs=None,
-        dimension_separator=None,
+        dimension_separator: Optional[DIMENSION_SEPARATOR] = None,
         client=None,
     ):
         self._dimension_separator = dimension_separator

--- a/zarr/_storage/v3.py
+++ b/zarr/_storage/v3.py
@@ -3,13 +3,14 @@ import shutil
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from threading import Lock
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, Optional
 
 from zarr.errors import (
     MetadataError,
     ReadOnlyError,
 )
 from zarr.util import buffer_size, json_loads, normalize_storage_path
+from zarr.types import DIMENSION_SEPARATOR
 
 from zarr._storage.absstore import ABSStoreV3  # noqa: F401
 from zarr._storage.store import (  # noqa: F401
@@ -224,7 +225,9 @@ class FSStoreV3(FSStore, StoreV3):
 
 
 class MemoryStoreV3(MemoryStore, StoreV3):
-    def __init__(self, root=None, cls=dict, dimension_separator=None):
+    def __init__(
+        self, root=None, cls=dict, dimension_separator: Optional[DIMENSION_SEPARATOR] = None
+    ):
         if root is None:
             self.root = cls()
         else:

--- a/zarr/_storage/v3_storage_transformers.py
+++ b/zarr/_storage/v3_storage_transformers.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from zarr._storage.store import StorageTransformer, StoreV3, _rmdir_from_keys_v3
 from zarr.util import normalize_storage_path
+from zarr.types import DIMENSION_SEPARATOR
 
 
 MAX_UINT_64 = 2**64 - 1
@@ -118,7 +119,7 @@ class ShardingStorageTransformer(StorageTransformer):  # lgtm[py/missing-equals]
         return transformer_copy
 
     @property
-    def dimension_separator(self) -> str:
+    def dimension_separator(self) -> DIMENSION_SEPARATOR:
         assert (
             self._dimension_separator is not None
         ), "dimension_separator is not initialized, first get a copy via _copy_for_array."

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -470,7 +470,7 @@ def open_array(
     write_empty_chunks=True,
     *,
     zarr_version=None,
-    dimension_separator=None,
+    dimension_separator: Optional[DIMENSION_SEPARATOR] = None,
     meta_array=None,
     **kwargs,
 ):


### PR DESCRIPTION
Not very exciting, but carrys on the typing train. This PR adds typing to wherever a dimension separator argument is used in functions/methods.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
