### PR TITLE
Add Norman Rzepka to core-dev team

### DIFF
--- a/TEAM.md
+++ b/TEAM.md
@@ -6,6 +6,7 @@
 - @d-v-b (Davis Bennett)
 - @jakirkham (jakirkham)
 - @martindurant (Martin Durant)
+- @normanrz (Norman Rzepka)
 
 ## Emeritus core-developers
 - @alimanfoo (Alistair Miles)


### PR DESCRIPTION
Welcoming @normanrz to the core-dev team!
