### PR TITLE
[V3] Update minimum supported Python and Numpy versions 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ readme = { file = "README.md", content-type = "text/markdown" }
 maintainers = [
     { name = "Alistair Miles", email = "alimanfoo@googlemail.com" }
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     'asciitree',
-    'numpy>=1.20,!=1.21.0',
+    'numpy>=1.24',
     'fasteners',
     'numcodecs>=0.10.0',
 ]
@@ -30,10 +30,9 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Operating System :: Unix',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 license = { text = "MIT" }
 

--- a/requirements_dev_numpy.txt
+++ b/requirements_dev_numpy.txt
@@ -1,4 +1,4 @@
 # Break this out into a separate file to allow testing against
 # different versions of numpy. This file should pin to the latest
 # numpy version.
-numpy==1.24.3
+numpy==1.26.3


### PR DESCRIPTION
This PR bumps the minimum supported Python and Numpy versions for the V3 branch. These are aligned with Spec0000 (see #1616) assuming we are planning to release in late Q1 or Q2 of 2024. 

Knowing that we are developing against Python 3.10+ will help smooth over some syntax pain, especially when working on [the goal of 100% type hint coverage](https://github.com/zarr-developers/zarr-python/blob/main/v3-roadmap-and-design.md#python-type-hints-and-static-analysis).

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
