### PR TITLE
fix sync group class methods

### DIFF
--- a/src/zarr/v3/codecs/bytes.py
+++ b/src/zarr/v3/codecs/bytes.py
@@ -27,7 +27,7 @@ class BytesCodecConfigurationMetadata:
 @frozen
 class BytesCodecMetadata:
     configuration: BytesCodecConfigurationMetadata
-    name: Literal["bytes"] = field(default="bytes", init=False)
+    name: Literal["bytes"] = field(default="bytes", init=True)
 
 
 @frozen

--- a/src/zarr/v3/group.py
+++ b/src/zarr/v3/group.py
@@ -12,7 +12,7 @@ from zarr.v3.attributes import Attributes
 from zarr.v3.common import ZARR_JSON, ZARRAY_JSON, ZATTRS_JSON, ZGROUP_JSON, make_cattr
 from zarr.v3.config import RuntimeConfiguration, SyncConfiguration
 from zarr.v3.store import StoreLike, StorePath, make_store_path
-from zarr.v3.sync import SyncMixin
+from zarr.v3.sync import SyncMixin, sync
 
 logger = logging.getLogger("zarr.group")
 
@@ -20,8 +20,8 @@ logger = logging.getLogger("zarr.group")
 @frozen
 class GroupMetadata:
     attributes: Dict[str, Any] = field(factory=dict)
-    zarr_format: Literal[2, 3] = 3  # field(default=3, validator=validators.in_([2, 3]))
-    node_type: Literal["group"] = field(default="group", init=False)
+    zarr_format: Literal[2, 3] = 3
+    node_type: Literal["group"] = field(default="group", init=True)
 
     def to_bytes(self) -> Dict[str, bytes]:
         if self.zarr_format == 3:
@@ -52,7 +52,7 @@ class AsyncGroup:
         *,
         attributes: Optional[Dict[str, Any]] = None,
         exists_ok: bool = False,
-        zarr_format: Literal[2, 3] = 3,  # field(default=3, validator=validators.in_([2, 3])),
+        zarr_format: Literal[2, 3] = 3,
         runtime_configuration: RuntimeConfiguration = RuntimeConfiguration(),
     ) -> AsyncGroup:
         store_path = make_store_path(store)
@@ -305,13 +305,14 @@ class Group(SyncMixin):
         exists_ok: bool = False,
         runtime_configuration: RuntimeConfiguration = RuntimeConfiguration(),
     ) -> Group:
-        obj = cls._sync(
+        obj = sync(
             AsyncGroup.create(
                 store,
                 attributes=attributes,
                 exists_ok=exists_ok,
                 runtime_configuration=runtime_configuration,
-            )
+            ),
+            loop=runtime_configuration.asyncio_loop,
         )
 
         return cls(obj)
@@ -322,7 +323,9 @@ class Group(SyncMixin):
         store: StoreLike,
         runtime_configuration: RuntimeConfiguration = RuntimeConfiguration(),
     ) -> Group:
-        obj = cls._sync(AsyncGroup.open(store, runtime_configuration))
+        obj = sync(
+            AsyncGroup.open(store, runtime_configuration), loop=runtime_configuration.asyncio_loop
+        )
         return cls(obj)
 
     def __getitem__(self, path: str) -> Union[Array, Group]:

--- a/tests/test_group_v3.py
+++ b/tests/test_group_v3.py
@@ -54,3 +54,14 @@ def test_group(store_path) -> None:
     # and the attrs were modified in the store
     bar3 = foo["bar"]
     assert dict(bar3.attrs) == {"baz": "qux", "name": "bar"}
+
+
+def test_group_sync_constructor(store_path) -> None:
+
+    group = Group.create(
+        store=store_path,
+        attributes={"title": "test 123"},
+        runtime_configuration=RuntimeConfiguration(),
+    )
+
+    assert group._async_group.metadata.attributes["title"] == "test 123"


### PR DESCRIPTION
Small follow up to #1634. This fixes the `Group`'s class methods and adds a test. 

I also have been experiencing some pain with attrs with `init=False`. You'll see I disabled a few instances related to this pain. Likely not a big deal since @d-v-b is close to removing attrs. 