### PR TITLE
Add test matrix for V3

### DIFF
--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -30,3 +30,6 @@ jobs:
     - name: Run Tests
       run: |
         hatch run test:run
+    - name: Run mypy
+      run: |
+        hatch run test:run-mypy

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -31,5 +31,6 @@ jobs:
       run: |
         hatch run test:run
     - name: Run mypy
+      continue-on-error: true
       run: |
         hatch run test:run-mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,26 +99,13 @@ features = ["extra"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11"]
-numpy = ["1.24"]
-version = ["minimal-legacy"]
+numpy = ["1.24", "1.26"]
+version = ["minimal"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11"]
-numpy = ["1.26"]
+numpy = ["1.24", "1.26"]
 features = ["optional"]
-version = ["minimal-latest"]
-
-[[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
-numpy = ["1.24"]
-features = ["optional"]
-version = ["legacy"]
-
-[[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
-numpy = ["1.26"]
-features = ["optional"]
-version = ["latest"]
 
 [tool.hatch.envs.test.scripts]
 run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,16 @@ docs = [
     'numpydoc',
     'numcodecs[msgpack]',
 ]
+extra = [
+    'attrs',
+    'cattrs',
+    'msgpack',
+    'crc32c',
+    'zstandard'
+]
+optional = [
+    'lmdb',
+]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/zarr-developers/zarr-python/issues"
@@ -79,17 +89,35 @@ build.hooks.vcs.version-file = "src/zarr/_version.py"
 
 [tool.hatch.envs.test]
 extra-dependencies = [
-    "attrs",
-    "cattrs",
     "coverage",
     "pytest",
     "pytest-cov",
-    "msgpack",
-    "lmdb",
-    "zstandard",
-    "crc32c",
     "pytest-asyncio"
 ]
+features = ["extra"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11"]
+numpy = ["1.24"]
+version = ["minimal-legacy"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11"]
+numpy = ["1.26"]
+features = ["optional"]
+version = ["minimal-latest"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11"]
+numpy = ["1.24"]
+features = ["optional"]
+version = ["legacy"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11"]
+numpy = ["1.26"]
+features = ["optional"]
+version = ["latest"]
 
 [tool.hatch.envs.test.scripts]
 run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ extra-dependencies = [
     "coverage",
     "pytest",
     "pytest-cov",
-    "pytest-asyncio"
+    "pytest-asyncio",
+    "mypy",
 ]
 features = ["extra"]
 
@@ -123,6 +124,7 @@ version = ["latest"]
 run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
 run = "run-coverage --no-cov"
 run-verbose = "run-coverage --verbose"
+run-mypy = "mypy src"
 
 [tool.hatch.envs.docs]
 features = ['docs']


### PR DESCRIPTION
Part of #1648 

The `extras` are packages that should be optional (with import skipping), which could be addressed separately.

The current setup includes 8 combinations (below), would appreciate feedback on this.

```
$ hatch env show --ascii
                Standalone                
+---------+---------+----------+---------+
| Name    | Type    | Features | Scripts |
+=========+=========+==========+=========+
| default | virtual |          |         |
+---------+---------+----------+---------+
| docs    | virtual | docs     | build   |
|         |         |          | rtd     |
|         |         |          | serve   |
+---------+---------+----------+---------+
                                        Matrices                                         
+------+---------+---------------------------+----------+----------------+--------------+
| Name | Type    | Envs                      | Features | Dependencies   | Scripts      |
+======+=========+===========================+==========+================+==============+
| test | virtual | test.py3.10-1.24-minimal  | extra    | coverage       | run          |
|      |         | test.py3.10-1.26-minimal  |          | mypy           | run-coverage |
|      |         | test.py3.11-1.24-minimal  |          | pytest         | run-mypy     |
|      |         | test.py3.11-1.26-minimal  |          | pytest-asyncio | run-verbose  |
|      |         | test.py3.10-1.24-optional |          | pytest-cov     |              |
|      |         | test.py3.10-1.26-optional |          |                |              |
|      |         | test.py3.11-1.24-optional |          |                |              |
|      |         | test.py3.11-1.26-optional |          |                |              |
+------+---------+---------------------------+----------+----------------+--------------+
```
