### PR TITLE
Prototype of `object-store`-based Store implementation

### DIFF
--- a/src/zarr/v3/store/object_store.py
+++ b/src/zarr/v3/store/object_store.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional, Tuple
+
+from object_store import ObjectStore as _ObjectStore
+from object_store import Path as ObjectPath
+
+from zarr.v3.abc.store import Store
+
+
+class ObjectStore(Store):
+    supports_writes: bool = True
+    supports_partial_writes: bool = False
+    supports_listing: bool = True
+
+    store: _ObjectStore
+
+    def init(self, store: _ObjectStore):
+        self.store = store
+
+    def __str__(self) -> str:
+        return f"object://{self.store}"
+
+    def __repr__(self) -> str:
+        return f"ObjectStore({repr(str(self))})"
+
+    async def get(
+        self, key: str, byte_range: Optional[Tuple[int, Optional[int]]] = None
+    ) -> Optional[bytes]:
+        if byte_range is None:
+            return await self.store.get_async(ObjectPath(key))
+
+        start, end = byte_range
+        if end is None:
+            # Have to wrap a separate object-store function to support this
+            raise NotImplementedError
+
+        return await self.store.get_range_async(ObjectPath(key), start, end - start)
+
+    async def get_partial_values(
+        self, key_ranges: List[Tuple[str, Tuple[int, int]]]
+    ) -> List[bytes]:
+        # TODO: use rust-based concurrency inside object-store
+        futs = [self.get(key, byte_range=byte_range) for (key, byte_range) in key_ranges]
+
+        # Seems like a weird type match where `get()` returns `Optional[bytes]` but
+        # `get_partial_values` is non-optional?
+        return await asyncio.gather(*futs)  # type: ignore
+
+    async def exists(self, key: str) -> bool:
+        try:
+            _ = await self.store.head_async(ObjectPath(key))
+            return True
+        except FileNotFoundError:
+            return False
+
+    async def set(self, key: str, value: bytes) -> None:
+        await self.store.put_async(ObjectPath(key), value)
+
+    async def delete(self, key: str) -> None:
+        await self.store.delete_async(ObjectPath(key))
+
+    async def set_partial_values(self, key_start_values: List[Tuple[str, int, bytes]]) -> None:
+        raise NotImplementedError
+
+    async def list(self) -> List[str]:
+        objects = await self.store.list_async(None)
+        return [str(obj.location) for obj in objects]
+
+    async def list_prefix(self, prefix: str) -> List[str]:
+        objects = await self.store.list_async(ObjectPath(prefix))
+        return [str(obj.location) for obj in objects]
+
+    async def list_dir(self, prefix: str) -> List[str]:
+        list_result = await self.store.list_with_delimiter_async(ObjectPath(prefix))
+        common_prefixes = set(list_result.common_prefixes)
+        return [str(obj.location) for obj in list_result.objects if obj not in common_prefixes]


### PR DESCRIPTION
Prototype of [object-store](https://github.com/roeap/object-store-python) based store. 

[object-store](https://docs.rs/object_store/latest/object_store/) is a rust crate for interoperating with remote object stores like S3, GCS, Azure, etc. See the [highlights](https://docs.rs/object_store/latest/object_store/#highlights) section of its docs. It [doesn't even try to implement](https://docs.rs/object_store/latest/object_store/#why-not-a-filesystem-interface) a filesystem interface, instead focusing on the core atomic operations supported across object stores. This makes it a good candidate for use with a Zarr v3 Store.

[object-store-python](https://github.com/roeap/object-store-python) is a Python binding to object-store. With https://github.com/roeap/object-store-python/pull/6, I added async methods to the library. So the underlying Rust binary will return a Python coroutine that can be awaited.

That and related PRs haven't been merged yet, but you can try this out locally by installing
```
pip install git+https://github.com/kylebarron/object-store-python.git@dev#subdirectory=object-store
```
note that you need the Rust compiler on your computer. Install that by following [these docs](https://www.rust-lang.org/tools/install).

TODO:

* [ ] Implement multiple-range support in the underlying object-store-python library
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
