### PR TITLE
Pyodide support: don't require fasteners on emscripten

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.9"
 dependencies = [
     'asciitree',
     'numpy>=1.21.1',
-    'fasteners',
+    'fasteners; sys_platform != "emscripten"',
     'numcodecs>=0.10.0',
 ]
 dynamic = [

--- a/zarr/sync.py
+++ b/zarr/sync.py
@@ -3,8 +3,6 @@ from collections import defaultdict
 from threading import Lock
 from typing import Protocol
 
-import fasteners
-
 
 class Synchronizer(Protocol):
     """Base class for synchronizers."""
@@ -49,6 +47,8 @@ class ProcessSynchronizer(Synchronizer):
         self.path = path
 
     def __getitem__(self, item):
+        import fasteners
+
         path = os.path.join(self.path, item)
         lock = fasteners.InterProcessLock(path)
         return lock


### PR DESCRIPTION
This patch makes fasteners dependencies conditional on not-emscripten and moves
the fasteners import from top level into the function where it is used. It is the one patch
needed for zarr to work in Pyodide/