### PR TITLE
Update release.rst for v2.17.1

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2023 Zarr Developers <https://github.com/zarr-developers>
+Copyright (c) 2015-2024 Zarr Developers <https://github.com/zarr-developers>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ main_doc = "index"
 
 # General information about the project.
 project = "zarr"
-copyright = "2023, Zarr Developers"
+copyright = "2024, Zarr Developers"
 author = "Zarr Developers"
 
 version = zarr.__version__

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,8 +18,25 @@ Release notes
 Unreleased
 ----------
 
+.. _release_2.17.1:
+
+2.17.1
+------
+
+Enhancements
+~~~~~~~~~~~~
+
 * Change occurrences of % and format() to f-strings.
   By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1423`.
+
+* Proper argument for numpy.reshape.
+  By :user:`Dimitri Papadopoulos Orfanos <DmitriPapadopoulos>` :issue:`1425`.
+
+Docs
+~~~~
+
+* ZIP related tweaks.
+  By :user:`Davis Bennett <d-v-b>` :issue:`1641`.
 
 .. _release_2.17.0:
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,11 +32,26 @@ Enhancements
 * Proper argument for numpy.reshape.
   By :user:`Dimitri Papadopoulos Orfanos <DmitriPapadopoulos>` :issue:`1425`.
 
+* Add typing to dimension separator arguments.
+  By :user:`David Stansby <dstansby>` :issue:`1620`.
+
 Docs
 ~~~~
 
 * ZIP related tweaks.
   By :user:`Davis Bennett <d-v-b>` :issue:`1641`.
+
+Maintenance
+~~~~~~~~~~~
+
+* Update config.yml with Zulip.
+  By :user:`Josh Moore <joshmoore>`.
+
+* Replace Gitter with the new Zulip Chat link.
+  By :user:`Sanket Verma <msankeys963>` :issue:`1685`.
+
+* Fix RTD build.
+  By :user:`Sanket Verma <msankeys963>` :issue:`1694`.
 
 .. _release_2.17.0:
 


### PR DESCRIPTION
Hi all.

This PR updates the `release.rst` to include #1425 and #1641 and prepares for the `2.17.1` release.

TODO:
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
