### PR TITLE
Replace Gitter with new Zulip Chat link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: A new major feature should be discussed in the Zarr specifications repository.
   - name: ❓ Discuss something on Zulip
     url: https://ossci.zulipchat.com/
-    about: For questions like "How do I do X with Zarr?", you can move to our Gitter channel.
+    about: For questions like "How do I do X with Zarr?", you can move to our Zulip Chat.
   - name: ❓ Discuss something on GitHub Discussions
     url: https://github.com/zarr-developers/zarr-python/discussions
     about: For questions like "How do I do X with Zarr?", you can move to GitHub Discussions.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@
   </td>
 </tr>
 <tr>
-	<td>Gitter</td>
+	<td>Zulip</td>
 	<td>
-		<a href="https://gitter.im/zarr-developers/community">
-		<img src="https://badges.gitter.im/zarr-developers/community.svg" />
+		<a href="https://ossci.zulipchat.com/">
+		<img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" />
 		</a>
 	</td>
 </tr>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Zarr-Python
 `Installation <installation.html>`_ |
 `Source Repository <https://github.com/zarr-developers/zarr-python>`_ |
 `Issue Tracker <https://github.com/zarr-developers/zarr-python/issues>`_ |
-`Gitter <https://gitter.im/zarr-developers/community>`_
+`Zulip Chat <https://ossci.zulipchat.com/>`_
 
 Zarr is a file storage format for chunked, compressed, N-dimensional arrays based on an open-source specification.
 


### PR DESCRIPTION
This PR replaces the link of the Gitter chat with the new Zulip chat.

The blog post for the announcement: https://zarr.dev/blog/zulip-transition/

See https://github.com/zarr-developers/community/issues/68 and https://github.com/zarr-developers/blog/pull/45.

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
