### PR TITLE
docs(tutorial.rst): fix link to GCSMap

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -868,7 +868,7 @@ implementations of the ``MutableMapping`` interface for Amazon S3 (`S3Map
 Distributed File System (`HDFSMap
 <https://hdfs3.readthedocs.io/en/latest/api.html#hdfs3.mapping.HDFSMap>`_) and
 Google Cloud Storage (`GCSMap
-<http://gcsfs.readthedocs.io/en/latest/api.html#gcsfs.mapping.GCSMap>`_), which
+<https://gcsfs.readthedocs.io/en/latest/api.html#gcsfs.core.GCSFileSystem.get_mapper>`_), which
 can be used with Zarr.
 
 Here is an example using S3Map to read an array created previously::


### PR DESCRIPTION
Fixing link to close https://github.com/zarr-developers/zarr-python/issues/1683

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
