### PR TITLE
Apply assorted ruff/refurb rules (FURB)

### DIFF
--- a/zarr/_storage/v3_storage_transformers.py
+++ b/zarr/_storage/v3_storage_transformers.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import operator
 import os
 from typing import NamedTuple, Tuple, Optional, Union, Iterator
 
@@ -101,7 +102,7 @@ class ShardingStorageTransformer(StorageTransformer):  # lgtm[py/missing-equals]
             if chunks_per_shard == ():
                 chunks_per_shard = (1,)
         self.chunks_per_shard = chunks_per_shard
-        self._num_chunks_per_shard = functools.reduce(lambda x, y: x * y, chunks_per_shard, 1)
+        self._num_chunks_per_shard = functools.reduce(operator.mul, chunks_per_shard, 1)
         self._dimension_separator = None
         self._data_key_prefix = None
 

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -232,7 +232,7 @@ class Metadata2:
                 return -np.inf
             else:
                 return np.array(v, dtype=dtype)[()]
-        elif dtype.kind in "c":
+        elif dtype.kind == "c":
             v = (
                 cls.decode_fill_value(v[0], dtype.type().real.dtype),
                 cls.decode_fill_value(v[1], dtype.type().imag.dtype),
@@ -283,7 +283,7 @@ class Metadata2:
             return int(v)
         elif dtype.kind == "b":
             return bool(v)
-        elif dtype.kind in "c":
+        elif dtype.kind == "c":
             c = cast(np.complex128, np.dtype(complex).type())
             v = (
                 cls.encode_fill_value(v.real, c.real.dtype, object_codec),

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -1995,9 +1995,7 @@ class TestArrayWithN5Store(TestArrayWithDirectoryStore):
     def test_compressors(self):
         compressors = [None, BZ2(), Zlib(), GZip(), MsgPack()]
         if LZMA:
-            compressors.append(LZMA())
-            compressors.append(LZMA(preset=1))
-            compressors.append(LZMA(preset=6))
+            compressors.extend((LZMA(), LZMA(preset=1), LZMA(preset=6)))
         for compressor in compressors:
             a1 = self.create_array(shape=1000, chunks=100, compressor=compressor)
             a1[0:100] = 1


### PR DESCRIPTION
Note: #1873 is the same applied to the [`v3`](https://github.com/zarr-developers/zarr-python/tree/v3) branch

```
FURB113 Use `compressors.extend(...)` instead of repeatedly calling `compressors.append()`
FURB118 Use `operator.mul` instead of defining a lambda
FURB171 Membership test against single-item container
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
