### PR TITLE
Add Google Cloud Storage example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,7 @@
+Examples
+========
+
+.. toctree::
+    :glob:
+
+    examples/*

--- a/docs/examples/google_cloud.rst
+++ b/docs/examples/google_cloud.rst
@@ -1,0 +1,18 @@
+Opening from Google Cloud Storage
+=================================
+This example shows how to open a read-only bucket in Google Cloud Storage.
+This requires the ``gcsfs`` package in addition to ``zarr``.
+
+
+.. code:: python
+
+    import zarr
+    import gcsfs
+
+    project = "my_project"
+    bucket = "my_bucket"
+    path_to_array = "a/b/c"
+
+    fs = gcsfs.GCSFileSystem(project=bucket, token='anon', access='read_only')
+    store = zarr.FSStore(url=bucket, fs=fs)
+    array = zarr.open_array(store=store, path=path_to_array)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,9 @@ Zarr-Python
     getting_started
     tutorial
     api
-    spec
+    examples
     release
+    spec
     license
     acknowledgments
     contributing


### PR DESCRIPTION
This adds an example of how to open an array that's in Google Cloud Storage. Fixes https://github.com/zarr-developers/zarr-python/issues/1684

I've added a new section to the docs, "Examples", for short, self-contained examples, that achieve a specific goal. This is distinct from existing sections of the docs, and should complement the existing tutorial and reference sections. For those familiar with [Diataxis](https://diataxis.fr/), this is essentially the "how-to guides" quadrant.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
