### PR TITLE
Fix tests with Pytest 8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,7 +62,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools wheel line_profiler
         python -m pip install -rrequirements_dev_minimal.txt numpy${{matrix.numpy_version}} -rrequirements_dev_optional.txt pymongo redis
-        python -m pip install .
+        python -m pip install -e .
         python -m pip freeze
     - name: Tests
       shell: "bash -l {0}"

--- a/requirements_dev_minimal.txt
+++ b/requirements_dev_minimal.txt
@@ -5,4 +5,4 @@ numcodecs==0.12.1
 msgpack-python==0.5.6
 setuptools-scm==8.0.4
 # test requirements
-pytest==7.4.4
+pytest==8.1.1


### PR DESCRIPTION
An attempt to resolve https://github.com/zarr-developers/zarr-python/pull/1671. The issue was installing the package in non-editable mode creates a copy of the package, and `pytest` gets confused about which of the duplicate files it should be importing. Installing in editable mode fixes this.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
