### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         numpy_version: ['>=1.22.0', '==1.21.*']
         exclude:
           - python-version: '3.10'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,14 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        numpy_version: ['>=1.22.0', '==1.21.*']
+        numpy_version: ['>=1.24.0', '==1.23.*']
         exclude:
           - python-version: '3.10'
-            numpy_version: '==1.21.*'
+            numpy_version: '==1.23.*'
           - python-version: '3.11'
-            numpy_version: '==1.21.*'
+            numpy_version: '==1.23.*'
+          - python-version: '3.12'
+            numpy_version: '==1.23.*'
     services:
       redis:
         image: redis

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -53,6 +53,12 @@ Maintenance
 * Fix RTD build.
   By :user:`Sanket Verma <msankeys963>` :issue:`1694`.
 
+* Add CI test environment for Python 3.12
+  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
+
+* Bump minimum supported NumPy version to 1.23 (per spec 0000)
+  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
+
 .. _release_2.17.0:
 
 2.17.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 requires-python = ">=3.9"
 dependencies = [
     'asciitree',
-    'numpy>=1.21.1',
+    'numpy>=1.23',
     'fasteners; sys_platform != "emscripten"',
     'numcodecs>=0.10.0',
 ]


### PR DESCRIPTION
Curious if this works now. Will follow up if CI fails.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
