### PR TITLE
Override ipython repr methods.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,12 @@ Release notes
 Unreleased
 ----------
 
+Enhancements
+~~~~~~~~~~~~
+
+* Override IPython ``_repr_*_`` methods to avoid expensive lookups against object stores.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1716`.
+
 .. _release_2.17.1:
 
 2.17.1

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -515,6 +515,13 @@ class Group(MutableMapping):
             raise KeyError(item)
 
     def __getattr__(self, item):
+        # https://github.com/jupyter/notebook/issues/2014
+        # Save a possibly expensive lookup (for e.g. against cloud stores)
+        # Note: The _ipython_display_ method is required to display the right info as a side-effect.
+        # It is simpler to pretend it doesn't exist.
+        if item in ["_ipython_canary_method_should_not_exist_", "_ipython_display_"]:
+            raise AttributeError
+
         # allow access to group members via dot notation
         try:
             return self.__getitem__(item)
@@ -1330,6 +1337,40 @@ class Group(MutableMapping):
             self.require_group("/" + dest.rsplit("/", 1)[0])
 
         self._write_op(self._move_nosync, source, dest)
+
+    # Override ipython repr methods, GH1716
+    # https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
+    #     " If the methods don’t exist, the standard repr() is used. If a method exists and
+    #       returns None, it is treated the same as if it does not exist."
+    def _repr_html_(self):
+        return None
+
+    def _repr_latex_(self):
+        return None
+
+    def _repr_mimebundle_(self, **kwargs):
+        return None
+
+    def _repr_svg_(self):
+        return None
+
+    def _repr_png_(self):
+        return None
+
+    def _repr_jpeg_(self):
+        return None
+
+    def _repr_markdown_(self):
+        return None
+
+    def _repr_javascript_(self):
+        return None
+
+    def _repr_pdf_(self):
+        return None
+
+    def _repr_json_(self):
+        return None
 
 
 def _normalize_store_arg(store, *, storage_options=None, mode="r", zarr_version=None):

--- a/zarr/tests/test_hierarchy.py
+++ b/zarr/tests/test_hierarchy.py
@@ -1,4 +1,5 @@
 import atexit
+import operator
 import os
 import sys
 import pickle
@@ -86,6 +87,26 @@ class TestGroup(unittest.TestCase):
             synchronizer=synchronizer,
         )
         return g
+
+    def test_ipython_repr_methods(self):
+        g = self.create_group()
+        for method in [
+            "html",
+            "json",
+            "javascript",
+            "markdown",
+            "svg",
+            "png",
+            "jpeg",
+            "latex",
+            "pdf",
+            "mimebundle",
+        ]:
+            assert operator.methodcaller(f"_repr_{method}_")(g) is None
+        with pytest.raises(AttributeError):
+            g._ipython_display_()
+        with pytest.raises(AttributeError):
+            g._ipython_canary_method_should_not_exist_()
 
     def test_group_init_1(self):
         store, chunk_store = self.create_store()


### PR DESCRIPTION
Closes #1716

This avoids expensive lookups against object stores.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
