### PR TITLE
Fix release notes (following #1719)

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,6 +18,15 @@ Release notes
 Unreleased
 ----------
 
+Maintenance
+~~~~~~~~~~~
+
+* Add CI test environment for Python 3.12
+  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
+
+* Bump minimum supported NumPy version to 1.23 (per spec 0000)
+  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
+
 .. _release_2.17.1:
 
 2.17.1
@@ -52,12 +61,6 @@ Maintenance
 
 * Fix RTD build.
   By :user:`Sanket Verma <msankeys963>` :issue:`1694`.
-
-* Add CI test environment for Python 3.12
-  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
-
-* Bump minimum supported NumPy version to 1.23 (per spec 0000)
-  By :user:`Joe Hamman <jhamman>` :issue:`1719`.
 
 .. _release_2.17.0:
 


### PR DESCRIPTION
My release notes from #1719 landed in the wrong place. This moves them to the "Unreleased" section.

