### PR TITLE
Specify hatch envs using GitHub actions matrix for v3 tests

### DIFF
--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         numpy-version: ['1.24', '1.26']
         dependency-set: ["minimal", "optional"]
 

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -10,7 +10,7 @@ on:
     branches: [ v3 ]
 
 jobs:
-  run-tests:
+  py=${{ matrix.python-version }}, np=${{ matrix.numpy-version }}, deps=${{ matrix.dependency-set }}:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         numpy-version: ['1.24', '1.26']
         dependency-set: ["minimal", "optional"]
 

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -10,7 +10,8 @@ on:
     branches: [ v3 ]
 
 jobs:
-  py=${{ matrix.python-version }}, np=${{ matrix.numpy-version }}, deps=${{ matrix.dependency-set }}:
+  test:
+    name: py=${{ matrix.python-version }}, np=${{ matrix.numpy-version }}, deps=${{ matrix.dependency-set }}
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-v3.yml
+++ b/.github/workflows/test-v3.yml
@@ -13,12 +13,18 @@ jobs:
   run-tests:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+        numpy-version: ['1.24', '1.26']
+        dependency-set: ["minimal", "optional"]
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
     - name: Install Hatch
       run: |
@@ -29,7 +35,7 @@ jobs:
         hatch env create
     - name: Run Tests
       run: |
-        hatch run test:run
+        hatch env run --env test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} run
     - name: Run mypy
       continue-on-error: true
       run: |


### PR DESCRIPTION
Addresses @jhamman's request from https://github.com/zarr-developers/zarr-python/pull/1656#discussion_r1483310948. Not the cleanest solution, but seems to be the only option until https://github.com/pypa/hatch/issues/858 is resolved.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
