### PR TITLE
Array & Group: Use already loaded attributes to populate cache.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -21,8 +21,12 @@ Unreleased
 Enhancements
 ~~~~~~~~~~~~
 
+* [v3] Reuse the download array metadata when creating an ``Array``.
+  By :user:`Deepak Cherian <dcherian>`.
+
 * Optimize ``Array.info`` so that it calls `getsize` only once.
   By :user:`Deepak Cherian <dcherian>`.
+
 * Override IPython ``_repr_*_`` methods to avoid expensive lookups against object stores.
   By :user:`Deepak Cherian <dcherian>` :issue:`1716`.
 

--- a/zarr/attrs.py
+++ b/zarr/attrs.py
@@ -25,14 +25,16 @@ class Attributes(MutableMapping):
 
     """
 
-    def __init__(self, store, key=".zattrs", read_only=False, cache=True, synchronizer=None):
+    def __init__(
+        self, store, key=".zattrs", read_only=False, cache=True, synchronizer=None, cached_dict=None
+    ):
         self._version = getattr(store, "_store_version", 2)
         _Store = Store if self._version == 2 else StoreV3
         self.store = _Store._ensure_store(store)
         self.key = key
         self.read_only = read_only
         self.cache = cache
-        self._cached_asdict = None
+        self._cached_asdict = cached_dict if cache else None
         self.synchronizer = synchronizer
 
     def _get_nosync(self):

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -174,6 +174,8 @@ class Array:
         self._attrs = Attributes(
             store, key=akey, read_only=read_only, synchronizer=synchronizer, cache=cache_attrs
         )
+        if cache_attrs:
+            self._attrs._cached_asdict = self._meta["attributes"]
 
         # initialize info reporter
         self._info_reporter = InfoReporter(self)

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -172,10 +172,13 @@ class Array:
         # initialize attributes
         akey = _prefix_to_attrs_key(self._store, self._key_prefix)
         self._attrs = Attributes(
-            store, key=akey, read_only=read_only, synchronizer=synchronizer, cache=cache_attrs
+            store,
+            key=akey,
+            read_only=read_only,
+            synchronizer=synchronizer,
+            cache=cache_attrs,
+            cached_dict=self._meta["attributes"] if self._version == 3 else None,
         )
-        if cache_attrs:
-            self._attrs._cached_asdict = self._meta["attributes"]
 
         # initialize info reporter
         self._info_reporter = InfoReporter(self)

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -209,6 +209,8 @@ class Group(MutableMapping):
         self._attrs = Attributes(
             store, key=akey, read_only=read_only, cache=cache_attrs, synchronizer=synchronizer
         )
+        if cache_attrs:
+            self._attrs._cached_asdict = self._meta["attributes"]
 
         # setup info
         self._info = InfoReporter(self)

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -207,10 +207,13 @@ class Group(MutableMapping):
             # object can still be created.
             akey = mkey
         self._attrs = Attributes(
-            store, key=akey, read_only=read_only, cache=cache_attrs, synchronizer=synchronizer
+            store,
+            key=akey,
+            read_only=read_only,
+            cache=cache_attrs,
+            synchronizer=synchronizer,
+            cached_dict=self._meta["attributes"] if self._version == 3 and self._meta else None,
         )
-        if cache_attrs:
-            self._attrs._cached_asdict = self._meta["attributes"]
 
         # setup info
         self._info = InfoReporter(self)


### PR DESCRIPTION
[Description of PR]

Spotted this quick (possible) optimization.

`_load_metadata` (two lines above) has already downloaded the attributes. May as well populate the cache ahead of the time if `cache_attrs is True` (which is the default)

TODO:
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
