### PR TITLE
chore(docs): reset release notes as unreleased

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,6 +13,23 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
+.. _unreleased:
+
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Docs
+~~~~
+
+
+Maintenance
+~~~~~~~~~~~
+
+
 .. _release_2.17.2:
 
 2.17.2


### PR DESCRIPTION
Add's unreleased section back to our changelog. 

* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
