### PR TITLE
Update release.rst for v2.17.2

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -40,13 +40,13 @@ Enhancements
 
 * [v3] Dramatically reduce number of ``__contains__`` requests in favor of optimistically calling `__getitem__`
   and handling any error that may arise.
-  By :user:`Deepak Cherian <dcherian>`.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1741`.
 
 * [v3] Reuse the downloaded array metadata when creating an ``Array``.
-  By :user:`Deepak Cherian <dcherian>`.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1734`.
 
 * Optimize ``Array.info`` so that it calls `getsize` only once.
-  By :user:`Deepak Cherian <dcherian>`.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1733`.
 
 * Override IPython ``_repr_*_`` methods to avoid expensive lookups against object stores.
   By :user:`Deepak Cherian <dcherian>` :issue:`1716`.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -37,6 +37,7 @@ Maintenance
 
 Enhancements
 ~~~~~~~~~~~~
+
 * [v3] Dramatically reduce number of ``__contains__`` requests in favor of optimistically calling `__getitem__`
   and handling any error that may arise.
   By :user:`Deepak Cherian <dcherian>`.
@@ -53,6 +54,21 @@ Enhancements
 * FSStore now raises rather than return bad data.
   By :user:`Martin Durant <martindurant>` and :user:`Ian Carroll <itcarroll>` :issue:`1604`.
 
+* Avoid redundant ``__contains__``.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1739`.
+
+Docs
+~~~~
+
+* Fix link to GCSMap in ``tutorial.rst``.
+  By :user:`Daniel Jahn <dahnj>` :issue:`1689`.
+
+* Endorse `SPEC0000 <https://scientific-python.org/specs/spec-0000/>`_ and state version support policy in ``installation.rst``.
+  By :user:`Sanket Verma <msankeys963>` :issue:`1665`.
+
+* Migrate v1 and v2 specification to `Zarr-Specs <https://zarr-specs.readthedocs.io/en/latest/specs.html>`_.
+  By :user:`Sanket Verma <msankeys963>` :issue:`1582`.
+
 Maintenance
 ~~~~~~~~~~~
 
@@ -61,7 +77,12 @@ Maintenance
 
 * Bump minimum supported NumPy version to 1.23 (per spec 0000)
   By :user:`Joe Hamman <jhamman>` :issue:`1719`.
-  
+
+* Minor fixes: Using ``is`` instead of ``type`` and removing unnecessary ``None``.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1737`.
+
+* Fix tests failure related to Pytest 8.
+  By :user:`David Stansby <dstansby>` :issue:`1714`.
 
 .. _release_2.17.1:
 


### PR DESCRIPTION
I've noticed that the release notes for 2.17.2 are incomplete.  Please compare [this](https://github.com/zarr-developers/zarr-python/releases/tag/v2.17.2) and [this](https://zarr.readthedocs.io/en/stable/release.html#release-2-17-2).

This PR completes the release notes for the current release.

TODO:
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
