### PR TITLE
Allow dmypy to be run on v3 branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ extend-exclude = [
 [tool.mypy]
 python_version = "3.8"
 ignore_missing_imports = true
-follow_imports = "silent"
+namespace_packages = false
 
 [tool.pytest.ini_options]
 doctest_optionflags = [


### PR DESCRIPTION
This allows `dmypy`, the `mypy` daemon to be run on the v3 branch. In turn this allows the `mypy` plugin to be used in VSCode.

`follow_imports` is not supported by the daemon, but not needed, and `namespace_packages = false` is needed so `mypy` doesn't interpret `src/` as a package.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
