### PR TITLE
Check untyped defs on v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,27 @@ extend-exclude = [
 ]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 ignore_missing_imports = true
 follow_imports = "silent"
+
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    "zarr._storage.store",
+    "zarr._storage.v3_storage_transformers",
+    "zarr.v3.group",
+    "zarr.core",
+    "zarr.hierarchy",
+    "zarr.indexing",
+    "zarr.storage",
+    "zarr.sync",
+    "zarr.util",
+    "tests.*",
+]
+check_untyped_defs = false
+
 
 [tool.pytest.ini_options]
 doctest_optionflags = [

--- a/src/zarr/attrs.py
+++ b/src/zarr/attrs.py
@@ -1,3 +1,4 @@
+from typing import Any
 import warnings
 from collections.abc import MutableMapping
 
@@ -39,7 +40,7 @@ class Attributes(MutableMapping):
         try:
             data = self.store[self.key]
         except KeyError:
-            d = dict()
+            d: dict[str, Any] = dict()
             if self._version > 2:
                 d["attributes"] = {}
         else:

--- a/src/zarr/n5.py
+++ b/src/zarr/n5.py
@@ -325,10 +325,9 @@ class N5FSStore(FSStore):
 
     def __init__(self, *args, **kwargs):
         if "dimension_separator" in kwargs:
-            kwargs.pop("dimension_separator")
             warnings.warn("Keyword argument `dimension_separator` will be ignored")
-        dimension_separator = "."
-        super().__init__(*args, dimension_separator=dimension_separator, **kwargs)
+        kwargs["dimension_separator"] = "."
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def _swap_separator(key: str):

--- a/src/zarr/v3/sync.py
+++ b/src/zarr/v3/sync.py
@@ -90,8 +90,9 @@ def _get_loop():
             # repeat the check just in case the loop got filled between the
             # previous two calls from another thread
             if loop[0] is None:
-                loop[0] = asyncio.new_event_loop()
-                th = threading.Thread(target=loop[0].run_forever, name="zarrIO")
+                new_loop = asyncio.new_event_loop()
+                loop[0] = new_loop
+                th = threading.Thread(target=new_loop.run_forever, name="zarrIO")
                 th.daemon = True
                 th.start()
                 iothread[0] = th


### PR DESCRIPTION
Part of https://github.com/zarr-developers/zarr-python/issues/1783. This enables the `check_untyped_defs` mypy rule, and makes some of the easiest fixes. For the tricker fixes, I added the files to the a mypy override list, and I think it's easiest if each of these is done in separate PRs so we can enable this rule now (to stop any more violations), but incrementally improve it.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
