### PR TITLE
[v3] Enable some more strict mypy options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,8 @@ namespace_packages = false
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-
+strict_equality = true
+strict_concatenate = true
 
 check_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ strict_equality = true
 strict_concatenate = true
 
 check_untyped_defs = true
+disallow_untyped_decorators = true
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
No fixes needed for these, but worth enabling them anyway to get closer to enabling `strict=True` in mypy.