### PR TITLE
deprecate(stores): add deprecation warnings to stores that we plan to remove in v3

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,6 +32,13 @@ Maintenance
 ~~~~~~~~~~~
 
 
+Deprecations
+~~~~~~~~~~~~
+* Deprecate the following stores: :class:`zarr.storage.DBMStore`, :class:`zarr.storage.LMDBStore`,
+  :class:`zarr.storage.SQLiteStore`, :class:`zarr.storage.MongoDBStore`, :class:`zarr.storage.RedisStore`,
+  and :class:`zarr.storage.ABSStore`. These stores are slated to be removed from Zarr-Python in version 3.0.
+  By :user:`Joe Hamman <jhamman>` :issue:`1801`.
+
 .. _release_2.17.2:
 
 2.17.2

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,6 +13,23 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
+.. _unreleased:
+
+Unreleased
+----------
+
+Enhancements
+~~~~~~~~~~~~
+
+
+Docs
+~~~~
+
+
+Maintenance
+~~~~~~~~~~~
+
+
 .. _release_2.17.2:
 
 2.17.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ filterwarnings = [
     "error:::zarr.*",
     "ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning",
     "ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning",
+    "ignore:The .* is deprecated and will be removed in a Zarr-Python version 3*:FutureWarning",
 ]
 
 

--- a/zarr/_storage/absstore.py
+++ b/zarr/_storage/absstore.py
@@ -5,7 +5,14 @@ import warnings
 
 from numcodecs.compat import ensure_bytes
 from zarr.util import normalize_storage_path
-from zarr._storage.store import _get_metadata_suffix, data_root, meta_root, Store, StoreV3
+from zarr._storage.store import (
+    _get_metadata_suffix,
+    data_root,
+    meta_root,
+    Store,
+    StoreV3,
+    V3_DEPRECATION_MESSAGE,
+)
 from zarr.types import DIMENSION_SEPARATOR
 
 __doctest_requires__ = {
@@ -73,6 +80,12 @@ class ABSStore(Store):
         dimension_separator: Optional[DIMENSION_SEPARATOR] = None,
         client=None,
     ):
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=3,
+        )
+
         self._dimension_separator = dimension_separator
         self.prefix = normalize_storage_path(prefix)
         if client is None:

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -25,7 +25,7 @@ DEFAULT_ZARR_VERSION: ZARR_VERSION = 2
 v3_api_available = os.environ.get("ZARR_V3_EXPERIMENTAL_API", "0").lower() not in ["0", "false"]
 
 V3_DEPRECATION_MESSAGE = (
-    "The {store} is deprecated and will be removed in a Zarr-Python version 3, see"
+    "The {store} is deprecated and will be removed in a Zarr-Python version 3, see "
     "https://github.com/zarr-developers/zarr-python/issues/1274 for more information."
 )
 

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -24,6 +24,11 @@ DEFAULT_ZARR_VERSION: ZARR_VERSION = 2
 
 v3_api_available = os.environ.get("ZARR_V3_EXPERIMENTAL_API", "0").lower() not in ["0", "false"]
 
+V3_DEPRECATION_MESSAGE = (
+    "The {store} is deprecated and will be removed in a Zarr-Python version 3, see"
+    "https://github.com/zarr-developers/zarr-python/issues/1274 for more information."
+)
+
 
 def assert_zarr_v3_api_available():
     if not v3_api_available:

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1605,6 +1605,12 @@ class NestedDirectoryStore(DirectoryStore):
     special handling for chunk keys so that chunk files for multidimensional
     arrays are stored in a nested directory tree.
 
+    .. deprecated:: 2.18.0
+            NestedDirectoryStore will be removed in Zarr-Python 3.0 where controlling
+            the chunk key encoding will be supported as part of the array metadata. See
+            `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+            for more information.
+
     Parameters
     ----------
     path : string
@@ -1676,6 +1682,13 @@ class NestedDirectoryStore(DirectoryStore):
     def __init__(
         self, path, normalize_keys=False, dimension_separator: Optional[DIMENSION_SEPARATOR] = "/"
     ):
+
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
+
         super().__init__(path, normalize_keys=normalize_keys)
         if dimension_separator is None:
             dimension_separator = "/"
@@ -1996,6 +2009,11 @@ def migrate_1to2(store):
 class DBMStore(Store):
     """Storage class using a DBM-style database.
 
+    .. deprecated:: 2.18.0
+            DBMStore will be removed in Zarr-Python 3.0. See
+            `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+            for more information.
+
     Parameters
     ----------
     path : string
@@ -2207,6 +2225,10 @@ class LMDBStore(Store):
     """Storage class using LMDB. Requires the `lmdb <https://lmdb.readthedocs.io/>`_
     package to be installed.
 
+    .. deprecated:: 2.18.0
+        LMDBStore will be removed in Zarr-Python 3.0. See
+        `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+        for more information.
 
     Parameters
     ----------
@@ -2593,6 +2615,11 @@ class LRUStoreCache(Store):
 class SQLiteStore(Store):
     """Storage class using SQLite.
 
+    .. deprecated:: 2.18.0
+            SQLiteStore will be removed in Zarr-Python 3.0. See
+            `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+            for more information.
+
     Parameters
     ----------
     path : string
@@ -2797,6 +2824,11 @@ class MongoDBStore(Store):
 
     .. note:: This is an experimental feature.
 
+    .. deprecated:: 2.18.0
+            MongoDBStore will be removed in Zarr-Python 3.0. See
+            `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+            for more information.
+
     Requires the `pymongo <https://pymongo.readthedocs.io/en/stable/>`_
     package to be installed.
 
@@ -2890,6 +2922,11 @@ class RedisStore(Store):
     """Storage class using Redis.
 
     .. note:: This is an experimental feature.
+
+    .. deprecated:: 2.18.0
+            RedisStore will be removed in Zarr-Python 3.0. See
+            `GH1274 <https://github.com/zarr-developers/zarr-python/issues/1274>`_
+            for more information.
 
     Requires the `redis <https://redis-py.readthedocs.io/>`_
     package to be installed.

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -88,6 +88,7 @@ from zarr._storage.store import (  # noqa: F401
     DEFAULT_ZARR_VERSION,
     BaseStore,
     Store,
+    V3_DEPRECATION_MESSAGE,
 )
 
 __doctest_requires__ = {
@@ -2083,6 +2084,12 @@ class DBMStore(Store):
         dimension_separator: Optional[DIMENSION_SEPARATOR] = None,
         **open_kwargs,
     ):
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
+
         if open is None:
             import dbm
 
@@ -2260,6 +2267,12 @@ class LMDBStore(Store):
         **kwargs,
     ):
         import lmdb
+
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
 
         # set default memory map size to something larger than the lmdb default, which is
         # very likely to be too small for any moderate array (logic copied from zict)
@@ -2612,6 +2625,12 @@ class SQLiteStore(Store):
     def __init__(self, path, dimension_separator: Optional[DIMENSION_SEPARATOR] = None, **kwargs):
         import sqlite3
 
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
+
         self._dimension_separator = dimension_separator
 
         # normalize path
@@ -2810,6 +2829,12 @@ class MongoDBStore(Store):
     ):
         import pymongo
 
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
+
         self._database = database
         self._collection = collection
         self._dimension_separator = dimension_separator
@@ -2884,6 +2909,12 @@ class RedisStore(Store):
         self, prefix="zarr", dimension_separator: Optional[DIMENSION_SEPARATOR] = None, **kwargs
     ):
         import redis
+
+        warnings.warn(
+            V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
+            FutureWarning,
+            stacklevel=2,
+        )
 
         self._prefix = prefix
         self._kwargs = kwargs


### PR DESCRIPTION
This adds a simple deprecation warning to the following stores: 

- [x] DBMStore 
- [x] LMDBStore
- [x] SQLiteStore
- [x] MongoDBStore
- [x] RedisStore
- [x] ABSStore
- [x] NestedDirectoryStore (note: this was already just a special case of the Directory store for v2

closes https://github.com/zarr-developers/zarr-python/issues/1756

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
