### PR TITLE
Disallow untyped calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ disallow_untyped_decorators = true
 disallow_any_generics = true
 
 disallow_incomplete_defs = true
+disallow_untyped_calls = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -198,6 +199,20 @@ module = [
     "zarr.group"
 ]
 disallow_incomplete_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+    "zarr.v2.*",
+    "zarr.array_v2",
+    "zarr.array",
+    "zarr.common",
+    "zarr.store.local",
+    "zarr.codecs.blosc",
+    "zarr.codecs.gzip",
+    "zarr.codecs.zstd",
+]
+disallow_untyped_calls = false
+
 
 [tool.pytest.ini_options]
 doctest_optionflags = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,21 +171,15 @@ disallow_incomplete_defs = true
 
 [[tool.mypy.overrides]]
 module = [
-    "zarr.v2._storage.store",
-    "zarr.v2._storage.v3_storage_transformers",
+    "zarr.v2.*",
     "zarr.group",
-    "zarr.v2.core",
-    "zarr.v2.hierarchy",
-    "zarr.v2.indexing",
-    "zarr.v2.storage",
-    "zarr.v2.sync",
-    "zarr.v2.util",
     "tests.*",
 ]
 check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
+    "zarr.v2.*",
     "zarr.abc.codec",
     "zarr.codecs.bytes",
     "zarr.codecs.pipeline",
@@ -194,8 +188,6 @@ module = [
     "zarr.array_v2",
     "zarr.array",
     "zarr.sync",
-    "zarr.v2.convenience",
-    "zarr.v2.meta",
 ]
 disallow_any_generics = false
 

--- a/src/zarr/common.py
+++ b/src/zarr/common.py
@@ -79,7 +79,7 @@ class ArraySpec:
     dtype: np.dtype[Any]
     fill_value: Any
 
-    def __init__(self, shape, dtype, fill_value):
+    def __init__(self, shape: ChunkCoords, dtype: np.dtype[Any], fill_value: Any) -> None:
         shape_parsed = parse_shapelike(shape)
         dtype_parsed = parse_dtype(dtype)
         fill_value_parsed = parse_fill_value(fill_value)

--- a/src/zarr/indexing.py
+++ b/src/zarr/indexing.py
@@ -19,7 +19,7 @@ def _err_too_many_indices(selection: SliceSelection, shape: ChunkCoords) -> None
     )
 
 
-def _err_negative_step():
+def _err_negative_step() -> None:
     raise IndexError("only slices with step >= 1 are supported")
 
 
@@ -50,7 +50,7 @@ class _ChunkDimProjection(NamedTuple):
     dim_out_sel: Optional[slice]
 
 
-def _ceildiv(a, b):
+def _ceildiv(a: float, b: float) -> int:
     return math.ceil(a / b)
 
 


### PR DESCRIPTION
This tightens up mypy again, disallowing untyped calls. As with other PRs I made some simple fixes, and put the more complex sub-modules in a list to ignore this error which we can fix one at a time in subsequent PRs.