### PR TITLE
add note to the top of the release page noting the plan for 2.18.* and 3.0

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -13,6 +13,11 @@ Release notes
     # to document your changes. On releases it will be
     # re-indented so that it does not show up in the notes.
 
+.. note::
+   Zarr-Python 2.18.* is expected be the final release in the 2.* series. Work on Zarr-Python 3.0 is underway.
+   See `GH1777 <https://github.com/zarr-developers/zarr-python/issues/1777>` for more details on the upcoming
+   3.0 release.
+
 .. _unreleased:
 
 Unreleased

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -15,7 +15,7 @@ Release notes
 
 .. note::
    Zarr-Python 2.18.* is expected be the final release in the 2.* series. Work on Zarr-Python 3.0 is underway.
-   See `GH1777 <https://github.com/zarr-developers/zarr-python/issues/1777>` for more details on the upcoming
+   See `GH1777 <https://github.com/zarr-developers/zarr-python/issues/1777>`_ for more details on the upcoming
    3.0 release.
 
 .. _unreleased:


### PR DESCRIPTION
Small doc update ahead of the pending 2.18 release. 

TODO:
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
