### PR TITLE
Test codec entrypoints

### DIFF
--- a/src/zarr/codecs/registry.py
+++ b/src/zarr/codecs/registry.py
@@ -12,16 +12,11 @@ __codec_registry: Dict[str, Type[Codec]] = {}
 __lazy_load_codecs: Dict[str, EntryPoint] = {}
 
 
-def _collect_entrypoints() -> None:
+def _collect_entrypoints() -> Dict[str, EntryPoint]:
     entry_points = get_entry_points()
-    if hasattr(entry_points, "select"):
-        # If entry_points() has a select method, use that. Python 3.10+
-        for e in entry_points.select(group="zarr.codecs"):
-            __lazy_load_codecs[e.name] = e
-    else:
-        # Otherwise, fallback to using get
-        for e in entry_points.get("zarr.codecs", []):
-            __lazy_load_codecs[e.name] = e
+    for e in entry_points.select(group="zarr.codecs"):
+        __lazy_load_codecs[e.name] = e
+    return __lazy_load_codecs
 
 
 def register_codec(key: str, codec_cls: Type[Codec]) -> None:

--- a/tests/v3/package_with_entrypoint-0.1.dist-info/entry_points.txt
+++ b/tests/v3/package_with_entrypoint-0.1.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[zarr.codecs]
+test = package_with_entrypoint:TestCodec

--- a/tests/v3/package_with_entrypoint/__init__.py
+++ b/tests/v3/package_with_entrypoint/__init__.py
@@ -1,0 +1,27 @@
+from numpy import ndarray
+from zarr.abc.codec import ArrayBytesCodec
+from zarr.common import ArraySpec, BytesLike
+from zarr.config import RuntimeConfiguration
+
+
+class TestCodec(ArrayBytesCodec):
+    is_fixed_size = True
+
+    async def encode(
+        self,
+        chunk_array: ndarray,
+        chunk_spec: ArraySpec,
+        runtime_configuration: RuntimeConfiguration,
+    ) -> BytesLike | None:
+        pass
+
+    async def decode(
+        self,
+        chunk_bytes: BytesLike,
+        chunk_spec: ArraySpec,
+        runtime_configuration: RuntimeConfiguration,
+    ) -> ndarray:
+        pass
+
+    def compute_encoded_size(self, input_byte_length: int, chunk_spec: ArraySpec) -> int:
+        return input_byte_length

--- a/tests/v3/test_codec_entrypoints.py
+++ b/tests/v3/test_codec_entrypoints.py
@@ -1,0 +1,25 @@
+import os.path
+import sys
+
+import pytest
+
+import zarr.codecs.registry
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture()
+def set_path():
+    sys.path.append(here)
+    zarr.codecs.registry._collect_entrypoints()
+    yield
+    sys.path.remove(here)
+    entry_points = zarr.codecs.registry._collect_entrypoints()
+    entry_points.pop("test")
+
+
+@pytest.mark.usefixtures("set_path")
+def test_entrypoint_codec():
+    cls = zarr.codecs.registry.get_codec_class("test")
+    assert cls.__name__ == "TestCodec"


### PR DESCRIPTION
This PR adds tests for registering codecs via entry point. The test code is copied from numcodecs.
Seems to work 👌 

Contributes to #1748 

