### PR TITLE
Enable ruff/flake8-implicit-str-concat rules (ISC) and fix issues

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,6 +32,9 @@ Docs
 Maintenance
 ~~~~~~~~~~~
 
+* Enable ruff/flake8-implicit-str-concat rules (ISC) and fix issues.
+  By :user:`Dimitri Papadopoulos Orfanos <DimitriPapadopoulos>` :issue:`1837`.
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,8 @@ exclude = [
 
 [tool.ruff.lint]
 extend-select = [
-    "B"
+    "B",
+    "ISC"
 ]
 
 [tool.black]

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -581,7 +581,7 @@ def _path_to_prefix(path: Optional[str]) -> str:
 def _get_hierarchy_metadata(store: StoreV3) -> Mapping[str, Any]:
     version = getattr(store, "_store_version", 2)
     if version < 3:
-        raise ValueError("zarr.json hierarchy metadata not stored for " f"zarr v{version} stores")
+        raise ValueError(f"zarr.json hierarchy metadata not stored for zarr v{version} stores")
     if "zarr.json" not in store:
         raise ValueError("zarr.json metadata not found in store")
     return store._metadata_class.decode_hierarchy_metadata(store["zarr.json"])

--- a/zarr/_storage/store.py
+++ b/zarr/_storage/store.py
@@ -365,8 +365,8 @@ class StoreV3(BaseStore):
                 if start > len(values[key]):  # pragma: no cover
                     raise ValueError(
                         f"Cannot set value at start {start}, "
-                        + f"since it is beyond the data at key {key}, "
-                        + f"having length {len(values[key])}."
+                        f"since it is beyond the data at key {key}, "
+                        f"having length {len(values[key])}."
                     )
                 if start < 0:
                     values[key][start:] = value
@@ -434,7 +434,7 @@ class StorageTransformer(MutableMapping, abc.ABC):
         if _type not in self.valid_types:  # pragma: no cover
             raise ValueError(
                 f"Storage transformer cannot be initialized with type {_type}, "
-                + f"must be one of {list(self.valid_types)}."
+                f"must be one of {list(self.valid_types)}."
             )
         self.type = _type
         self._inner_store = None

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -364,7 +364,7 @@ class BoolArrayDimIndexer:
         # check number of dimensions
         if not is_bool_array(dim_sel, 1):
             raise IndexError(
-                "Boolean arrays in an orthogonal selection must " "be 1-dimensional only"
+                "Boolean arrays in an orthogonal selection must be 1-dimensional only"
             )
 
         # check shape
@@ -464,7 +464,7 @@ class IntArrayDimIndexer:
         dim_sel = np.asanyarray(dim_sel)
         if not is_integer_array(dim_sel, 1):
             raise IndexError(
-                "integer arrays in an orthogonal selection must be " "1-dimensional only"
+                "integer arrays in an orthogonal selection must be 1-dimensional only"
             )
 
         # handle wraparound
@@ -919,7 +919,7 @@ def check_fields(fields, dtype):
     # check type
     if not isinstance(fields, (str, list, tuple)):
         raise IndexError(
-            f"'fields' argument must be a string or list of strings; found " f"{type(fields)!r}"
+            f"'fields' argument must be a string or list of strings; found {type(fields)!r}"
         )
     if fields:
         if dtype.names is None:

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -363,9 +363,7 @@ class BoolArrayDimIndexer:
     def __init__(self, dim_sel, dim_len, dim_chunk_len):
         # check number of dimensions
         if not is_bool_array(dim_sel, 1):
-            raise IndexError(
-                "Boolean arrays in an orthogonal selection must be 1-dimensional only"
-            )
+            raise IndexError("Boolean arrays in an orthogonal selection must be 1-dimensional only")
 
         # check shape
         if dim_sel.shape[0] != dim_len:
@@ -463,9 +461,7 @@ class IntArrayDimIndexer:
         # ensure 1d array
         dim_sel = np.asanyarray(dim_sel)
         if not is_integer_array(dim_sel, 1):
-            raise IndexError(
-                "integer arrays in an orthogonal selection must be 1-dimensional only"
-            )
+            raise IndexError("integer arrays in an orthogonal selection must be 1-dimensional only")
 
         # handle wraparound
         if wraparound:


### PR DESCRIPTION
Note: #1868 is the same applied to the [`v3`](https://github.com/zarr-developers/zarr-python/tree/v3) branch

        ISC001 Implicitly concatenated string literals on one line
        ISC003 Explicitly concatenated string should be implicitly concatenated

This rule is currently disabled because it conflicts with the formatter:
https://github.com/astral-sh/ruff/issues/8272

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
