### PR TITLE
use np.inf instead of PINF/NINF

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,9 +25,8 @@ Unreleased
 
 Enhancements
 ~~~~~~~~~~~~
-* Performance improvement for reading and writing chunks if any of the dimensions is size 1. :issue:`1730`
-  By :user:`Deepak Cherian <dcherian>`.
-
+* Performance improvement for reading and writing chunks if any of the dimensions is size 1.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1730`.
 
 Docs
 ~~~~
@@ -35,16 +34,15 @@ Docs
 
 Maintenance
 ~~~~~~~~~~~
+* Minor updates to use `np.inf` instead of `np.PINF` / `np.NINF` in preparation for NumPy 2.0.0 release. 
+  By :user:`Joe Hamman <jhamman>` :issue:`1842`.
 
 Deprecations
 ~~~~~~~~~~~~
 
 * Deprecate experimental v3 support by issuing a `FutureWarning`.
   Also updated docs to warn about using the experimental v3 version.
-  By :user:`Joe Hamman <jhamman>` :issue:`1802` and :issue: `1807`.
-
-Deprecations
-~~~~~~~~~~~~
+  By :user:`Joe Hamman <jhamman>` :issue:`1802` and :issue:`1807`.
 * Deprecate the following stores: :class:`zarr.storage.DBMStore`, :class:`zarr.storage.LMDBStore`,
   :class:`zarr.storage.SQLiteStore`, :class:`zarr.storage.MongoDBStore`, :class:`zarr.storage.RedisStore`,
   and :class:`zarr.storage.ABSStore`. These stores are slated to be removed from Zarr-Python in version 3.0.

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -227,9 +227,9 @@ class Metadata2:
             if v == "NaN":
                 return np.nan
             elif v == "Infinity":
-                return np.PINF
+                return np.inf
             elif v == "-Infinity":
-                return np.NINF
+                return -np.inf
             else:
                 return np.array(v, dtype=dtype)[()]
         elif dtype.kind in "c":

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -382,8 +382,8 @@ def test_encode_decode_array_structured():
 def test_encode_decode_fill_values_nan():
     fills = (
         (np.nan, "NaN", np.isnan),
-        (np.NINF, "-Infinity", np.isneginf),
-        (np.PINF, "Infinity", np.isposinf),
+        (-np.inf, "-Infinity", np.isneginf),
+        (np.inf, "Infinity", np.isposinf),
     )
 
     for v, s, f in fills:


### PR DESCRIPTION
This is a small backport of the numpy 2 compatibility changes that came up in #1828. This would be nice to slide into the 2.18 release. 
 
TODO:
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
