### PR TITLE
Add pytest to mypy dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,4 @@ repos:
           - types-redis
           - types-setuptools
           - attrs
+          - pytest


### PR DESCRIPTION
If/when we start type checking tests, this will be needed to give `mypy` type information from `pytest`. See also https://github.com/zarr-developers/zarr-python/pull/1844#issuecomment-2097462278.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
