### PR TITLE
ci: only test v3 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         hatch env run -e test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} list-env
     - name: Run Tests
       run: |
-        hatch env run --env test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} run
+        hatch env run --env test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} test-verbose
     - name: Run mypy
       continue-on-error: true
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,10 +114,10 @@ numpy = ["1.24", "1.26", "2.0.0rc1"]
 features = ["optional"]
 
 [tool.hatch.envs.test.scripts]
-run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
-run = "run-coverage --no-cov"
-run-verbose = "run-coverage --verbose"
-run-mypy = "mypy src"
+test-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests/v3 tests/v3"
+test = "test-coverage --no-cov"
+test-verbose = "test-coverage --verbose"
+test-mypy = "mypy src"
 list-env = "pip list"
 
 [tool.hatch.envs.docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ numpy = ["1.24", "1.26", "2.0.0rc1"]
 features = ["optional"]
 
 [tool.hatch.envs.test.scripts]
-test-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests/v3 tests/v3"
+test-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests/v3 --ignore=tests/v2"
 test = "test-coverage --no-cov"
 test-verbose = "test-coverage --verbose"
 test-mypy = "mypy src"


### PR DESCRIPTION
This PR changes our hatch test script in two ways:

1. renames the `run` script to a more informative `test` script 
2. only runs tests in the `v3` directory

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
