### PR TITLE
Feature/store metadata methods

### DIFF
--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -1,7 +1,32 @@
 from abc import abstractmethod, ABC
+import json
+import numbers
+from enum import Enum
 
+import numpy as np
 from collections.abc import AsyncGenerator
-from typing import List, Tuple, Optional
+from typing import Any, List, Tuple, Optional
+
+
+def json_default(o: Any) -> Any:
+    # See json.JSONEncoder.default docstring for explanation
+    # This is necessary to encode numpy dtype
+    if isinstance(o, numbers.Integral):
+        return int(o)
+    if isinstance(o, numbers.Real):
+        return float(o)
+    if isinstance(o, np.dtype):
+        if o.fields is None:
+            return o.str
+        else:
+            return o.descr
+    if isinstance(o, Enum):
+        return o.name
+    # this serializes numcodecs compressors
+    # todo: implement to_dict for codecs
+    elif hasattr(o, "get_config"):
+        return o.get_config()
+    raise TypeError
 
 
 class Store(ABC):
@@ -21,6 +46,12 @@ class Store(ABC):
         bytes
         """
         ...
+
+    async def get_metadata(self, key: str) -> Optional[dict[str, Any]]:
+        data = await self.get(key)
+        if data is None:
+            return None
+        return json.loads(data)
 
     @abstractmethod
     async def get_partial_values(
@@ -70,6 +101,10 @@ class Store(ABC):
         value : bytes
         """
         ...
+
+    async def set_metadata(self, key: str, metadata: dict[str, Any]) -> None:
+        data = json.dumps(metadata, default=json_default).encode("utf-8")
+        await self.set(key, data)
 
     @abstractmethod
     async def delete(self, key: str) -> None:

--- a/src/zarr/metadata.py
+++ b/src/zarr/metadata.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, cast, Dict, Iterable, Any
 from dataclasses import dataclass, field
-import json
 import numpy as np
 import numpy.typing as npt
 
@@ -194,23 +193,6 @@ class ArrayMetadata(Metadata):
             fill_value=self.fill_value,
         )
 
-    def to_bytes(self) -> bytes:
-        def _json_convert(o):
-            if isinstance(o, np.dtype):
-                return str(o)
-            if isinstance(o, Enum):
-                return o.name
-            # this serializes numcodecs compressors
-            # todo: implement to_dict for codecs
-            elif hasattr(o, "get_config"):
-                return o.get_config()
-            raise TypeError
-
-        return json.dumps(
-            self.to_dict(),
-            default=_json_convert,
-        ).encode()
-
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ArrayMetadata:
         # check that the zarr_format attribute is correct
@@ -290,17 +272,6 @@ class ArrayV2Metadata(Metadata):
     @property
     def ndim(self) -> int:
         return len(self.shape)
-
-    def to_bytes(self) -> bytes:
-        def _json_convert(o):
-            if isinstance(o, np.dtype):
-                if o.fields is None:
-                    return o.str
-                else:
-                    return o.descr
-            raise TypeError
-
-        return json.dumps(self.to_dict(), default=_json_convert).encode()
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ArrayV2Metadata:

--- a/src/zarr/store/core.py
+++ b/src/zarr/store/core.py
@@ -30,10 +30,16 @@ class StorePath:
     ) -> Optional[BytesLike]:
         return await self.store.get(self.path, byte_range)
 
+    async def get_metadata(self) -> Optional[dict[str, Any]]:
+        return await self.store.get_metadata(self.path)
+
     async def set(self, value: BytesLike, byte_range: Optional[Tuple[int, int]] = None) -> None:
         if byte_range is not None:
             raise NotImplementedError("Store.set does not have partial writes yet")
         await self.store.set(self.path, value)
+
+    async def set_metadata(self, metadata: dict[str, Any]) -> None:
+        await self.store.set_metadata(self.path, metadata)
 
     async def delete(self) -> None:
         await self.store.delete(self.path)

--- a/src/zarr/store/memory.py
+++ b/src/zarr/store/memory.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Optional, MutableMapping, List, Tuple
+from typing import Any, Optional, MutableMapping, List, Tuple
 
 from zarr.common import BytesLike, concurrent_map
 from zarr.abc.store import Store
@@ -14,9 +14,9 @@ class MemoryStore(Store):
     supports_partial_writes: bool = True
     supports_listing: bool = True
 
-    _store_dict: MutableMapping[str, bytes]
+    _store_dict: MutableMapping[str, bytes | dict[str, Any]]
 
-    def __init__(self, store_dict: Optional[MutableMapping[str, bytes]] = None):
+    def __init__(self, store_dict: Optional[MutableMapping[str, bytes | dict[str, Any]]] = None):
         self._store_dict = store_dict or {}
 
     def __str__(self) -> str:
@@ -31,8 +31,17 @@ class MemoryStore(Store):
         assert isinstance(key, str)
         try:
             value = self._store_dict[key]
+            assert isinstance(value, (bytes, bytearray, memoryview))
             if byte_range is not None:
                 value = value[byte_range[0] : byte_range[1]]
+            return value
+        except KeyError:
+            return None
+
+    async def get_metadata(self, key: str) -> Optional[dict[str, Any]]:
+        try:
+            value = self._store_dict[key]
+            assert isinstance(value, dict)
             return value
         except KeyError:
             return None
@@ -54,11 +63,16 @@ class MemoryStore(Store):
             raise TypeError(f"Expected BytesLike. Got {type(value)}.")
 
         if byte_range is not None:
-            buf = bytearray(self._store_dict[key])
+            val = self._store_dict[key]
+            assert isinstance(val, (bytes, bytearray, memoryview))
+            buf = bytearray(val)
             buf[byte_range[0] : byte_range[1]] = value
             self._store_dict[key] = buf
         else:
             self._store_dict[key] = value
+
+    async def set_metadata(self, key: str, metadata: dict[str, Any]) -> None:
+        self._store_dict[key] = metadata
 
     async def delete(self, key: str) -> None:
         try:

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -28,6 +28,16 @@ class StoreTests:
         await store.set(key, data)
         assert await store.get(key) == data
 
+    async def test_set_get_metadata_roundtrip(self, store: Store) -> None:
+        meta = {
+            "zarr_version": "17",
+            "bar": 1,
+            "baz": [1, 2, 3],
+            "qux": {"a": 1, "b": 2, "c": [3, 4, 5]},
+        }
+        await store.set_metadata("foo/zarr.json", meta)
+        assert await store.get_metadata("foo/zarr.json") == meta
+
     @pytest.mark.parametrize("key", ["foo/c/0"])
     @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
     async def test_get_partial_values(self, store: Store, key: str, data: bytes) -> None:


### PR DESCRIPTION
This PR takes adds the option for stores to store metadata in whatever container makes sense for the store. 

- adds `Store.set_metadata` and `Store.get_metadata` methods
  - moves json serialization/deserialization to Store ABC.
  - these methods can be overridden by stores that don't want to store metadata as JSON. For now, I've illustrated this with the `MemoryStore` that now keeps metadata objects as plain dictionaries.


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
