### PR TITLE
Fix some untyped calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,11 +203,6 @@ module = [
     "zarr.v2.*",
     "zarr.array_v2",
     "zarr.array",
-    "zarr.common",
-    "zarr.store.local",
-    "zarr.codecs.blosc",
-    "zarr.codecs.gzip",
-    "zarr.codecs.zstd",
 ]
 disallow_untyped_calls = false
 

--- a/src/zarr/common.py
+++ b/src/zarr/common.py
@@ -41,14 +41,14 @@ async def concurrent_map(
     else:
         sem = asyncio.Semaphore(limit)
 
-        async def run(item):
+        async def run(item: Tuple[Any]) -> V:
             async with sem:
                 return await func(*item)
 
         return await asyncio.gather(*[asyncio.ensure_future(run(item)) for item in items])
 
 
-async def to_thread(func, /, *args, **kwargs):
+async def to_thread(func: Callable[..., V], /, *args: Any, **kwargs: Any) -> V:
     loop = asyncio.get_running_loop()
     ctx = contextvars.copy_context()
     func_call = functools.partial(ctx.run, func, *args, **kwargs)


### PR DESCRIPTION
This fixes some untyped functions in `zarr.common`, which in turn fixes most of the untyped calls that now don't have to be ignored in `pyproject.toml`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
