### PR TITLE
Fix a regression with scalar indexing due to #1800

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -31,6 +31,8 @@ Docs
 
 Maintenance
 ~~~~~~~~~~~
+* Fix a regression when indexing out a single value from arrays with size-1 chunks.
+  By :user:`Deepak Cherian <dcherian>`
 
 Deprecations
 ~~~~~~~~~~~~

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -31,8 +31,8 @@ Docs
 
 Maintenance
 ~~~~~~~~~~~
-* Fix a regression when indexing out a single value from arrays with size-1 chunks.
-  By :user:`Deepak Cherian <dcherian>`
+* Fix a regression when getting or setting a single value from arrays with size-1 chunks.
+  By :user:`Deepak Cherian <dcherian>` :issue:`1874`
 
 Deprecations
 ~~~~~~~~~~~~

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2283,8 +2283,11 @@ class Array:
                 chunk.fill(value)
 
             else:
-                # ensure array is contiguous
-                chunk = value.astype(self._dtype, order=self._order, copy=False)
+                if not isinstance(value, np.ndarray):
+                    chunk = np.asarray(value, dtype=self._dtype, order=self._order)
+                else:
+                    # ensure array is contiguous
+                    chunk = value.astype(self._dtype, order=self._order, copy=False)
 
         else:
             # partially replace the contents of this chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2283,11 +2283,8 @@ class Array:
                 chunk.fill(value)
 
             else:
-                if not isinstance(value, np.ndarray):
-                    chunk = np.asarray(value, dtype=self._dtype, order=self._order)
-                else:
-                    # ensure array is contiguous
-                    chunk = value.astype(self._dtype, order=self._order, copy=False)
+                # ensure array is contiguous
+                chunk = value.astype(self._dtype, order=self._order, copy=False)
 
         else:
             # partially replace the contents of this chunk

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -2030,7 +2030,9 @@ class Array:
             and not self._filters
             and self._dtype != object
         ):
-            dest = out[out_selection]
+            # For 0D arrays out_selection = () and out[out_selection] is a scalar
+            # Avoid that
+            dest = out[out_selection] if out_selection else out
             # Assume that array-like objects that doesn't have a
             # `writeable` flag is writable.
             dest_is_writable = getattr(dest, "writeable", True)

--- a/zarr/indexing.py
+++ b/zarr/indexing.py
@@ -52,6 +52,8 @@ def is_scalar(value, dtype):
         return True
     if isinstance(value, tuple) and dtype.names and len(value) == len(dtype.names):
         return True
+    if dtype.kind == "O" and not isinstance(value, np.ndarray):
+        return True
     return False
 
 

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3157,3 +3157,13 @@ def test_issue_1279(tmpdir):
 
     written_data = ds_reopened[:]
     assert_array_equal(data, written_data)
+
+
+def test_scalar_indexing():
+    store = zarr.KVStore({})
+
+    store["a"] = zarr.create((3,), chunks=(1,), store=store)
+    store["a"][:] = [1, 2, 3]
+
+    assert store["a"][1] == np.array(2.0)
+    assert store["a"][(1,)] == np.array(2.0)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3176,3 +3176,27 @@ def test_scalar_indexing():
 
     store["a"][0] = (-3,)
     assert store["a"][0] == np.array(-3)
+
+
+def test_object_array_indexing():
+    # regression test for #1874
+    from numcodecs import MsgPack
+
+    root = zarr.group()
+    arr = root.create_dataset(
+        name="my_dataset",
+        shape=0,
+        dtype=object,
+        object_codec=MsgPack(),
+    )
+    new_items = [
+        ["A", 1],
+        ["B", 2, "hello"],
+    ]
+    arr_add = np.empty(len(new_items), dtype=object)
+    arr_add[:] = new_items
+    arr.append(arr_add)
+
+    elem = ["C", 3]
+    arr[0] = elem
+    assert arr[0] == elem

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3170,3 +3170,9 @@ def test_scalar_indexing():
 
     store["a"][0] = [-1]
     assert store["a"][0] == np.array(-1)
+
+    store["a"][0] = -2
+    assert store["a"][0] == np.array(-2)
+
+    store["a"][0] = (-3,)
+    assert store["a"][0] == np.array(-3)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3167,3 +3167,6 @@ def test_scalar_indexing():
 
     assert store["a"][1] == np.array(2.0)
     assert store["a"][(1,)] == np.array(2.0)
+
+    store["a"][0] = [-1]
+    assert store["a"][0] == np.array(-1)

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3197,6 +3197,12 @@ def test_object_array_indexing():
     arr_add[:] = new_items
     arr.append(arr_add)
 
+    # heterogeneous elements
     elem = ["C", 3]
     arr[0] = elem
     assert arr[0] == elem
+
+    # homogeneous elements
+    elem = [1, 3]
+    arr[1] = elem
+    assert arr[1] == elem

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3168,13 +3168,13 @@ def test_scalar_indexing():
     assert store["a"][1] == np.array(2.0)
     assert store["a"][(1,)] == np.array(2.0)
 
-    store["a"][0] = [-1]
+    store["a"][slice(1)] = [-1]
     assert store["a"][0] == np.array(-1)
 
     store["a"][0] = -2
     assert store["a"][0] == np.array(-2)
 
-    store["a"][0] = (-3,)
+    store["a"][slice(1)] = (-3,)
     assert store["a"][0] == np.array(-3)
 
 


### PR DESCRIPTION
Fixes a regression in indexing out scalars from size-1 chunks.

TODO:
* [x] Closes #1874, Closes #1883
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
