### PR TITLE
Revert "Fix `is_total_slice` for size-1 dimensions (#1800)"

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,6 +25,9 @@ Unreleased
 
 Enhancements
 ~~~~~~~~~~~~
+* Revert "Performance improvement for reading and writing chunks if any of the dimensions is size 1."
+  By :user:`Deepak Cherian <dcherian>`. :issue:`1874`.
+
 
 Docs
 ~~~~

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -89,15 +89,6 @@ def test_is_total_slice():
     assert not is_total_slice((slice(0, 50), slice(0, 50)), (100, 100))
     assert not is_total_slice((slice(0, 100, 2), slice(0, 100)), (100, 100))
 
-    # size-1 dimension edge-case
-    # https://github.com/zarr-developers/zarr-python/issues/1730
-    assert is_total_slice((slice(0, 1),), (1,))
-    # this is an equivalent selection (without a slice)
-    assert is_total_slice((0,), (1,))
-    # same for multidimensional selection
-    assert is_total_slice((slice(0, 1), slice(0, 10)), (1, 10))
-    assert is_total_slice((0, slice(0, 10)), (1, 10))
-
     with pytest.raises(TypeError):
         is_total_slice("foo", (100,))
 

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -234,17 +234,8 @@ def is_total_slice(item, shape: Tuple[int]) -> bool:
     if isinstance(item, tuple):
         return all(
             (
-                (
-                    isinstance(it, slice)
-                    and (
-                        (it == slice(None))
-                        or ((it.stop - it.start == sh) and (it.step in [1, None]))
-                    )
-                )
-                # The only scalar edge case, indexing with int 0 along a size-1 dimension
-                # is identical to a total slice
-                # https://github.com/zarr-developers/zarr-python/issues/1730
-                or (isinstance(it, int) and it == 0 and sh == 1)
+                isinstance(it, slice)
+                and ((it == slice(None)) or ((it.stop - it.start == sh) and (it.step in [1, None])))
             )
             for it, sh in zip(item, shape)
         )


### PR DESCRIPTION
This reverts commit 9d046ea.

Closes #1874 by reverting #1800

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
