### PR TITLE
Remove some unused mypy overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,6 @@ check_untyped_defs = false
 [[tool.mypy.overrides]]
 module = [
     "zarr.v2.*",
-    "zarr.abc.codec",
     "zarr.array_v2",
 ]
 disallow_any_generics = false
@@ -239,7 +238,6 @@ module = [
     "zarr.v2.*",
     "zarr.array_v2",
     "zarr.array",
-    "zarr.common",
     "zarr.group",
     "zarr.metadata"
 ]


### PR DESCRIPTION
These files must have been fixed at some point without the mypy overrides being removed, so remove them.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
