### PR TITLE
Fix list of packages in mypy pre-commit environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,16 @@ repos:
       - id: mypy
         files: src
         additional_dependencies:
-          - types-redis
-          - types-setuptools
-          - pytest
-          - numpy
+          # Package dependencies
+          - asciitree
+          - crc32c
+          - donfig
+          - fasteners
           - numcodecs
+          - numpy
+          - typing_extensions
           - zstandard
+          # Tests
+          - pytest
+          # Zarr v2
+          - types-redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ maintainers = [
     { name = "Ryan Abernathey" }
 ]
 requires-python = ">=3.10"
+# If you add a new dependency here, please also add it to .pre-commit-config.yml
 dependencies = [
     'asciitree',
     'numpy>=1.24',


### PR DESCRIPTION
This makes sure the list of dependencies in the mypy pre-commit environment mirrors the dependencies of the package (+ any dependencies needed for tests). I also had to make a small fix in `zstd`, which I think is correct?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
