### PR TITLE
Enable extra mypy error codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ disallow_untyped_defs = true
 no_implicit_reexport = true
 
 
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,7 @@ disallow_untyped_defs = true
 no_implicit_reexport = true
 
 
+
 [[tool.mypy.overrides]]
 module = [
     "zarr.v2.*",

--- a/src/zarr/buffer.py
+++ b/src/zarr/buffer.py
@@ -79,7 +79,7 @@ class NDArrayLike(Protocol):
 
     def all(self) -> bool: ...
 
-    def __eq__(self, other: Any) -> Self:  # type: ignore
+    def __eq__(self, other: Any) -> Self:  # type: ignore[explicit-override, override]
         """Element-wise equal
 
         Notice

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -205,7 +205,7 @@ class _ShardBuilder(_ShardReader, ShardMutableMapping):
     ) -> _ShardBuilder:
         obj = cls.create_empty(chunks_per_shard)
         for chunk_coords in morton_order_iter(chunks_per_shard):
-            if tombstones is not None and chunk_coords in tombstones:
+            if chunk_coords in tombstones:
                 continue
             for shard_dict in shard_dicts:
                 maybe_value = shard_dict.get(chunk_coords, None)

--- a/src/zarr/indexing.py
+++ b/src/zarr/indexing.py
@@ -199,11 +199,8 @@ def is_total_slice(item: Selection, shape: ChunkCoords) -> bool:
     if isinstance(item, tuple):
         return all(
             (
-                isinstance(dim_sel, slice)
-                and (
-                    (dim_sel == slice(None))
-                    or ((dim_sel.stop - dim_sel.start == dim_len) and (dim_sel.step in [1, None]))
-                )
+                (dim_sel == slice(None))
+                or ((dim_sel.stop - dim_sel.start == dim_len) and (dim_sel.step in [1, None]))
             )
             for dim_sel, dim_len in zip(item, shape, strict=False)
         )

--- a/src/zarr/metadata.py
+++ b/src/zarr/metadata.py
@@ -432,10 +432,11 @@ class ArrayV2Metadata(ArrayMetadata):
 def parse_dimension_names(data: None | Iterable[str]) -> tuple[str, ...] | None:
     if data is None:
         return data
-    if isinstance(data, Iterable) and all([isinstance(x, str) for x in data]):
+    elif all([isinstance(x, str) for x in data]):
         return tuple(data)
-    msg = f"Expected either None or a iterable of str, got {type(data)}"
-    raise TypeError(msg)
+    else:
+        msg = f"Expected either None or a iterable of str, got {type(data)}"
+        raise TypeError(msg)
 
 
 # todo: real validation

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -47,7 +47,7 @@ class StoreTests(Generic[S]):
         assert store.writeable
 
         with pytest.raises(AttributeError):
-            store.mode = "w"  # type: ignore
+            store.mode = "w"  # type: ignore[misc]
 
         # read-only
         kwargs = {**store_kwargs, "mode": "r"}


### PR DESCRIPTION
Enable extra mypy error codes. Another part of https://github.com/zarr-developers/zarr-python/issues/1783

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
