### PR TITLE
wip

### DIFF
--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -3,10 +3,21 @@ from collections.abc import AsyncGenerator
 from typing import Protocol, runtime_checkable
 
 from zarr.buffer import Buffer
-from zarr.common import BytesLike
+from zarr.common import BytesLike, OpenMode
 
 
 class Store(ABC):
+    _mode: OpenMode
+
+    @property
+    def mode(self) -> OpenMode:
+        """Access mode of the store."""
+        return self._mode
+
+    def _check_writable(self) -> None:
+        if self.mode not in ("a", "w", "w-"):
+            ValueError("store mode does not support writing")
+
     @abstractmethod
     async def get(
         self, key: str, byte_range: tuple[int, int | None] | None = None
@@ -146,6 +157,10 @@ class Store(ABC):
         AsyncGenerator[str, None]
         """
         ...
+
+    def close(self) -> None:  # noqa: B027
+        """Close the store."""
+        pass
 
 
 @runtime_checkable

--- a/src/zarr/common.py
+++ b/src/zarr/common.py
@@ -27,6 +27,7 @@ SliceSelection = tuple[slice, ...]
 Selection = slice | SliceSelection
 ZarrFormat = Literal[2, 3]
 JSON = None | str | int | float | Enum | dict[str, "JSON"] | list["JSON"] | tuple["JSON", ...]
+OpenMode = Literal["r", "r+", "a", "w", "w-"]
 
 
 def product(tup: ChunkCoords) -> int:

--- a/src/zarr/store/core.py
+++ b/src/zarr/store/core.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from zarr.abc.store import Store
 from zarr.buffer import Buffer
+from zarr.common import OpenMode
 from zarr.store.local import LocalStore
 
 
@@ -60,11 +61,16 @@ class StorePath:
 StoreLike = Store | StorePath | Path | str
 
 
-def make_store_path(store_like: StoreLike) -> StorePath:
+def make_store_path(store_like: StoreLike, *, mode: OpenMode | None = None) -> StorePath:
     if isinstance(store_like, StorePath):
+        if mode is not None:
+            assert mode == store_like.store.mode
         return store_like
     elif isinstance(store_like, Store):
+        if mode is not None:
+            assert mode == store_like.mode
         return StorePath(store_like)
     elif isinstance(store_like, str):
-        return StorePath(LocalStore(Path(store_like)))
+        assert mode is not None
+        return StorePath(LocalStore(Path(store_like), mode=mode))
     raise TypeError


### PR DESCRIPTION
This adds a new required attribute/property to the store API (`Store.mode`). Enforcing read/write permissions at the store is a much cleaner way of managing access than at the Group/Array level (as it is done in v2). I haven't pushed any test changes yet (waiting on #1900) but those will come next.

Xref: https://github.com/zarr-developers/zarr-python/discussions/1686#discussioncomment-8620796
Toward #1755 

Design note: Think of this as the MVP, with the main focus on the `Store.mode` property and the most basic functionality. I think we can continue to explore how to help stores enforce permissions (e.g. via a decorator or something else) later.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
