### PR TITLE
JSON -> dict[str, JSON]

### DIFF
--- a/src/zarr/abc/metadata.py
+++ b/src/zarr/abc/metadata.py
@@ -13,7 +13,7 @@ from zarr.common import JSON
 
 @dataclass(frozen=True)
 class Metadata:
-    def to_dict(self) -> JSON:
+    def to_dict(self) -> dict[str, JSON]:
         """
         Recursively serialize this model to a dictionary.
         This method inspects the fields of self and calls `x.to_dict()` for any fields that

--- a/src/zarr/codecs/pipeline.py
+++ b/src/zarr/codecs/pipeline.py
@@ -84,7 +84,7 @@ class BatchedCodecPipeline(CodecPipeline):
                 out.append(get_codec_class(name_parsed).from_dict(c))  # type: ignore[arg-type]
         return cls.from_list(out, batch_size=batch_size)
 
-    def to_dict(self) -> JSON:
+    def to_dict(self) -> dict[str, JSON]:
         return [c.to_dict() for c in self]
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Self:

--- a/src/zarr/codecs/pipeline.py
+++ b/src/zarr/codecs/pipeline.py
@@ -69,7 +69,7 @@ class BatchedCodecPipeline(CodecPipeline):
     batch_size: int
 
     @classmethod
-    def from_dict(cls, data: Iterable[JSON | Codec], *, batch_size: int | None = None) -> Self:
+    def from_dict(cls, data: dict[str, JSON | Codec], *, batch_size: int | None = None) -> Self:
         out: list[Codec] = []
         if not isinstance(data, Iterable):
             raise TypeError(f"Expected iterable, got {type(data)}")

--- a/src/zarr/common.py
+++ b/src/zarr/common.py
@@ -116,7 +116,7 @@ def parse_name(data: JSON, expected: str | None = None) -> str:
         raise TypeError(f"Expected a string, got an instance of {type(data)}.")
 
 
-def parse_configuration(data: JSON) -> JSON:
+def parse_configuration(data: JSON) -> dict[str, JSON]:
     if not isinstance(data, dict):
         raise TypeError(f"Expected dict, got {type(data)}")
     return data

--- a/src/zarr/metadata.py
+++ b/src/zarr/metadata.py
@@ -394,7 +394,7 @@ class ArrayV2Metadata(ArrayMetadata):
         _ = parse_zarr_format_v2(data.pop("zarr_format"))
         return cls(**data)
 
-    def to_dict(self) -> JSON:
+    def to_dict(self) -> dict[str, JSON]:
         zarray_dict = super().to_dict()
 
         assert isinstance(zarray_dict, dict)


### PR DESCRIPTION
Some functions that return `dict[str, JSON]` were mistakenly annotated as returning `JSON`. 

One wrinkle to this PR is the `BatchedCodecPipeline` class, where `from_dict` takes a list, and `to_dict` returns a list. In this PR, I annotated those methods as if they worked with dicts, which doesn't match the current runtime behavior. I think either the method name or the return type should change here, but I'm not sure which one. @normanrz any ideas?