### PR TITLE
Add zstd to old V3 supported codecs

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -32,6 +32,9 @@ Docs
 Maintenance
 ~~~~~~~~~~~
 
+* Add Zstd codec to old V3 code path.
+  By :user:`Ryan Abernathey <rabernat>` 
+
 Deprecations
 ~~~~~~~~~~~~
 

--- a/zarr/codecs.py
+++ b/zarr/codecs.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 from numcodecs import *
-from numcodecs import get_codec, Blosc, Pickle, Zlib, Delta, AsType, BZ2
+from numcodecs import get_codec, Blosc, Pickle, Zlib, Zstd, Delta, AsType, BZ2
 from numcodecs.registry import codec_registry

--- a/zarr/meta.py
+++ b/zarr/meta.py
@@ -414,6 +414,8 @@ class Metadata3(Metadata2):
             uri = uri + "lz4/1.0"
         elif isinstance(codec, numcodecs.LZMA):
             uri = uri + "lzma/1.0"
+        elif isinstance(codec, numcodecs.Zstd):
+            uri = uri + "zstd/1.0"
         meta = {
             "codec": uri,
             "configuration": config,
@@ -439,6 +441,8 @@ class Metadata3(Metadata2):
             conf["id"] = "lz4"
         elif meta["codec"].startswith(uri + "lzma/"):
             conf["id"] = "lzma"
+        elif meta["codec"].startswith(uri + "zstd/"):
+            conf["id"] = "zstd"
         else:
             raise NotImplementedError
 

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -270,10 +270,10 @@ def test_encode_decode_array_dtype_shape():
 
 @pytest.mark.parametrize("cname", ["zlib", "zstd"])
 def test_encode_decode_array_dtype_shape_v3(cname):
-    if cname=="zlib":
-        compressor=Zlib(1)
-    elif cname=="zstd":
-        compressor=Zstd(1)
+    if cname == "zlib":
+        compressor = Zlib(1)
+    elif cname == "zstd":
+        compressor = Zstd(1)
     meta = dict(
         shape=(100,),
         chunk_grid=dict(type="regular", chunk_shape=(10,), separator=("/")),
@@ -283,7 +283,8 @@ def test_encode_decode_array_dtype_shape_v3(cname):
         chunk_memory_layout="C",
     )
 
-    meta_json = """{
+    meta_json = (
+        """{
         "attributes": {},
         "chunk_grid": {
             "chunk_shape": [10],
@@ -292,9 +293,11 @@ def test_encode_decode_array_dtype_shape_v3(cname):
         },
         "chunk_memory_layout": "C",
         "compressor": {
-        """ + f"""
+        """
+        + f"""
         "codec": "https://purl.org/zarr/spec/codec/{cname}/1.0",
-        """ + """
+        """
+        + """
             "configuration": {
                 "level": 1
             }
@@ -304,6 +307,7 @@ def test_encode_decode_array_dtype_shape_v3(cname):
         "fill_value": null,
         "shape": [100, 10, 10 ]
     }"""
+    )
 
     # test encoding
     meta_enc = Metadata3.encode_array_metadata(meta)

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -315,7 +315,7 @@ def test_encode_decode_array_dtype_shape_v3():
     assert "filters" not in meta_dec
 
 
-@pytest.mark.parametrize("comp_id", ["gzip", "zlib", "blosc", "bz2", "lz4", "lzma"])
+@pytest.mark.parametrize("comp_id", ["gzip", "zlib", "blosc", "bz2", "lz4", "lzma", "zstd"])
 def test_decode_metadata_implicit_compressor_config_v3(comp_id):
     meta = {
         "attributes": {},


### PR DESCRIPTION
This adds `zstd` to the list of codecs supported by the old V3 code path. This is essentially a backport to support existing data that was already written this way.

TODO:
* [x] Add unit tests and/or doctests in docstrings
*  ~Add docstrings and API docs for any new/modified user-facing classes and functions~
*  ~New/modified features documented in docs/tutorial.rst~
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
