### PR TITLE
doc: update release notes for 2.18.2

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -18,25 +18,13 @@ Release notes
    See `GH1777 <https://github.com/zarr-developers/zarr-python/issues/1777>`_ for more details on the upcoming
    3.0 release.
 
-.. _unreleased:
-
-Unreleased
-----------
+.. _release_2.18.2:
 
 Enhancements
 ~~~~~~~~~~~~
 
-Docs
-~~~~
-
-Maintenance
-~~~~~~~~~~~
-
 * Add Zstd codec to old V3 code path.
   By :user:`Ryan Abernathey <rabernat>` 
-
-Deprecations
-~~~~~~~~~~~~
 
 .. _release_2.18.1:
 


### PR DESCRIPTION
Release notes for a small patch update fixing an issue with the experimental v3 compressor codepath.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
