### PR TITLE
Run sphinx directly on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,15 +1,19 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
-  commands:
-    - pip install hatch
-    - hatch run docs:rtd
 
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
 formats: all
+
+python:
+   install:
+   - method: pip
+     path: .
+     extra_requirements:
+        - docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,7 @@ list-env = "pip list"
 features = ['docs']
 
 [tool.hatch.envs.docs.scripts]
-build = "sphinx-build docs/ docs/_build/"
-rtd = "sphinx-build docs/ _readthedocs/html/"
+build = "cd docs && make html"
 serve = "sphinx-autobuild docs docs/_build --ignore 'docs/_autoapi/**/*' --host 0.0.0.0"
 
 [tool.ruff]


### PR DESCRIPTION
In https://github.com/zarr-developers/zarr-python/pull/1918 I noticed that errors on the doc build are not failing the readthedocs build. This is because sphinx runs `hatch run docs:rtd`, which in turn runs `sphinx-build` with no options, which does not fail on warnings.

Instead I think it's better to let readthedocs manage calling sphinx itself, and manage dependencies itself too for caching reasons. This allows it to use the configuration options that we define in the `Makefile`, which is the only way to configure sphinx to error on warnings.

I also updated the `hatch run docs:build` script to use `make html`, so it also catches sphinx warnings and turn them into errors.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
