### PR TITLE
Enable warn_unreachable for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,7 @@ ignore_missing_imports = true
 namespace_packages = false
 
 strict = true
-
+warn_unreachable = true
 
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 

--- a/src/zarr/codecs/_v2.py
+++ b/src/zarr/codecs/_v2.py
@@ -21,9 +21,6 @@ class V2Compressor(ArrayBytesCodec):
         chunk_bytes: Buffer,
         chunk_spec: ArraySpec,
     ) -> NDBuffer:
-        if chunk_bytes is None:
-            return None
-
         if self.compressor is not None:
             compressor = numcodecs.get_codec(self.compressor)
             chunk_numpy_array = ensure_ndarray(

--- a/src/zarr/codecs/blosc.py
+++ b/src/zarr/codecs/blosc.py
@@ -77,10 +77,10 @@ def parse_blocksize(data: JSON) -> int:
 class BloscCodec(BytesBytesCodec):
     is_fixed_size = False
 
-    typesize: int
+    typesize: int | None
     cname: BloscCname = BloscCname.zstd
     clevel: int = 5
-    shuffle: BloscShuffle = BloscShuffle.noshuffle
+    shuffle: BloscShuffle | None = BloscShuffle.noshuffle
     blocksize: int = 0
 
     def __init__(

--- a/src/zarr/store/local.py
+++ b/src/zarr/store/local.py
@@ -120,9 +120,9 @@ class LocalStore(Store):
     async def set(self, key: str, value: Buffer) -> None:
         self._check_writable()
         assert isinstance(key, str)
-        if isinstance(value, bytes | bytearray):
+        if isinstance(value, bytes | bytearray):  # type:ignore[unreachable]
             # TODO: to support the v2 tests, we convert bytes to Buffer here
-            value = Buffer.from_bytes(value)
+            value = Buffer.from_bytes(value)  # type:ignore[unreachable]
         if not isinstance(value, Buffer):
             raise TypeError("LocalStore.set(): `value` must a Buffer instance")
         path = self.root / key
@@ -134,10 +134,7 @@ class LocalStore(Store):
         for key, start, value in key_start_values:
             assert isinstance(key, str)
             path = self.root / key
-            if start is not None:
-                args.append((_put, path, value, start))
-            else:
-                args.append((_put, path, value))
+            args.append((_put, path, value, start))
         await concurrent_map(args, to_thread, limit=None)  # TODO: fix limit
 
     async def delete(self, key: str) -> None:

--- a/src/zarr/store/memory.py
+++ b/src/zarr/store/memory.py
@@ -52,9 +52,9 @@ class MemoryStore(Store):
     async def set(self, key: str, value: Buffer, byte_range: tuple[int, int] | None = None) -> None:
         self._check_writable()
         assert isinstance(key, str)
-        if isinstance(value, bytes | bytearray):
+        if isinstance(value, bytes | bytearray):  # type:ignore[unreachable]
             # TODO: to support the v2 tests, we convert bytes to Buffer here
-            value = Buffer.from_bytes(value)
+            value = Buffer.from_bytes(value)  # type:ignore[unreachable]
         if not isinstance(value, Buffer):
             raise TypeError(f"Expected Buffer. Got {type(value)}.")
 


### PR DESCRIPTION
One of the last parts of https://github.com/zarr-developers/zarr-python/issues/1783, a few simple fixes and the ignores I put in because it looks like those code paths will go when v2 is completely gone anyway?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
