### PR TITLE
narrow the type of drop_axes to just tuple[int, ...]

### DIFF
--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -345,7 +345,7 @@ class CodecPipeline(Metadata):
         self,
         batch_info: Iterable[tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple]],
         out: NDBuffer,
-        drop_axes: tuple[int, ...] | None = None,
+        drop_axes: tuple[int, ...] = (),
     ) -> None:
         """Reads chunk data from the store, decodes it and writes it into an output array.
         Partial decoding may be utilized if the codecs and stores support it.
@@ -367,7 +367,7 @@ class CodecPipeline(Metadata):
         self,
         batch_info: Iterable[tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]],
         value: NDBuffer,
-        drop_axes: tuple[int, ...] | None = None,
+        drop_axes: tuple[int, ...] = (),
     ) -> None:
         """Encodes chunk data and writes it to the store.
         Merges with existing chunk data by reading first, if necessary.

--- a/src/zarr/indexing.py
+++ b/src/zarr/indexing.py
@@ -88,7 +88,7 @@ def err_too_many_indices(selection: Any, shape: ChunkCoords) -> None:
 @runtime_checkable
 class Indexer(Protocol):
     shape: ChunkCoords
-    drop_axes: ChunkCoords | None
+    drop_axes: ChunkCoords
 
     def __iter__(self) -> Iterator[ChunkProjection]: ...
 
@@ -435,7 +435,7 @@ def is_basic_selection(selection: Any) -> TypeGuard[BasicSelection]:
 class BasicIndexer(Indexer):
     dim_indexers: list[IntDimIndexer | SliceDimIndexer]
     shape: ChunkCoords
-    drop_axes: None
+    drop_axes: ChunkCoords
 
     def __init__(
         self,
@@ -473,7 +473,7 @@ class BasicIndexer(Indexer):
             "shape",
             tuple(s.nitems for s in self.dim_indexers if not isinstance(s, IntDimIndexer)),
         )
-        object.__setattr__(self, "drop_axes", None)
+        object.__setattr__(self, "drop_axes", ())
 
     def __iter__(self) -> Iterator[ChunkProjection]:
         for dim_projections in itertools.product(*self.dim_indexers):
@@ -749,7 +749,7 @@ class OrthogonalIndexer(Indexer):
     shape: ChunkCoords
     chunk_shape: ChunkCoords
     is_advanced: bool
-    drop_axes: tuple[int, ...] | None
+    drop_axes: tuple[int, ...]
 
     def __init__(self, selection: Selection, shape: ChunkCoords, chunk_grid: ChunkGrid):
         chunk_shape = get_chunk_shape(chunk_grid)
@@ -798,7 +798,7 @@ class OrthogonalIndexer(Indexer):
                 if isinstance(dim_indexer, IntDimIndexer)
             )
         else:
-            drop_axes = None
+            drop_axes = ()
 
         object.__setattr__(self, "dim_indexers", dim_indexers)
         object.__setattr__(self, "shape", shape)
@@ -856,7 +856,7 @@ class OIndex:
 class BlockIndexer(Indexer):
     dim_indexers: list[SliceDimIndexer]
     shape: ChunkCoords
-    drop_axes: None
+    drop_axes: ChunkCoords
 
     def __init__(self, selection: BlockSelection, shape: ChunkCoords, chunk_grid: ChunkGrid):
         chunk_shape = get_chunk_shape(chunk_grid)
@@ -920,7 +920,7 @@ class BlockIndexer(Indexer):
 
         object.__setattr__(self, "dim_indexers", dim_indexers)
         object.__setattr__(self, "shape", shape)
-        object.__setattr__(self, "drop_axes", None)
+        object.__setattr__(self, "drop_axes", ())
 
     def __iter__(self) -> Iterator[ChunkProjection]:
         for dim_projections in itertools.product(*self.dim_indexers):
@@ -974,7 +974,7 @@ class CoordinateIndexer(Indexer):
     chunk_mixs: tuple[npt.NDArray[np.intp], ...]
     shape: ChunkCoords
     chunk_shape: ChunkCoords
-    drop_axes: None
+    drop_axes: ChunkCoords
 
     def __init__(self, selection: CoordinateSelection, shape: ChunkCoords, chunk_grid: ChunkGrid):
         chunk_shape = get_chunk_shape(chunk_grid)
@@ -1053,7 +1053,7 @@ class CoordinateIndexer(Indexer):
         object.__setattr__(self, "chunk_mixs", chunk_mixs)
         object.__setattr__(self, "chunk_shape", chunk_shape)
         object.__setattr__(self, "shape", shape)
-        object.__setattr__(self, "drop_axes", None)
+        object.__setattr__(self, "drop_axes", ())
 
     def __iter__(self) -> Iterator[ChunkProjection]:
         # iterate over chunks

--- a/src/zarr/v2/indexing.py
+++ b/src/zarr/v2/indexing.py
@@ -346,7 +346,7 @@ class BasicIndexer:
 
         self.dim_indexers = dim_indexers
         self.shape = tuple(s.nitems for s in self.dim_indexers if not isinstance(s, IntDimIndexer))
-        self.drop_axes = None
+        self.drop_axes = ()
 
     def __iter__(self):
         for dim_projections in itertools.product(*self.dim_indexers):
@@ -625,7 +625,7 @@ class OrthogonalIndexer:
                 if isinstance(dim_indexer, IntDimIndexer)
             )
         else:
-            self.drop_axes = None
+            self.drop_axes = ()
 
     def __iter__(self):
         for dim_projections in itertools.product(*self.dim_indexers):
@@ -724,7 +724,7 @@ class BlockIndexer:
 
         self.dim_indexers = dim_indexers
         self.shape = tuple(s.nitems for s in self.dim_indexers)
-        self.drop_axes = None
+        self.drop_axes = ()
 
     def __iter__(self):
         for dim_projections in itertools.product(*self.dim_indexers):
@@ -823,7 +823,7 @@ class CoordinateIndexer:
         self.selection = selection
         self.sel_sort = sel_sort
         self.shape = selection[0].shape if selection[0].shape else (1,)
-        self.drop_axes = None
+        self.drop_axes = ()
         self.array = array
 
         # precompute number of selected items for each chunk


### PR DESCRIPTION
I think an empty tuple conveys "drop no axes" as effectively as `None`, with less code.