### PR TITLE
Enable and apply ruff rule RUF009

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ extend-select = [
 ignore = [
     "RUF003",
     "RUF005",
-    "RUF009",
     "RUF012",
     "RUF015",
 ]

--- a/src/zarr/metadata.py
+++ b/src/zarr/metadata.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -310,7 +310,7 @@ class ArrayV2Metadata(ArrayMetadata):
     filters: list[dict[str, JSON]] | None = None
     dimension_separator: Literal[".", "/"] = "."
     compressor: dict[str, JSON] | None = None
-    attributes: dict[str, JSON] = cast(dict[str, JSON], field(default_factory=dict))
+    attributes: dict[str, JSON] = field(default_factory=dict)
     zarr_format: Literal[2] = field(init=False, default=2)
 
     def __init__(


### PR DESCRIPTION
I feel the modified code is consistent with the `ArrayV3Metadata` dataclass:
https://github.com/zarr-developers/zarr-python/blob/19365e20522e5d67b0b14698a7c6c953c450c5c6/src/zarr/metadata.py#L167

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
