### PR TITLE
Apply preview ruff rules

### DIFF
--- a/src/zarr/codecs/__init__.py
+++ b/src/zarr/codecs/__init__.py
@@ -11,12 +11,12 @@ from zarr.codecs.zstd import ZstdCodec
 
 __all__ = [
     "BatchedCodecPipeline",
-    "BloscCodec",
     "BloscCname",
+    "BloscCodec",
     "BloscShuffle",
     "BytesCodec",
-    "Endian",
     "Crc32cCodec",
+    "Endian",
     "GzipCodec",
     "ShardingCodec",
     "ShardingCodecIndexLocation",

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -368,7 +368,7 @@ async def test_asyncgroup_update_attributes(
 
 @pytest.mark.parametrize("store", ("local", "memory"), indirect=["store"])
 @pytest.mark.parametrize("zarr_format", (2, 3))
-async def test_group_init(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+def test_group_init(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
     agroup = sync(AsyncGroup.create(store=store, zarr_format=zarr_format))
     group = Group(agroup)
     assert group._async_group == agroup

--- a/tests/v3/test_sync.py
+++ b/tests/v3/test_sync.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
@@ -48,7 +47,7 @@ def test_sync_timeout() -> None:
     duration = 0.002
 
     async def foo() -> None:
-        time.sleep(duration)
+        await asyncio.sleep(duration)
 
     with pytest.raises(asyncio.TimeoutError):
         sync(foo(), timeout=duration / 2)


### PR DESCRIPTION
Fix issues reported by `ruff check --preview`.

I have no experience using [`asyncio`](https://docs.python.org/3/library/asyncio.html), so I am not confident in the [`RUF029`](https://docs.astral.sh/ruff/rules/unused-async/) fixes.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
