### PR TITLE
Add UPath dependency/type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
           - numcodecs
           - numpy
           - typing_extensions
+          - universal-pathlib
           # Tests
           - pytest
           # Zarr v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ extra = [
 ]
 optional = [
     'lmdb',
+    'universal-pathlib',
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes some kwarg typing, and adds `universal-pathlib` to the type checking and as a package dependency.