### PR TITLE
Bump NumPy to 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         numpy-version: ['1.24', '1.26', '2.0']
         dependency-set: ["minimal", "optional"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         numpy-version: ['1.24', '1.26', '2.0']
         dependency-set: ["minimal", "optional"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
-        numpy-version: ['1.24', '1.26', '2.0.0rc1']
+        numpy-version: ['1.24', '1.26', '2.0']
         dependency-set: ["minimal", "optional"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,12 @@ features = ["extra"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11"]
-numpy = ["1.24", "1.26", "2.0.0rc1"]
+numpy = ["1.24", "1.26", "2.0"]
 version = ["minimal"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11"]
-numpy = ["1.24", "1.26", "2.0.0rc1"]
+numpy = ["1.24", "1.26", "2.0"]
 features = ["optional"]
 
 [tool.hatch.envs.test.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,12 +124,12 @@ extra-dependencies = [
 features = ["extra"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.10", "3.11", "3.12"]
 numpy = ["1.24", "1.26", "2.0"]
 version = ["minimal"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.10", "3.11", "3.12"]
 numpy = ["1.24", "1.26", "2.0"]
 features = ["optional"]
 


### PR DESCRIPTION
Now that NumPy 2.0 is out, we should be testing against the latest version.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
