### PR TITLE
Allow 'chunks' as an alias for 'chunk_shape' in array creation

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -646,7 +646,11 @@ async def create(
     if zarr_format == 2 and chunks is None:
         chunks = shape
     if zarr_format == 3 and chunk_shape is None:
-        chunk_shape = shape
+        if chunks is not None:
+            chunk_shape = chunks
+            chunks = None
+        else:
+            chunk_shape = shape
 
     if order is not None:
         warnings.warn(

--- a/tests/v3/test_api.py
+++ b/tests/v3/test_api.py
@@ -5,7 +5,28 @@ from numpy.testing import assert_array_equal
 import zarr
 from zarr import Array, Group
 from zarr.abc.store import Store
-from zarr.api.synchronous import load, open, open_group, save, save_array, save_group
+from zarr.api.synchronous import create, load, open, open_group, save, save_array, save_group
+
+
+def test_create_array(memory_store: Store) -> None:
+    store = memory_store
+
+    # create array
+    z = create(shape=100, store=store)
+    assert isinstance(z, Array)
+    assert z.shape == (100,)
+
+    # create array, overwrite, specify chunk shape
+    z = create(shape=200, chunk_shape=20, store=store, overwrite=True)
+    assert isinstance(z, Array)
+    assert z.shape == (200,)
+    assert z.chunks == (20,)
+
+    # create array, overwrite, specify chunk shape via chunks param
+    z = create(shape=400, chunks=40, store=store, overwrite=True)
+    assert isinstance(z, Array)
+    assert z.shape == (400,)
+    assert z.chunks == (40,)
 
 
 def test_open_array(memory_store: Store) -> None:


### PR DESCRIPTION
This is a compatibility fix for v3.

It should fix #1965 - although I haven't tested it directly.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
