### PR TITLE
Use f-strings instead of legacy interpolation

### DIFF
--- a/src/zarr/v2/hierarchy.py
+++ b/src/zarr/v2/hierarchy.py
@@ -1195,11 +1195,11 @@ class Group(MutableMapping[str, Any]):
             contains_array(self._store, source)
             or contains_group(self._store, source, explicit_only=False)
         ):
-            raise ValueError('The source, "%s", does not exist.' % source)
+            raise ValueError(f'The source, "{source}", does not exist.')
         if contains_array(self._store, dest) or contains_group(
             self._store, dest, explicit_only=False
         ):
-            raise ValueError('The dest, "%s", already exists.' % dest)
+            raise ValueError(f'The dest, "{dest}", already exists.')
 
         # Ensure groups needed for `dest` exist.
         if "/" in dest:


### PR DESCRIPTION
[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
