### PR TITLE
Unnecessary comprehension

### DIFF
--- a/src/zarr/indexing.py
+++ b/src/zarr/indexing.py
@@ -1023,7 +1023,7 @@ class CoordinateIndexer(Indexer):
         # flatten selection
         selection_broadcast = tuple(dim_sel.reshape(-1) for dim_sel in selection_broadcast)
         chunks_multi_index_broadcast = tuple(
-            [dim_chunks.reshape(-1) for dim_chunks in chunks_multi_index_broadcast]
+            dim_chunks.reshape(-1) for dim_chunks in chunks_multi_index_broadcast
         )
 
         # ravel chunk indices

--- a/src/zarr/metadata.py
+++ b/src/zarr/metadata.py
@@ -436,7 +436,7 @@ class ArrayV2Metadata(ArrayMetadata):
 def parse_dimension_names(data: None | Iterable[str]) -> tuple[str, ...] | None:
     if data is None:
         return data
-    elif all([isinstance(x, str) for x in data]):
+    elif all(isinstance(x, str) for x in data):
         return tuple(data)
     else:
         msg = f"Expected either None or a iterable of str, got {type(data)}"


### PR DESCRIPTION
`all` can take a generator.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
