### PR TITLE
Unnecessary comprehension

### DIFF
--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -187,10 +187,7 @@ class ArrayBytesCodecPartialDecodeMixin:
         Iterable[NDBuffer | None]
         """
         return await concurrent_map(
-            [
-                (byte_getter, selection, chunk_spec)
-                for byte_getter, selection, chunk_spec in batch_info
-            ],
+            list(batch_info),
             self._decode_partial_single,
             config.get("async.concurrency"),
         )
@@ -227,10 +224,7 @@ class ArrayBytesCodecPartialEncodeMixin:
             The chunk spec contains information about the chunk.
         """
         await concurrent_map(
-            [
-                (byte_setter, chunk_array, selection, chunk_spec)
-                for byte_setter, chunk_array, selection, chunk_spec in batch_info
-            ],
+            list(batch_info),
             self._encode_partial_single,
             config.get("async.concurrency"),
         )
@@ -402,7 +396,7 @@ async def batching_helper(
     batch_info: Iterable[tuple[CodecInput | None, ArraySpec]],
 ) -> list[CodecOutput | None]:
     return await concurrent_map(
-        [(chunk_array, chunk_spec) for chunk_array, chunk_spec in batch_info],
+        list(batch_info),
         noop_for_none(func),
         config.get("async.concurrency"),
     )


### PR DESCRIPTION
Use `list(...)` instead.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
