### PR TITLE
Fix string interpolation

### DIFF
--- a/src/zarr/store/remote.py
+++ b/src/zarr/store/remote.py
@@ -69,7 +69,7 @@ class RemoteStore(Store):
             self.path = url.path.rstrip("/")
             self._fs = url.fs
         else:
-            raise ValueError("URL not understood, %s", url)
+            raise ValueError(f"URL not understood, {url}")
         self.allowed_exceptions = allowed_exceptions
         # test instantiate file system
         if not self._fs.async_impl:


### PR DESCRIPTION
Fix typo in legacy string interpolation (`,` instead of `%`) by replacing with f-string.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
