### PR TITLE
Autogenerate all API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-docs/api/zarr
+docs/_autoapi
 
 # PyBuilder
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/api/zarr
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -52,6 +52,7 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)/../_autoapi
 
 .PHONY: html
 html:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -4,4 +4,4 @@ API Reference
 .. toctree::
     :maxdepth: 1
 
-    zarr
+    zarr/index

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -4,4 +4,4 @@ API Reference
 .. toctree::
     :maxdepth: 1
 
-    zarr/index
+    ../_autoapi/zarr/index

--- a/docs/api/zarr.rst
+++ b/docs/api/zarr.rst
@@ -1,5 +1,0 @@
-zarr
-====
-
-.. autoapimodule:: zarr
-    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ def autoapi_skip_modules(app: sphinx.application.Sphinx, what: str, name: str, o
     Return True if a module should be skipped in th API docs.
     """
     parts = name.split(".")
-    if what == "module" and any((part.startswith("_") or part == "v2") for part in parts):
+    if what == "module" and (any(part.startswith("_") for part in parts) or "v2" in name or name.startswith("zarr.core")):
         return True
     return False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ autoapi_dirs = ['../src/zarr']
 autoapi_add_toctree_entry = False
 autoapi_generate_api_docs = True
 autoapi_member_order = "groupwise"
-autoapi_root = "api"
+autoapi_root = "_autoapi"
 autoapi_keep_files = True
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,9 +57,10 @@ issues_github_path = "zarr-developers/zarr-python"
 
 autoapi_dirs = ['../src/zarr']
 autoapi_add_toctree_entry = False
-autoapi_generate_api_docs = False
+autoapi_generate_api_docs = True
 autoapi_member_order = "groupwise"
 autoapi_root = "api"
+autoapi_keep_files = True
 
 
 # Add any paths that contain templates here, relative to this directory.
@@ -172,8 +173,19 @@ html_theme_options = {
 html_logo = "_static/logo1.png"
 
 
+def autoapi_skip_modules(app: sphinx.application.Sphinx, what: str, name: str, obj: object, skip: bool, options: dict[str, Any]) -> bool:
+    """
+    Return True if a module should be skipped in th API docs.
+    """
+    parts = name.split("_")
+    if what == "module" and any(part.startswith("_") or part == "v2" for part in parts):
+        return True
+    return False
+
+
 def setup(app: sphinx.application.Sphinx) -> None:
     app.add_css_file("custom.css")
+    app.connect("autoapi-skip-member", autoapi_skip_modules)
 
 
 # The name of an image file (relative to this directory) to use as a favicon of
@@ -339,7 +351,7 @@ texinfo_documents = [
 # use in refs e.g:
 # :ref:`comparison manual <python:comparisons>`
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
+    "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "numcodecs": ("https://numcodecs.readthedocs.io/en/stable/", None),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,7 +177,7 @@ def autoapi_skip_modules(app: sphinx.application.Sphinx, what: str, name: str, o
     """
     Return True if a module should be skipped in th API docs.
     """
-    parts = name.split("_")
+    parts = name.split(".")
     if what == "module" and any((part.startswith("_") or part == "v2") for part in parts):
         return True
     return False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ def autoapi_skip_modules(app: sphinx.application.Sphinx, what: str, name: str, o
     Return True if a module should be skipped in th API docs.
     """
     parts = name.split("_")
-    if what == "module" and any(part.startswith("_") or part == "v2" for part in parts):
+    if what == "module" and any((part.startswith("_") or part == "v2") for part in parts):
         return True
     return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,9 @@ gpu = [
     "cupy-cuda12x",
 ]
 docs = [
-    'sphinx',
+    'sphinx<8',
     'sphinx-autobuild>=2021.3.14',
-    'sphinx-autoapi<3.2',
+    'sphinx-autoapi<3.1',
     'sphinx_design',
     'sphinx-issues',
     'sphinx-copybutton',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ gpu = [
 docs = [
     'sphinx',
     'sphinx-autobuild>=2021.3.14',
-    'sphinx-autoapi',
+    'sphinx-autoapi<3.2',
     'sphinx_design',
     'sphinx-issues',
     'sphinx-copybutton',

--- a/src/zarr/codecs/blosc.py
+++ b/src/zarr/codecs/blosc.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 
 
 class BloscShuffle(Enum):
+    """
+    Enum for shuffle filter used by blosc.
+    """
+
     noshuffle = "noshuffle"
     shuffle = "shuffle"
     bitshuffle = "bitshuffle"
@@ -38,6 +42,10 @@ class BloscShuffle(Enum):
 
 
 class BloscCname(Enum):
+    """
+    Enum for compression library used by blosc.
+    """
+
     lz4 = "lz4"
     lz4hc = "lz4hc"
     blosclz = "blosclz"

--- a/src/zarr/codecs/bytes.py
+++ b/src/zarr/codecs/bytes.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 
 class Endian(Enum):
+    """
+    Enum for endian type used by bytes codec.
+    """
+
     big = "big"
     little = "little"
 

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -60,6 +60,10 @@ ShardMutableMapping = MutableMapping[ChunkCoords, Buffer]
 
 
 class ShardingCodecIndexLocation(Enum):
+    """
+    Enum for index location used by the sharding codec.
+    """
+
     start = "start"
     end = "end"
 

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -68,6 +68,9 @@ if TYPE_CHECKING:
 
     from zarr.abc.codec import Codec, CodecPipeline
 
+# Array and AsyncArray are defined in the base ``zarr`` namespace
+__all__ = ["parse_array_metadata", "create_codec_pipeline"]
+
 
 def parse_array_metadata(data: Any) -> ArrayV2Metadata | ArrayV3Metadata:
     if isinstance(data, ArrayV2Metadata | ArrayV3Metadata):

--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
     from zarr.codecs.bytes import Endian
     from zarr.core.common import BytesLike, ChunkCoords
 
+# Everything here is imported into ``zarr.core.buffer`` namespace.
+__all__: list[str] = []
+
 
 @runtime_checkable
 class ArrayLike(Protocol):

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -559,6 +559,10 @@ class BoolArrayDimIndexer:
 
 
 class Order(Enum):
+    """
+    Enum for indexing order.
+    """
+
     UNKNOWN = 0
     INCREASING = 1
     DECREASING = 2

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -700,7 +700,7 @@ def slice_to_range(s: slice, length: int) -> range:
 
 
 def ix_(selection: Any, shape: ChunkCoords) -> npt.NDArray[np.intp]:
-    """Convert an orthogonal selection to a numpy advanced (fancy) selection, like numpy.ix_
+    """Convert an orthogonal selection to a numpy advanced (fancy) selection, like ``numpy.ix_``
     but with support for slices and single ints."""
 
     # normalisation

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -155,9 +155,12 @@ def basic_indices(draw: st.DrawFn, *, shape: tuple[int], **kwargs):  # type: ign
 
 
 def key_ranges(keys: SearchStrategy = node_names) -> SearchStrategy[list]:
-    """fn to generate key_ranges strategy for get_partial_values()
-    returns list strategy w/ form: [(key, (range_start, range_step)),
-                                    (key, (range_start, range_step)),...]
+    """
+    Funciton to generate key_ranges strategy for get_partial_values()
+    returns list strategy w/ form::
+
+        [(key, (range_start, range_step)),
+         (key, (range_start, range_step)),...]
     """
     byte_ranges = st.tuples(
         st.none() | st.integers(min_value=0), st.none() | st.integers(min_value=0)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -156,7 +156,7 @@ def basic_indices(draw: st.DrawFn, *, shape: tuple[int], **kwargs):  # type: ign
 
 def key_ranges(keys: SearchStrategy = node_names) -> SearchStrategy[list]:
     """
-    Funciton to generate key_ranges strategy for get_partial_values()
+    Function to generate key_ranges strategy for get_partial_values()
     returns list strategy w/ form::
 
         [(key, (range_start, range_step)),

--- a/src/zarr/v2/indexing.py
+++ b/src/zarr/v2/indexing.py
@@ -534,7 +534,7 @@ def slice_to_range(s: slice, l: int):  # noqa: E741
 
 
 def ix_(selection, shape):
-    """Convert an orthogonal selection to a numpy advanced (fancy) selection, like numpy.ix_
+    """Convert an orthogonal selection to a numpy advanced (fancy) selection, like ``numpy.ix_``
     but with support for slices and single ints."""
 
     # normalisation

--- a/src/zarr/v2/meta.py
+++ b/src/zarr/v2/meta.py
@@ -17,8 +17,7 @@ ZARR_FORMAT = 2
 
 # FLOAT_FILLS = {"NaN": np.nan, "Infinity": np.PINF, "-Infinity": np.NINF}
 
-_v3_core_types = set("".join(d) for d in itertools.product("<>", ("u", "i", "f"), ("2", "4", "8")))
-_v3_core_types = {"bool", "i1", "u1"} | _v3_core_types
+_v3_core_types = {"bool", "i1", "u1"} | set("".join(d) for d in itertools.product("<>", ("u", "i", "f"), ("2", "4", "8")))
 
 # The set of complex types allowed ({"<c8", "<c16", ">c8", ">c16"})
 _v3_complex_types = set(f"{end}c{_bytes}" for end, _bytes in itertools.product("<>", ("8", "16")))

--- a/src/zarr/v2/n5.py
+++ b/src/zarr/v2/n5.py
@@ -272,6 +272,7 @@ class N5FSStore(FSStore):
     """Implementation of the N5 format (https://github.com/saalfeldlab/n5)
     using `fsspec`, which allows storage on a variety of filesystems. Based
     on `zarr.N5Store`.
+
     Parameters
     ----------
     path : string


### PR DESCRIPTION
This updates the doc build to automatically generate all API docs. I've set it so any module with a part that starts with "_" is not documented, so that's the way to make a sub-module private.

See https://zarr--2002.org.readthedocs.build/en/2002/_autoapi/zarr/index.html for the API ref in the build of this PR. 

I think it's worth merging this to make sure new additions/removals to the API don't break API docs, and we can bikeshed what's in/out of the public API in a follow up PR.

Fixes https://github.com/zarr-developers/zarr-python/issues/1993.
