### PR TITLE
Bump fsspec version in tests

### DIFF
--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -18,6 +18,6 @@ pytest-cov==5.0.0
 pytest-doctestplus==1.2.1
 pytest-timeout==2.3.1
 h5py==3.11.0
-fsspec==2023.12.2
-s3fs==2023.12.2
+fsspec==2024.6.1
+s3fs==2024.6.1
 moto[server]>=5.0.1


### PR DESCRIPTION
I'm trying to debug https://github.com/zarr-developers/zarr-python/issues/1679 - if we're lucky, there might just be some bad versions of fsspec we need to exclude.