### PR TITLE
Apply and enforce more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ extend-select = [
     "I",   # isort
     "ISC", # flake8-implicit-str-concat
     "PGH", # pygrep-hooks
+    "PYI", # flake8-pyi
     "RSE", # flake8-raise
     "RUF",
     "TCH", # flake8-type-checking
@@ -218,6 +219,7 @@ extend-select = [
     "UP",  # pyupgrade
 ]
 ignore = [
+    "PYI013",
     "RUF005",
     "TRY003",
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,14 +207,15 @@ extend-exclude = [
 
 [tool.ruff.lint]
 extend-select = [
-    "B",  # flake8-bugbear
-    "I",  # isort
-    "ISC",
-    "UP",  # pyupgrade
-    "RSE",
+    "B",   # flake8-bugbear
+    "I",   # isort
+    "ISC", # flake8-implicit-str-concat
+    "PGH", # pygrep-hooks
+    "RSE", # flake8-raise
     "RUF",
     "TCH", # flake8-type-checking
     "TRY", # tryceratops
+    "UP",  # pyupgrade
 ]
 ignore = [
     "RUF005",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,21 @@ extend-select = [
 ignore = [
     "RUF005",
     "TRY003",
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 
 [tool.mypy]

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from asyncio import gather
 from collections.abc import AsyncGenerator, Iterable
+from types import TracebackType
 from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 from typing_extensions import Self
@@ -49,7 +50,12 @@ class Store(ABC):
         """Enter a context manager that will close the store upon exiting."""
         return self
 
-    def __exit__(self, *args: Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         """Close the store."""
         self.close()
 

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -36,7 +36,7 @@ class Store(ABC):
     _mode: AccessMode
     _is_open: bool
 
-    def __init__(self, mode: AccessModeLiteral = "r", *args: Any, **kwargs: Any):
+    def __init__(self, mode: AccessModeLiteral = "r", *args: Any, **kwargs: Any) -> None:
         self._is_open = False
         self._mode = AccessMode.from_literal(mode)
 

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import warnings
-from typing import TYPE_CHECKING, Any, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
     from zarr.abc.codec import Codec
     from zarr.core.buffer import NDArrayLike
     from zarr.core.chunk_key_encodings import ChunkKeyEncoding
+
+    # TODO: this type could use some more thought
+    ArrayLike = AsyncArray | Array | npt.NDArray[Any]
+    PathLike = str
 
 __all__ = [
     "consolidate_metadata",
@@ -52,10 +56,6 @@ __all__ = [
     "zeros",
     "zeros_like",
 ]
-
-# TODO: this type could use some more thought, noqa to avoid "Variable "asynchronous.ArrayLike" is not valid as a type"
-ArrayLike = Union[AsyncArray | Array | npt.NDArray[Any]]  # noqa
-PathLike = str
 
 
 def _get_shape_chunks(a: ArrayLike | Any) -> tuple[ChunkCoords | None, ChunkCoords | None]:

--- a/src/zarr/codecs/transpose.py
+++ b/src/zarr/codecs/transpose.py
@@ -96,16 +96,14 @@ class TransposeCodec(ArrayArrayCodec):
         chunk_spec: ArraySpec,
     ) -> NDBuffer:
         inverse_order = np.argsort(self.order)
-        chunk_array = chunk_array.transpose(inverse_order)
-        return chunk_array
+        return chunk_array.transpose(inverse_order)
 
     async def _encode_single(
         self,
         chunk_array: NDBuffer,
         _chunk_spec: ArraySpec,
     ) -> NDBuffer | None:
-        chunk_array = chunk_array.transpose(self.order)
-        return chunk_array
+        return chunk_array.transpose(self.order)
 
     def compute_encoded_size(self, input_byte_length: int, _chunk_spec: ArraySpec) -> int:
         return input_byte_length

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -294,7 +294,7 @@ class AsyncArray:
         dtype: npt.DTypeLike,
         chunks: ChunkCoords,
         dimension_separator: Literal[".", "/"] | None = None,
-        fill_value: None | int | float = None,
+        fill_value: None | float = None,
         order: Literal["C", "F"] | None = None,
         filters: list[dict[str, JSON]] | None = None,
         compressor: dict[str, JSON] | None = None,

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -110,7 +110,7 @@ class AsyncArray:
         metadata: ArrayMetadata,
         store_path: StorePath,
         order: Literal["C", "F"] | None = None,
-    ):
+    ) -> None:
         metadata_parsed = parse_array_metadata(metadata)
         order_parsed = parse_indexing_order(order or config.get("array.order"))
 
@@ -331,8 +331,7 @@ class AsyncArray:
         data: dict[str, JSON],
     ) -> AsyncArray:
         metadata = parse_array_metadata(data)
-        async_array = cls(metadata=metadata, store_path=store_path)
-        return async_array
+        return cls(metadata=metadata, store_path=store_path)
 
     @classmethod
     async def open(

--- a/src/zarr/core/attributes.py
+++ b/src/zarr/core/attributes.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class Attributes(MutableMapping[str, JSON]):
-    def __init__(self, obj: Array | Group):
+    def __init__(self, obj: Array | Group) -> None:
         # key=".zattrs", read_only=False, cache=True, synchronizer=None
         self._obj = obj
 

--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -93,7 +93,7 @@ class NDArrayLike(Protocol):
 
     def all(self) -> bool: ...
 
-    def __eq__(self, other: Any) -> Self:  # type: ignore[explicit-override, override]
+    def __eq__(self, other: object) -> Self:  # type: ignore[explicit-override, override]
         """Element-wise equal
 
         Notes

--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -136,7 +136,7 @@ class Buffer(ABC):
         array-like object that must be 1-dim, contiguous, and byte dtype.
     """
 
-    def __init__(self, array_like: ArrayLike):
+    def __init__(self, array_like: ArrayLike) -> None:
         if array_like.ndim != 1:
             raise ValueError("array_like: only 1-dim allowed")
         if array_like.dtype != np.dtype("b"):
@@ -313,7 +313,7 @@ class NDBuffer:
         ndarray-like object that is convertible to a regular Numpy array.
     """
 
-    def __init__(self, array: NDArrayLike):
+    def __init__(self, array: NDArrayLike) -> None:
         # assert array.ndim > 0
         assert array.dtype != object
         self._data = array

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -45,7 +45,7 @@ class Buffer(core.Buffer):
         array-like object that must be 1-dim, contiguous, and byte dtype.
     """
 
-    def __init__(self, array_like: ArrayLike):
+    def __init__(self, array_like: ArrayLike) -> None:
         super().__init__(array_like)
 
     @classmethod
@@ -143,7 +143,7 @@ class NDBuffer(core.NDBuffer):
         ndarray-like object that is convertible to a regular Numpy array.
     """
 
-    def __init__(self, array: NDArrayLike):
+    def __init__(self, array: NDArrayLike) -> None:
         super().__init__(array)
 
     @classmethod

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -48,7 +48,7 @@ class Buffer(core.Buffer):
         array-like object that must be 1-dim, contiguous, and byte dtype.
     """
 
-    def __init__(self, array_like: ArrayLike):
+    def __init__(self, array_like: ArrayLike) -> None:
         if cp is None:
             raise ImportError(
                 "Cannot use zarr.buffer.gpu.Buffer without cupy. Please install cupy."
@@ -137,7 +137,7 @@ class NDBuffer(core.NDBuffer):
         ndarray-like object that is convertible to a regular Numpy array.
     """
 
-    def __init__(self, array: NDArrayLike):
+    def __init__(self, array: NDArrayLike) -> None:
         if cp is None:
             raise ImportError(
                 "Cannot use zarr.buffer.gpu.NDBuffer without cupy. Please install cupy."

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -54,7 +54,7 @@ def parse_zarr_format(data: Any) -> ZarrFormat:
 def parse_attributes(data: Any) -> dict[str, Any]:
     if data is None:
         return {}
-    elif isinstance(data, dict) and all(map(lambda v: isinstance(v, str), data.keys())):
+    elif isinstance(data, dict) and all(isinstance(v, str) for v in data.keys()):
         return data
     msg = f"Expected dict with string keys. Got {type(data)} instead."
     raise TypeError(msg)
@@ -888,7 +888,7 @@ class Group(SyncMixin):
         """
         _members = self._sync_iter(self._async_group.members(max_depth=max_depth))
 
-        result = tuple(map(lambda kv: (kv[0], _parse_async_node(kv[1])), _members))
+        result = tuple((kv[0], _parse_async_node(kv[1])) for kv in _members)
         return result
 
     def __contains__(self, member: str) -> bool:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -54,7 +54,7 @@ def parse_zarr_format(data: Any) -> ZarrFormat:
 def parse_attributes(data: Any) -> dict[str, Any]:
     if data is None:
         return {}
-    elif isinstance(data, dict) and all(isinstance(v, str) for v in data.keys()):
+    elif isinstance(data, dict) and all(isinstance(k, str) for k in data):
         return data
     msg = f"Expected dict with string keys. Got {type(data)} instead."
     raise TypeError(msg)
@@ -104,7 +104,9 @@ class GroupMetadata(Metadata):
                 ),
             }
 
-    def __init__(self, attributes: dict[str, Any] | None = None, zarr_format: ZarrFormat = 3):
+    def __init__(
+        self, attributes: dict[str, Any] | None = None, zarr_format: ZarrFormat = 3
+    ) -> None:
         attributes_parsed = parse_attributes(attributes)
         zarr_format_parsed = parse_zarr_format(zarr_format)
 
@@ -202,11 +204,10 @@ class AsyncGroup:
         store_path: StorePath,
         data: dict[str, Any],
     ) -> AsyncGroup:
-        group = cls(
+        return cls(
             metadata=GroupMetadata.from_dict(data),
             store_path=store_path,
         )
-        return group
 
     async def getitem(
         self,
@@ -888,8 +889,7 @@ class Group(SyncMixin):
         """
         _members = self._sync_iter(self._async_group.members(max_depth=max_depth))
 
-        result = tuple((kv[0], _parse_async_node(kv[1])) for kv in _members)
-        return result
+        return tuple((kv[0], _parse_async_node(kv[1])) for kv in _members)
 
     def __contains__(self, member: str) -> bool:
         return self._sync(self._async_group.contains(member))

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -54,7 +54,7 @@ class ArrayIndexError(IndexError):
 class BoundsCheckError(IndexError):
     _msg = ""
 
-    def __init__(self, dim_len: int):
+    def __init__(self, dim_len: int) -> None:
         self._msg = f"index out of bounds for dimension with length {dim_len}"
 
 
@@ -255,7 +255,7 @@ class IntDimIndexer:
     dim_chunk_len: int
     nitems: int = 1
 
-    def __init__(self, dim_sel: int, dim_len: int, dim_chunk_len: int):
+    def __init__(self, dim_sel: int, dim_len: int, dim_chunk_len: int) -> None:
         object.__setattr__(self, "dim_sel", normalize_integer_selection(dim_sel, dim_len))
         object.__setattr__(self, "dim_len", dim_len)
         object.__setattr__(self, "dim_chunk_len", dim_chunk_len)
@@ -279,7 +279,7 @@ class SliceDimIndexer:
     stop: int
     step: int
 
-    def __init__(self, dim_sel: slice, dim_len: int, dim_chunk_len: int):
+    def __init__(self, dim_sel: slice, dim_len: int, dim_chunk_len: int) -> None:
         # normalize
         start, stop, step = dim_sel.indices(dim_len)
         if step < 1:
@@ -453,7 +453,7 @@ class BasicIndexer(Indexer):
         selection: BasicSelection,
         shape: ChunkCoords,
         chunk_grid: ChunkGrid,
-    ):
+    ) -> None:
         chunk_shape = get_chunk_shape(chunk_grid)
         # handle ellipsis
         selection_normalized = replace_ellipsis(selection, shape)
@@ -509,7 +509,7 @@ class BoolArrayDimIndexer:
     nitems: int
     dim_chunk_ixs: npt.NDArray[np.intp]
 
-    def __init__(self, dim_sel: npt.NDArray[np.bool_], dim_len: int, dim_chunk_len: int):
+    def __init__(self, dim_sel: npt.NDArray[np.bool_], dim_len: int, dim_chunk_len: int) -> None:
         # check number of dimensions
         if not is_bool_array(dim_sel, 1):
             raise IndexError("Boolean arrays in an orthogonal selection must be 1-dimensional only")
@@ -626,7 +626,7 @@ class IntArrayDimIndexer:
         wraparound: bool = True,
         boundscheck: bool = True,
         order: Order = Order.UNKNOWN,
-    ):
+    ) -> None:
         # ensure 1d array
         dim_sel = np.asanyarray(dim_sel)
         if not is_integer_array(dim_sel, 1):
@@ -766,7 +766,7 @@ class OrthogonalIndexer(Indexer):
     is_advanced: bool
     drop_axes: tuple[int, ...]
 
-    def __init__(self, selection: Selection, shape: ChunkCoords, chunk_grid: ChunkGrid):
+    def __init__(self, selection: Selection, shape: ChunkCoords, chunk_grid: ChunkGrid) -> None:
         chunk_shape = get_chunk_shape(chunk_grid)
 
         # handle ellipsis
@@ -880,7 +880,9 @@ class BlockIndexer(Indexer):
     shape: ChunkCoords
     drop_axes: ChunkCoords
 
-    def __init__(self, selection: BasicSelection, shape: ChunkCoords, chunk_grid: ChunkGrid):
+    def __init__(
+        self, selection: BasicSelection, shape: ChunkCoords, chunk_grid: ChunkGrid
+    ) -> None:
         chunk_shape = get_chunk_shape(chunk_grid)
 
         # handle ellipsis
@@ -1005,7 +1007,9 @@ class CoordinateIndexer(Indexer):
     chunk_shape: ChunkCoords
     drop_axes: ChunkCoords
 
-    def __init__(self, selection: CoordinateSelection, shape: ChunkCoords, chunk_grid: ChunkGrid):
+    def __init__(
+        self, selection: CoordinateSelection, shape: ChunkCoords, chunk_grid: ChunkGrid
+    ) -> None:
         chunk_shape = get_chunk_shape(chunk_grid)
 
         cdata_shape: ChunkCoords
@@ -1122,7 +1126,7 @@ class CoordinateIndexer(Indexer):
 
 @dataclass(frozen=True)
 class MaskIndexer(CoordinateIndexer):
-    def __init__(self, selection: MaskSelection, shape: ChunkCoords, chunk_grid: ChunkGrid):
+    def __init__(self, selection: MaskSelection, shape: ChunkCoords, chunk_grid: ChunkGrid) -> None:
         # some initial normalization
         selection_normalized = cast(tuple[MaskSelection], ensure_tuple(selection))
         selection_normalized = cast(tuple[MaskSelection], replace_lists(selection_normalized))

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -292,35 +292,35 @@ COMPLEX = np.complex64 | np.complex128
 
 @overload
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: BOOL_DTYPE,
 ) -> BOOL: ...
 
 
 @overload
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: INTEGER_DTYPE,
 ) -> INTEGER: ...
 
 
 @overload
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: FLOAT_DTYPE,
 ) -> FLOAT: ...
 
 
 @overload
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: COMPLEX_DTYPE,
 ) -> COMPLEX: ...
 
 
 @overload
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: np.dtype[Any],
 ) -> Any:
     # This dtype[Any] is unfortunately necessary right now.
@@ -334,7 +334,7 @@ def parse_fill_value(
 
 
 def parse_fill_value(
-    fill_value: int | float | complex | str | bytes | np.generic | Sequence[Any] | bool | None,
+    fill_value: complex | str | bytes | np.generic | Sequence[Any] | bool | None,
     dtype: BOOL_DTYPE | INTEGER_DTYPE | FLOAT_DTYPE | COMPLEX_DTYPE | np.dtype[Any],
 ) -> BOOL | INTEGER | FLOAT | COMPLEX | Any:
     """

--- a/src/zarr/core/sync.py
+++ b/src/zarr/core/sync.py
@@ -117,9 +117,7 @@ async def _collect_aiterator(data: AsyncIterator[T]) -> tuple[T, ...]:
     """
     Collect an entire async iterator into a tuple
     """
-    result = []
-    async for x in data:
-        result.append(x)
+    result = [x async for x in data]
     return tuple(result)
 
 

--- a/src/zarr/registry.py
+++ b/src/zarr/registry.py
@@ -107,7 +107,7 @@ def fully_qualified_name(cls: type) -> str:
 
 
 def register_codec(key: str, codec_cls: type[Codec]) -> None:
-    if key not in __codec_registries.keys():
+    if key not in __codec_registries:
         __codec_registries[key] = Registry()
     __codec_registries[key].register(codec_cls)
 
@@ -158,7 +158,7 @@ def get_pipeline_class(reload_config: bool = False) -> type[CodecPipeline]:
     if pipeline_class:
         return pipeline_class
     raise BadConfigError(
-        f"Pipeline class '{path}' not found in registered pipelines: {list(__pipeline_registry.keys())}."
+        f"Pipeline class '{path}' not found in registered pipelines: {list(__pipeline_registry)}."
     )
 
 
@@ -172,7 +172,7 @@ def get_buffer_class(reload_config: bool = False) -> type[Buffer]:
     if buffer_class:
         return buffer_class
     raise BadConfigError(
-        f"Buffer class '{path}' not found in registered buffers: {list(__buffer_registry.keys())}."
+        f"Buffer class '{path}' not found in registered buffers: {list(__buffer_registry)}."
     )
 
 
@@ -185,7 +185,7 @@ def get_ndbuffer_class(reload_config: bool = False) -> type[NDBuffer]:
     if ndbuffer_class:
         return ndbuffer_class
     raise BadConfigError(
-        f"NDBuffer class '{path}' not found in registered buffers: {list(__ndbuffer_registry.keys())}."
+        f"NDBuffer class '{path}' not found in registered buffers: {list(__ndbuffer_registry)}."
     )
 
 

--- a/src/zarr/store/common.py
+++ b/src/zarr/store/common.py
@@ -64,10 +64,9 @@ class StorePath:
     def __repr__(self) -> str:
         return f"StorePath({self.store.__class__.__name__}, {str(self)!r})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         try:
-            if self.store == other.store and self.path == other.path:
-                return True
+            return self.store == other.store and self.path == other.path  # type: ignore[attr-defined, no-any-return]
         except Exception:
             pass
         return False

--- a/src/zarr/store/common.py
+++ b/src/zarr/store/common.py
@@ -23,15 +23,14 @@ def _dereference_path(root: str, path: str) -> str:
     assert isinstance(path, str)
     root = root.rstrip("/")
     path = f"{root}/{path}" if root else path
-    path = path.rstrip("/")
-    return path
+    return path.rstrip("/")
 
 
 class StorePath:
     store: Store
     path: str
 
-    def __init__(self, store: Store, path: str | None = None):
+    def __init__(self, store: Store, path: str | None = None) -> None:
         self.store = store
         self.path = path or ""
 
@@ -265,8 +264,7 @@ async def contains_array(store_path: StorePath, zarr_format: ZarrFormat) -> bool
             except (ValueError, KeyError):
                 return False
     elif zarr_format == 2:
-        result = await (store_path / ZARRAY_JSON).exists()
-        return result
+        return await (store_path / ZARRAY_JSON).exists()
     msg = f"Invalid zarr_format provided. Got {zarr_format}, expected 2 or 3"
     raise ValueError(msg)
 

--- a/src/zarr/store/local.py
+++ b/src/zarr/store/local.py
@@ -79,7 +79,7 @@ class LocalStore(Store):
 
     root: Path
 
-    def __init__(self, root: Path | str, *, mode: AccessModeLiteral = "r"):
+    def __init__(self, root: Path | str, *, mode: AccessModeLiteral = "r") -> None:
         super().__init__(mode=mode)
         if isinstance(root, str):
             root = Path(root)

--- a/src/zarr/store/memory.py
+++ b/src/zarr/store/memory.py
@@ -30,7 +30,7 @@ class MemoryStore(Store):
         store_dict: MutableMapping[str, Buffer] | None = None,
         *,
         mode: AccessModeLiteral = "r",
-    ):
+    ) -> None:
         super().__init__(mode=mode)
         if store_dict is None:
             store_dict = {}
@@ -80,8 +80,7 @@ class MemoryStore(Store):
         async def _get(key: str, byte_range: tuple[int, int | None]) -> Buffer | None:
             return await self.get(key, prototype=prototype, byte_range=byte_range)
 
-        vals = await concurrent_map(key_ranges, _get, limit=None)
-        return vals
+        return await concurrent_map(key_ranges, _get, limit=None)
 
     async def exists(self, key: str) -> bool:
         return key in self._store_dict
@@ -137,7 +136,7 @@ class MemoryStore(Store):
             prefix = prefix[:-1]
 
         if prefix == "":
-            keys_unique = set(k.split("/")[0] for k in self._store_dict.keys())
+            keys_unique = set(k.split("/")[0] for k in self._store_dict)
         else:
             # Our dictionary doesn't contain directory markers, but we want to include
             # a pseudo directory when there's a nested item and we're listing an
@@ -166,7 +165,7 @@ class GpuMemoryStore(MemoryStore):
         store_dict: MutableMapping[str, Buffer] | None = None,
         *,
         mode: AccessModeLiteral = "r",
-    ):
+    ) -> None:
         super().__init__(mode=mode)
         if store_dict:
             self._store_dict = {k: gpu.Buffer.from_buffer(store_dict[k]) for k in iter(store_dict)}

--- a/src/zarr/store/remote.py
+++ b/src/zarr/store/remote.py
@@ -39,7 +39,7 @@ class RemoteStore(Store):
         mode: AccessModeLiteral = "r",
         path: str = "/",
         allowed_exceptions: tuple[type[Exception], ...] = ALLOWED_EXCEPTIONS,
-    ):
+    ) -> None:
         """
         Parameters
         ----------
@@ -49,6 +49,7 @@ class RemoteStore(Store):
             keys, rather than some other IO failure
         storage_options: passed on to fsspec to make the filesystem instance. If url is a UPath,
             this must not be used.
+
         """
         super().__init__(mode=mode)
         self.fs = fs

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -171,5 +171,4 @@ def key_ranges(keys: SearchStrategy = node_names) -> SearchStrategy[list]:
         st.none() | st.integers(min_value=0), st.none() | st.integers(min_value=0)
     )
     key_tuple = st.tuples(keys, byte_ranges)
-    key_range_st = st.lists(key_tuple, min_size=1, max_size=10)
-    return key_range_st
+    return st.lists(key_tuple, min_size=1, max_size=10)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -4,7 +4,7 @@ from typing import Any
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
 import numpy as np
-from hypothesis import given, settings  # noqa
+from hypothesis import given, settings  # noqa: F401
 from hypothesis.strategies import SearchStrategy
 
 from zarr.core.array import Array

--- a/tests/v3/conftest.py
+++ b/tests/v3/conftest.py
@@ -105,7 +105,7 @@ def xp(request: pytest.FixtureRequest) -> Iterator[ModuleType]:
     if request.param == "cupy":
         request.node.add_marker(pytest.mark.gpu)
 
-    yield pytest.importorskip(request.param)
+    return pytest.importorskip(request.param)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/v3/conftest.py
+++ b/tests/v3/conftest.py
@@ -14,8 +14,7 @@ from zarr.store import LocalStore, MemoryStore, StorePath, ZipStore
 from zarr.store.remote import RemoteStore
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
-    from types import ModuleType
+    from collections.abc import Generator
     from typing import Any, Literal
 
     from _pytest.compat import LEGACY_PATH
@@ -99,7 +98,7 @@ async def async_group(request: pytest.FixtureRequest, tmpdir: LEGACY_PATH) -> As
 
 
 @pytest.fixture(params=["numpy", "cupy"])
-def xp(request: pytest.FixtureRequest) -> Iterator[ModuleType]:
+def xp(request: pytest.FixtureRequest) -> Any:
     """Fixture to parametrize over numpy-like libraries"""
 
     if request.param == "cupy":

--- a/tests/v3/test_array.py
+++ b/tests/v3/test_array.py
@@ -27,7 +27,7 @@ def test_array_creation_existing_node(
     """
     spath = StorePath(store)
     group = Group.from_store(spath, zarr_format=zarr_format)
-    expected_exception: type[ContainsArrayError] | type[ContainsGroupError]
+    expected_exception: type[ContainsArrayError | ContainsGroupError]
     if extant_node == "array":
         expected_exception = ContainsArrayError
         _ = group.create_array("extant", shape=(10,), dtype="uint8")

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -468,7 +468,7 @@ def test_group_creation_existing_node(
     """
     spath = StorePath(store)
     group = Group.from_store(spath, zarr_format=zarr_format)
-    expected_exception: type[ContainsArrayError] | type[ContainsGroupError]
+    expected_exception: type[ContainsArrayError | ContainsGroupError]
     attributes: dict[str, JSON] = {"old": True}
 
     if extant_node == "array":

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -271,7 +271,7 @@ def test_group_iter(store: Store, zarr_format: ZarrFormat) -> None:
 
     group = Group.from_store(store, zarr_format=zarr_format)
     with pytest.raises(NotImplementedError):
-        [x for x in group]  # type: ignore
+        [x for x in group]
 
 
 def test_group_len(store: Store, zarr_format: ZarrFormat) -> None:
@@ -281,7 +281,7 @@ def test_group_len(store: Store, zarr_format: ZarrFormat) -> None:
 
     group = Group.from_store(store, zarr_format=zarr_format)
     with pytest.raises(NotImplementedError):
-        len(group)  # type: ignore
+        len(group)
 
 
 def test_group_setitem(store: Store, zarr_format: ZarrFormat) -> None:

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -550,7 +550,7 @@ async def test_asyncgroup_attrs(store: Store, zarr_format: ZarrFormat) -> None:
 
 
 async def test_asyncgroup_info(store: Store, zarr_format: ZarrFormat) -> None:
-    agroup = await AsyncGroup.from_store(  # noqa
+    agroup = await AsyncGroup.from_store(  # noqa: F841
         store,
         zarr_format=zarr_format,
     )

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -93,8 +93,8 @@ def test_group_members(store: Store, zarr_format: ZarrFormat) -> None:
     members_expected["subgroup"] = group.create_group("subgroup")
     # make a sub-sub-subgroup, to ensure that the children calculation doesn't go
     # too deep in the hierarchy
-    subsubgroup = members_expected["subgroup"].create_group("subsubgroup")  # type: ignore
-    subsubsubgroup = subsubgroup.create_group("subsubsubgroup")  # type: ignore
+    subsubgroup = members_expected["subgroup"].create_group("subsubgroup")
+    subsubsubgroup = subsubgroup.create_group("subsubsubgroup")
 
     members_expected["subarray"] = group.create_array(
         "subarray", shape=(100,), dtype="uint8", chunk_shape=(10,), exists_ok=True

--- a/tests/v3/test_indexing.py
+++ b/tests/v3/test_indexing.py
@@ -1782,9 +1782,9 @@ async def test_accessed_chunks(
 
         # Combine and generate the cartesian product to determine the chunks keys that
         # will be accessed
-        chunks_accessed = []
-        for comb in itertools.product(*chunks_per_dim):
-            chunks_accessed.append(".".join([str(ci) for ci in comb]))
+        chunks_accessed = [
+            ".".join([str(ci) for ci in comb]) for comb in itertools.product(*chunks_per_dim)
+        ]
 
         counts_before = store.counter.copy()
 

--- a/tests/v3/test_indexing.py
+++ b/tests/v3/test_indexing.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 async def store() -> AsyncGenerator[StorePath]:
-    yield StorePath(await MemoryStore.open(mode="w"))
+    return StorePath(await MemoryStore.open(mode="w"))
 
 
 def zarr_array_from_numpy_array(

--- a/tests/v3/test_metadata/test_v3.py
+++ b/tests/v3/test_metadata/test_v3.py
@@ -303,7 +303,7 @@ def test_parse_invalid_dtype_raises(data):
 @pytest.mark.parametrize(
     "data_type,fill_value", [("uint8", -1), ("int32", 22.5), ("float32", "foo")]
 )
-async def test_invalid_fill_value_raises(data_type: str, fill_value: int | float) -> None:
+async def test_invalid_fill_value_raises(data_type: str, fill_value: float) -> None:
     metadata_dict = {
         "zarr_format": 3,
         "node_type": "array",

--- a/tests/v3/test_properties.py
+++ b/tests/v3/test_properties.py
@@ -4,10 +4,11 @@ from numpy.testing import assert_array_equal
 
 pytest.importorskip("hypothesis")
 
-import hypothesis.extra.numpy as npst  # noqa
-import hypothesis.strategies as st  # noqa
-from hypothesis import given, settings  # noqa
-from zarr.testing.strategies import arrays, np_arrays, basic_indices  # noqa
+import hypothesis.extra.numpy as npst  # noqa: E402
+import hypothesis.strategies as st  # noqa: E402
+from hypothesis import given  # noqa: E402
+
+from zarr.testing.strategies import arrays, basic_indices, np_arrays  # noqa: E402
 
 
 @given(st.data())

--- a/tests/v3/test_store/test_remote.py
+++ b/tests/v3/test_store/test_remote.py
@@ -86,10 +86,7 @@ def s3(s3_base: None) -> Generator[s3fs.S3FileSystem, None, None]:
 
 
 async def alist(it):
-    out = []
-    async for a in it:
-        out.append(a)
-    return out
+    return [a async for a in it]
 
 
 async def test_basic() -> None:

--- a/tests/v3/test_store/test_stateful_store.py
+++ b/tests/v3/test_store/test_stateful_store.py
@@ -202,9 +202,9 @@ class ZarrStoreStateMachine(RuleBasedStateMachine):
     @invariant()
     def check_vals_equal(self) -> None:
         note("Checking values equal")
-        for key, _val in self.model.items():
+        for key, val in self.model.items():
             store_item = self.store.get(key, self.prototype).to_bytes()
-            assert self.model[key].to_bytes() == store_item
+            assert val.to_bytes() == store_item
 
     @invariant()
     def check_num_keys_equal(self) -> None:

--- a/tests/v3/test_store/test_stateful_store.py
+++ b/tests/v3/test_store/test_stateful_store.py
@@ -131,7 +131,7 @@ class ZarrStoreStateMachine(RuleBasedStateMachine):
     @rule(key=paths, data=st.data())
     def get_invalid_keys(self, key: str, data: DataObject) -> None:
         note("(get_invalid)")
-        assume(key not in self.model.keys())
+        assume(key not in self.model)
         assert self.store.get(key, self.prototype) is None
 
     @precondition(lambda self: len(self.model.keys()) > 0)

--- a/tests/v3/test_v2.py
+++ b/tests/v3/test_v2.py
@@ -9,7 +9,7 @@ from zarr.store import MemoryStore, StorePath
 
 @pytest.fixture
 async def store() -> Iterator[StorePath]:
-    yield StorePath(await MemoryStore.open(mode="w"))
+    return StorePath(await MemoryStore.open(mode="w"))
 
 
 def test_simple(store: StorePath) -> None:


### PR DESCRIPTION
* Apply [`PERF401`](https://docs.astral.sh/ruff/rules/manual-list-comprehension/), but do not enforce for now - see https://github.com/pypa/setuptools/pull/4449#issuecomment-2239482683 and https://github.com/numpy/numpy/pull/26876#issuecomment-2223009885 and make your own opinion :smile:
* Apply [`PT022`](https://docs.astral.sh/ruff/rules/pytest-useless-yield-fixture/). Do not enforce for now, I fear you won't like other [`PT`](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt) rules.
* ~~Enforce [`TCH`](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch) rules.~~
* Enforce [`PGH`](https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh) rules.
* Apply [`C405`](https://docs.astral.sh/ruff/rules/unnecessary-literal-set/) and [`C417`](https://docs.astral.sh/ruff/rules/unnecessary-map/). Do not enforce for now, some [`C4`](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4) rules seem too strict.
* Enforce [`PYI`](https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi) rules.
* ~~Fix pre-commit warnings and errors as they occur~~
* ~~Catch more precise exceptions than `Exception`~~

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
