### PR TITLE
Enforce ruff/tryceratops rules (TRY)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,11 @@ extend-select = [
     "UP",  # pyupgrade
     "RSE",
     "RUF",
+    "TRY", # tryceratops
 ]
 ignore = [
     "RUF005",
+    "TRY003",
 ]
 
 [tool.mypy]

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -862,7 +862,7 @@ async def open_array(
 
     try:
         return await AsyncArray.open(store_path, zarr_format=zarr_format)
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         if store_path.store.mode.create:
             return await create(
                 store=store_path,
@@ -871,7 +871,7 @@ async def open_array(
                 overwrite=store_path.store.mode.overwrite,
                 **kwargs,
             )
-        raise e
+        raise
 
 
 async def open_like(a: ArrayLike, path: str, **kwargs: Any) -> AsyncArray:

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -66,7 +66,7 @@ def _like_args(a: ArrayLike, kwargs: dict[str, Any]) -> dict[str, Any]:
         if isinstance(a.metadata, ArrayV3Metadata):
             new["codecs"] = a.metadata.codecs
         else:
-            raise ValueError(f"Unsupported zarr format: {a.metadata.zarr_format}")
+            raise TypeError(f"Unsupported zarr format: {a.metadata.zarr_format}")
     else:
         # TODO: set default values compressor/codecs
         # to do this, we may need to evaluate if this is a v2 or v3 array

--- a/src/zarr/array.py
+++ b/src/zarr/array.py
@@ -87,7 +87,7 @@ def create_codec_pipeline(metadata: ArrayV2Metadata | ArrayV3Metadata) -> CodecP
             [V2Filters(metadata.filters or []), V2Compressor(metadata.compressor)]
         )
     else:
-        raise AssertionError
+        raise TypeError
 
 
 @dataclass(frozen=True)
@@ -394,7 +394,7 @@ class AsyncArray:
         if isinstance(self.metadata.chunk_grid, RegularChunkGrid):
             return self.metadata.chunk_grid.chunk_shape
         else:
-            raise ValueError(
+            raise TypeError(
                 f"chunk attribute is only available for RegularChunkGrid, this array has a {self.metadata.chunk_grid}"
             )
 

--- a/src/zarr/codecs/pipeline.py
+++ b/src/zarr/codecs/pipeline.py
@@ -492,7 +492,7 @@ def codecs_from_list(
                     "must be preceded by another ArrayArrayCodec. "
                     f"Got {type(prev_codec)} instead."
                 )
-                raise ValueError(msg)
+                raise TypeError(msg)
             array_array += (cur_codec,)
 
         elif isinstance(cur_codec, ArrayBytesCodec):
@@ -501,7 +501,7 @@ def codecs_from_list(
                     f"Invalid codec order. ArrayBytes codec {cur_codec}"
                     f" must be preceded by an ArrayArrayCodec. Got {type(prev_codec)} instead."
                 )
-                raise ValueError(msg)
+                raise TypeError(msg)
 
             if array_bytes_maybe is not None:
                 msg = (
@@ -521,7 +521,7 @@ def codecs_from_list(
                 )
             bytes_bytes += (cur_codec,)
         else:
-            raise AssertionError
+            raise TypeError
 
     if array_bytes_maybe is None:
         raise ValueError("Required ArrayBytesCodec was not found.")

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -387,7 +387,7 @@ class ShardingCodec(
                 "The shard's `chunk_shape` and array's `shape` need to have the same number of dimensions."
             )
         if not isinstance(chunk_grid, RegularChunkGrid):
-            raise ValueError("Sharding is only compatible with regular chunk grids.")
+            raise TypeError("Sharding is only compatible with regular chunk grids.")
         if not all(
             s % c == 0
             for s, c in zip(

--- a/src/zarr/group.py
+++ b/src/zarr/group.py
@@ -467,9 +467,10 @@ class AsyncGroup:
         # TODO: this can be made more efficient.
         try:
             await self.getitem(member)
-            return True
         except KeyError:
             return False
+        else:
+            return True
 
     # todo: decide if this method should be separate from `groups`
     async def group_keys(self) -> AsyncGenerator[str, None]:

--- a/src/zarr/store/core.py
+++ b/src/zarr/store/core.py
@@ -251,9 +251,10 @@ async def contains_group(store_path: StorePath, zarr_format: ZarrFormat) -> bool
                 extant_meta_json = json.loads(extant_meta_bytes.to_bytes())
                 # we avoid constructing a full metadata document here in the name of speed.
                 result: bool = extant_meta_json["node_type"] == "group"
-                return result
             except (ValueError, KeyError):
                 return False
+            else:
+                return result
     elif zarr_format == 2:
         return await (store_path / ZGROUP_JSON).exists()
     msg = f"Invalid zarr_format provided. Got {zarr_format}, expected 2 or 3"  # type: ignore[unreachable]

--- a/src/zarr/store/local.py
+++ b/src/zarr/store/local.py
@@ -87,9 +87,10 @@ class LocalStore(Store):
     async def empty(self) -> bool:
         try:
             subpaths = os.listdir(self.root)
-            return not subpaths
         except FileNotFoundError:
             return True
+        else:
+            return not subpaths
 
     def __str__(self) -> str:
         return f"file://{self.root}"

--- a/src/zarr/store/remote.py
+++ b/src/zarr/store/remote.py
@@ -118,7 +118,6 @@ class RemoteStore(Store):
                     else self._fs._cat_file(path)
                 )
             )
-            return value
 
         except self.allowed_exceptions:
             return None
@@ -127,6 +126,8 @@ class RemoteStore(Store):
                 # this is an s3-specific condition we probably don't want to leak
                 return prototype.buffer.from_bytes(b"")
             raise
+        else:
+            return value
 
     async def set(
         self,

--- a/tests/v3/test_codecs/test_codecs.py
+++ b/tests/v3/test_codecs/test_codecs.py
@@ -382,7 +382,7 @@ def test_invalid_metadata(store: Store) -> None:
             fill_value=0,
         )
     spath2 = StorePath(store, "invalid_endian")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         Array.create(
             spath2,
             shape=(16, 16),


### PR DESCRIPTION
Ignore [`TRY003`](https://docs.astral.sh/ruff/rules/raise-vanilla-args/) for now. I don't like it in this context.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
