### PR TITLE
Updated test dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     'zstandard',
     'typing_extensions',
     'donfig',
-    'pytest'
 ]
 dynamic = [
   "version",
@@ -55,6 +54,21 @@ license = {text = "MIT License"}
 keywords = ["Python", "compressed", "ndimensional-arrays", "zarr"]
 
 [project.optional-dependencies]
+test = [
+    "coverage",
+    "pytest",
+    "pytest-cov",
+    "msgpack",
+    "lmdb",
+    "s3fs",
+    "pytest-asyncio",
+    "moto[s3]",
+    "flask-cors",
+    "flask",
+    "requests",
+    "mypy"
+]
+
 jupyter = [
     'notebook',
     'ipytree>=0.2.2',
@@ -108,21 +122,7 @@ dependencies = [
     "numpy~={matrix:numpy}",
     "universal_pathlib"
 ]
-extra-dependencies = [
-    "coverage",
-    "pytest",
-    "pytest-cov",
-    "msgpack",
-    "lmdb",
-    "s3fs",
-    "pytest-asyncio",
-    "moto[s3]",
-    "flask-cors",
-    "flask",
-    "requests",
-    "mypy"
-]
-features = ["extra"]
+features = ["test", "extra"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.10", "3.11", "3.12"]


### PR DESCRIPTION
(note: pending some discussion at https://github.com/zarr-developers/zarr-python/issues/2068#issuecomment-2274067546 on the desired behavior w.r.t `zarr.testing.StoreTests`)

- removed pytest as a required dep
- move test hatch env dep to a "test" optional dependency and include as a feature

Here's the output of `hatch env run -e test.py3.10-1.24-minimal pip list`

```
Package            Version
------------------ -----------
aiobotocore        2.13.1
aiohappyeyeballs   2.3.5
aiohttp            3.10.1
aioitertools       0.11.0
aiosignal          1.3.1
asciitree          0.3.3
async-timeout      4.0.3
attrs              24.2.0
blinker            1.8.2
boto3              1.34.131
botocore           1.34.131
certifi            2024.7.4
cffi               1.17.0
charset-normalizer 3.3.2
click              8.1.7
coverage           7.6.1
crc32c             2.5
cryptography       43.0.0
donfig             0.8.1.post1
exceptiongroup     1.2.2
fasteners          0.19
Flask              3.0.3
Flask-Cors         4.0.1
frozenlist         1.4.1
fsspec             2024.6.1
idna               3.7
iniconfig          2.0.0
itsdangerous       2.2.0
Jinja2             3.1.4
jmespath           1.0.1
lmdb               1.5.1
MarkupSafe         2.1.5
moto               5.0.12
msgpack            1.0.8
multidict          6.0.5
mypy               1.11.1
mypy-extensions    1.0.0
numcodecs          0.13.0
numpy              1.26.4
packaging          24.1
pip                24.0
pluggy             1.5.0
py-partiql-parser  0.5.5
pycparser          2.22
pytest             8.3.2
pytest-asyncio     0.23.8
pytest-cov         5.0.0
python-dateutil    2.9.0.post0
PyYAML             6.0.2
requests           2.32.3
responses          0.25.3
s3fs               2024.6.1
s3transfer         0.10.2
setuptools         69.2.0
six                1.16.0
tomli              2.0.1
typing_extensions  4.12.2
universal_pathlib  0.2.2
urllib3            2.2.2
Werkzeug           3.0.3
wheel              0.43.0
wrapt              1.16.0
xmltodict          0.13.0
yarl               1.9.4
zstandard          0.23.0
```

The presence of, e.g. s3fs, indicates that the hatch env stuff is picking up those deps through the `test` feature, while still allowing non-hatch usage through `pip install -e .[test]`.


Closes #2068 

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
