### PR TITLE
Re-enable dependabot on main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 ---
 version: 2
 updates:
+  # Updates for v3 branch (the default branch)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -11,6 +12,26 @@ updates:
           - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Same updates, but for main branch
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "daily"
+    groups:
+      requirements:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/2045. I don't think there's a way to test this before merging it?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
