### PR TITLE
Return TypedDict instances from Metadata.to_dict()

### DIFF
--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable, Iterable
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeVar
 
 import numpy as np
+from typing_extensions import NotRequired
 
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import ByteGetter, ByteSetter
@@ -168,6 +169,22 @@ class BytesBytesCodec(_Codec[Buffer, Buffer]):
 
 
 Codec = ArrayArrayCodec | ArrayBytesCodec | BytesBytesCodec
+
+
+class CodecConfigDict(TypedDict):
+    """A dictionary representing a codec configuration."""
+
+    ...
+
+
+T = TypeVar("T", bound=CodecConfigDict)
+
+
+class CodecDict(TypedDict, Generic[T]):
+    """A generic dictionary representing a codec."""
+
+    name: str
+    configuration: NotRequired[T]
 
 
 class ArrayBytesCodecPartialDecodeMixin:

--- a/src/zarr/codecs/bytes.py
+++ b/src/zarr/codecs/bytes.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from zarr.abc.codec import ArrayBytesCodec
+from zarr.abc.codec import ArrayBytesCodec, CodecConfigDict, CodecDict
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
 from zarr.core.common import JSON, parse_enum, parse_named_configuration
@@ -23,6 +23,18 @@ class Endian(Enum):
 
 
 default_system_endian = Endian(sys.byteorder)
+
+
+class BytesCodecConfigDict(CodecConfigDict):
+    """A dictionary representing a bytes codec configuration."""
+
+    endian: Endian
+
+
+class BytesCodecDict(CodecDict[BytesCodecConfigDict]):
+    """A dictionary representing a bytes codec."""
+
+    ...
 
 
 @dataclass(frozen=True)
@@ -44,11 +56,12 @@ class BytesCodec(ArrayBytesCodec):
         configuration_parsed = configuration_parsed or {}
         return cls(**configuration_parsed)  # type: ignore[arg-type]
 
-    def to_dict(self) -> dict[str, JSON]:
-        if self.endian is None:
-            return {"name": "bytes"}
-        else:
-            return {"name": "bytes", "configuration": {"endian": self.endian}}
+    def to_dict(self) -> BytesCodecDict:
+        out_dict: BytesCodecDict = {"name": "bytes"}
+        if self.endian is not None:
+            out_dict["configuration"] = {"endian": self.endian}
+
+        return out_dict
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Self:
         if array_spec.dtype.itemsize == 0:

--- a/src/zarr/codecs/crc32c_.py
+++ b/src/zarr/codecs/crc32c_.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from crc32c import crc32c
 
-from zarr.abc.codec import BytesBytesCodec
+from zarr.abc.codec import BytesBytesCodec, CodecConfigDict, CodecDict
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import Buffer
 from zarr.core.common import JSON, parse_named_configuration
@@ -14,6 +14,12 @@ from zarr.registry import register_codec
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+
+
+class Crc32cCodecDict(CodecDict[CodecConfigDict]):
+    """A dictionary representing a CRC32C codec."""
+
+    ...
 
 
 @dataclass(frozen=True)
@@ -25,8 +31,9 @@ class Crc32cCodec(BytesBytesCodec):
         parse_named_configuration(data, "crc32c", require_configuration=False)
         return cls()
 
-    def to_dict(self) -> dict[str, JSON]:
-        return {"name": "crc32c"}
+    def to_dict(self) -> Crc32cCodecDict:
+        out_dict = {"name": "crc32c"}
+        return cast(Crc32cCodecDict, out_dict)
 
     async def _decode_single(
         self,

--- a/src/zarr/codecs/gzip.py
+++ b/src/zarr/codecs/gzip.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from numcodecs.gzip import GZip
 
-from zarr.abc.codec import BytesBytesCodec
+from zarr.abc.codec import BytesBytesCodec, CodecConfigDict, CodecDict
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import Buffer, as_numpy_array_wrapper
 from zarr.core.common import JSON, parse_named_configuration, to_thread
@@ -13,6 +13,18 @@ from zarr.registry import register_codec
 
 if TYPE_CHECKING:
     from typing_extensions import Self
+
+
+class GzipCodecConfigDict(CodecConfigDict):
+    """A dictionary representing a gzip codec configuration."""
+
+    level: int
+
+
+class GzipCodecDict(CodecDict[GzipCodecConfigDict]):
+    """A dictionary representing a gzip codec."""
+
+    ...
 
 
 def parse_gzip_level(data: JSON) -> int:
@@ -41,8 +53,9 @@ class GzipCodec(BytesBytesCodec):
         _, configuration_parsed = parse_named_configuration(data, "gzip")
         return cls(**configuration_parsed)  # type: ignore[arg-type]
 
-    def to_dict(self) -> dict[str, JSON]:
-        return {"name": "gzip", "configuration": {"level": self.level}}
+    def to_dict(self) -> GzipCodecDict:
+        out_dict = {"name": "gzip", "configuration": {"level": self.level}}
+        return cast(GzipCodecDict, out_dict)
 
     async def _decode_single(
         self,

--- a/src/zarr/codecs/pipeline.py
+++ b/src/zarr/codecs/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from itertools import islice, pairwise
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from warnings import warn
 
 import numpy as np
@@ -15,6 +15,7 @@ from zarr.abc.codec import (
     ArrayBytesCodecPartialEncodeMixin,
     BytesBytesCodec,
     Codec,
+    CodecDict,
     CodecPipeline,
 )
 from zarr.abc.store import ByteGetter, ByteSetter
@@ -85,8 +86,8 @@ class BatchedCodecPipeline(CodecPipeline):
                 out.append(get_codec_class(name_parsed).from_dict(c))  # type: ignore[arg-type]
         return cls.from_list(out, batch_size=batch_size)
 
-    def to_dict(self) -> JSON:
-        return [c.to_dict() for c in self]
+    def to_dict(self) -> list[CodecDict[Any]]:
+        return cast(list[CodecDict[Any]], [c.to_dict() for c in self])
 
     def evolve_from_array_spec(self, array_spec: ArraySpec) -> Self:
         return type(self).from_list([c.evolve_from_array_spec(array_spec=array_spec) for c in self])

--- a/src/zarr/core/chunk_key_encodings.py
+++ b/src/zarr/core/chunk_key_encodings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
 from zarr.abc.metadata import Metadata
 from zarr.core.common import (
@@ -21,6 +21,13 @@ def parse_separator(data: JSON) -> SeparatorLiteral:
     if data not in (".", "/"):
         raise ValueError(f"Expected an '.' or '/' separator. Got {data} instead.")
     return cast(SeparatorLiteral, data)
+
+
+class ChunkKeyEncodingDict(TypedDict):
+    """A dictionary representing a chunk key encoding configuration."""
+
+    name: str
+    configuration: dict[Literal["separator"], SeparatorLiteral]
 
 
 @dataclass(frozen=True)
@@ -53,8 +60,9 @@ class ChunkKeyEncoding(Metadata):
         msg = f"Unknown chunk key encoding. Got {name_parsed}, expected one of ('v2', 'default')."
         raise ValueError(msg)
 
-    def to_dict(self) -> dict[str, JSON]:
-        return {"name": self.name, "configuration": {"separator": self.separator}}
+    def to_dict(self) -> ChunkKeyEncodingDict:
+        out_dict = {"name": self.name, "configuration": {"separator": self.separator}}
+        return cast(ChunkKeyEncodingDict, out_dict)
 
     @abstractmethod
     def decode_chunk_key(self, chunk_key: str) -> ChunkCoords:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -5,7 +5,7 @@ import json
 import logging
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass, field, replace
-from typing import TYPE_CHECKING, Literal, cast, overload
+from typing import TYPE_CHECKING, Literal, TypedDict, cast, overload
 
 import numpy.typing as npt
 from typing_extensions import deprecated
@@ -77,8 +77,17 @@ def _parse_async_node(node: AsyncArray | AsyncGroup) -> Array | Group:
         raise TypeError(f"Unknown node type, got {type(node)}")
 
 
+class GroupMetadataDict(TypedDict):
+    """A dictionary representing a group metadata."""
+
+    attributes: dict[str, Any]
+    zarr_format: ZarrFormat
+    node_type: Literal["group"]
+
+
 @dataclass(frozen=True)
 class GroupMetadata(Metadata):
+    # TODO: Should attributes be a dict[str, JSON] instead?
     attributes: dict[str, Any] = field(default_factory=dict)
     zarr_format: ZarrFormat = 3
     node_type: Literal["group"] = field(default="group", init=False)
@@ -113,8 +122,8 @@ class GroupMetadata(Metadata):
         assert data.pop("node_type", None) in ("group", None)
         return cls(**data)
 
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    def to_dict(self) -> GroupMetadataDict:
+        return cast(GroupMetadataDict, asdict(self))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Define TypedDict classes for metadata models that have a well-typed dict representation and set the return value of the the model's to_dict() method to the TypedDict

[Description of PR]

Closes zarr-developers/zarr-python#1773

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
