### PR TITLE
Doc/v3 migration guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Zarr-Python
     :hidden:
 
     getting_started
+    migration
     tutorial
     api/index
     spec

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,22 +1,86 @@
-Installation
-============
+Zarr-Python 3 Migration Guide
+=============================
 
-Zarr depends on NumPy. It is generally best to `install NumPy
-<https://numpy.org/doc/stable/user/install.html>`_ first using whatever method is most
-appropriate for your operating system and Python distribution. Other dependencies should be
-installed automatically if using one of the installation methods below.
+Zarr-Python 3 introduces a number of changes to the API, including a number
+of significant breaking changes and pending deprecations.
 
-Install Zarr from PyPI::
+This page provides a guide highlighting the most notable changes to help you
+migrate your code from Zarr-Python 2.x to Zarr-Python 3.x.
 
-    $ pip install zarr
+Compatibility target
+--------------------
 
-Alternatively, install Zarr via conda::
+Zarr-Python 3 represents a major refactor of the Zarr-Python codebase. Some of the goals motivating this refactor included:
 
-    $ conda install -c conda-forge zarr
+  - adding support for the V3 specification (alongside the V3 specification)
+  - cleaning up internal and user facing APIs
+  - improving performance (particularly in high latency storage environments like cloud object store)
 
-To install the latest development version of Zarr, you can use pip with the
-latest GitHub main::
+Though these goals necessitated some breaking changes to the API (hence the major version update), we have tried to maintain
+backwards compatibility in the most widely used parts of the API including the `Array` and `Group` classes and the top-level
+API (e.g. `zarr.open_array` and `zarr.open_group`).
 
-    $ pip install git+https://github.com/zarr-developers/zarr-python.git
+Getting ready for 3.0
+---------------------
 
-To work with Zarr source code in development, see `Contributing <contributing.html>`_.
+Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take the following actions:
+
+1. Pin the supported Zarr-Python version to ``zarr>=2,<3``. This is a best practice and will protect your users from any incompatibilities that may arise during the release of Zarr-Python 3.0.
+2. Limit your imports from the Zarr-Python package. Most of the primary API ``zarr.*`` will be compatible in 3.0. However, the following breaking API changes are planned:
+   
+   - ``numcodecs.*`` will no longer be available in ``zarr.*``. (Suggested action: transition to importing codecs from ``numcodecs`` directly.)
+   - The ``zarr.v3_api_available`` feature flag is being removed. (Suggested action: this experimental feature was deprecated in v2.18.)
+   - The following internal modules are being removed or significant changed:
+   
+    - ``zarr.attrs``
+    - ``zarr.codecs``
+    - ``zarr.context``
+    - ``zarr.core``
+    - ``zarr.hierarchy``
+    - ``zarr.indexing``
+    - ``zarr.meta``
+    - ``zarr.meta_v1``
+    - ``zarr.storage``
+    - ``zarr.sync``
+    - ``zarr.types``
+    - ``zarr.util``
+
+Continue using Zarr-Python 2
+----------------------------
+
+Zarr-Python 2.x is still available, though we recommend migrating to Zarr-Python 3 for its improvements and new features.
+
+If you need to use the latest Zarr-Python 2 release, you can install it with:
+
+    $ pip install "zarr==2.*"
+
+
+Migration Guide
+---------------
+
+The following sections provide details on the most important changes in Zarr-Python 3.
+
+Changes to the Array class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+Changes to the Group class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+Changes to the Store class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some of the biggest changes in Zarr-Python 3 are found in the `Store` class. The most notable changes to the Store API are:
+
+1. Dropped the ``MutableMapping`` base class in favor of a custom abstract base class (``zarr.abc.store.Store``).
+2. Switched to a primarily Async interface.
+
+TODO
+
+Miscellaneous changes
+~~~~~~~~~~~~~~~~~~~~~
+
+TODO

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,86 +1,22 @@
-Zarr-Python 3 Migration Guide
-=============================
+Installation
+============
 
-Zarr-Python 3 introduces a number of changes to the API, including a number
-of significant breaking changes and pending deprecations.
+Zarr depends on NumPy. It is generally best to `install NumPy
+<https://numpy.org/doc/stable/user/install.html>`_ first using whatever method is most
+appropriate for your operating system and Python distribution. Other dependencies should be
+installed automatically if using one of the installation methods below.
 
-This page provides a guide highlighting the most notable changes to help you
-migrate your code from Zarr-Python 2.x to Zarr-Python 3.x.
+Install Zarr from PyPI::
 
-Compatibility target
---------------------
+    $ pip install zarr
 
-Zarr-Python 3 represents a major refactor of the Zarr-Python codebase. Some of the goals motivating this refactor included:
+Alternatively, install Zarr via conda::
 
-  - adding support for the V3 specification (alongside the V3 specification)
-  - cleaning up internal and user facing APIs
-  - improving performance (particularly in high latency storage environments like cloud object store)
+    $ conda install -c conda-forge zarr
 
-Though these goals necessitated some breaking changes to the API (hence the major version update), we have tried to maintain
-backwards compatibility in the most widely used parts of the API including the `Array` and `Group` classes and the top-level
-API (e.g. `zarr.open_array` and `zarr.open_group`).
+To install the latest development version of Zarr, you can use pip with the
+latest GitHub main::
 
-Getting ready for 3.0
----------------------
+    $ pip install git+https://github.com/zarr-developers/zarr-python.git
 
-Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take the following actions:
-
-1. Pin the supported Zarr-Python version to ``zarr>=2,<3``. This is a best practice and will protect your users from any incompatibilities that may arise during the release of Zarr-Python 3.0.
-2. Limit your imports from the Zarr-Python package. Most of the primary API ``zarr.*`` will be compatible in 3.0. However, the following breaking API changes are planned:
-   
-   - ``numcodecs.*`` will no longer be available in ``zarr.*``. (Suggested action: transition to importing codecs from ``numcodecs`` directly.)
-   - The ``zarr.v3_api_available`` feature flag is being removed. (Suggested action: this experimental feature was deprecated in v2.18.)
-   - The following internal modules are being removed or significant changed:
-   
-    - ``zarr.attrs``
-    - ``zarr.codecs``
-    - ``zarr.context``
-    - ``zarr.core``
-    - ``zarr.hierarchy``
-    - ``zarr.indexing``
-    - ``zarr.meta``
-    - ``zarr.meta_v1``
-    - ``zarr.storage``
-    - ``zarr.sync``
-    - ``zarr.types``
-    - ``zarr.util``
-
-Continue using Zarr-Python 2
-----------------------------
-
-Zarr-Python 2.x is still available, though we recommend migrating to Zarr-Python 3 for its improvements and new features.
-
-If you need to use the latest Zarr-Python 2 release, you can install it with:
-
-    $ pip install "zarr==2.*"
-
-
-Migration Guide
----------------
-
-The following sections provide details on the most important changes in Zarr-Python 3.
-
-Changes to the Array class
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-TODO
-
-Changes to the Group class
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-TODO
-
-Changes to the Store class
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Some of the biggest changes in Zarr-Python 3 are found in the `Store` class. The most notable changes to the Store API are:
-
-1. Dropped the ``MutableMapping`` base class in favor of a custom abstract base class (``zarr.abc.store.Store``).
-2. Switched to a primarily Async interface.
-
-TODO
-
-Miscellaneous changes
-~~~~~~~~~~~~~~~~~~~~~
-
-TODO
+To work with Zarr source code in development, see `Contributing <contributing.html>`_.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,86 @@
+Zarr-Python 3 Migration Guide
+=============================
+
+Zarr-Python 3 introduces a number of changes to the API, including a number
+of significant breaking changes and pending deprecations.
+
+This page provides a guide highlighting the most notable changes to help you
+migrate your code from Zarr-Python 2.x to Zarr-Python 3.x.
+
+Compatibility target
+--------------------
+
+Zarr-Python 3 represents a major refactor of the Zarr-Python codebase. Some of the goals motivating this refactor included:
+
+  - adding support for the V3 specification (alongside the V3 specification)
+  - cleaning up internal and user facing APIs
+  - improving performance (particularly in high latency storage environments like cloud object store)
+
+Though these goals necessitated some breaking changes to the API (hence the major version update), we have tried to maintain
+backwards compatibility in the most widely used parts of the API including the `Array` and `Group` classes and the top-level
+API (e.g. `zarr.open_array` and `zarr.open_group`).
+
+Getting ready for 3.0
+---------------------
+
+Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take the following actions:
+
+1. Pin the supported Zarr-Python version to ``zarr>=2,<3``. This is a best practice and will protect your users from any incompatibilities that may arise during the release of Zarr-Python 3.0.
+2. Limit your imports from the Zarr-Python package. Most of the primary API ``zarr.*`` will be compatible in 3.0. However, the following breaking API changes are planned:
+   
+   - ``numcodecs.*`` will no longer be available in ``zarr.*``. (Suggested action: transition to importing codecs from ``numcodecs`` directly.)
+   - The ``zarr.v3_api_available`` feature flag is being removed. (Suggested action: this experimental feature was deprecated in v2.18.)
+   - The following internal modules are being removed or significant changed:
+   
+    - ``zarr.attrs``
+    - ``zarr.codecs``
+    - ``zarr.context``
+    - ``zarr.core``
+    - ``zarr.hierarchy``
+    - ``zarr.indexing``
+    - ``zarr.meta``
+    - ``zarr.meta_v1``
+    - ``zarr.storage``
+    - ``zarr.sync``
+    - ``zarr.types``
+    - ``zarr.util``
+
+Continue using Zarr-Python 2
+----------------------------
+
+Zarr-Python 2.x is still available, though we recommend migrating to Zarr-Python 3 for its improvements and new features.
+
+If you need to use the latest Zarr-Python 2 release, you can install it with:
+
+    $ pip install "zarr==2.*"
+
+
+Migration Guide
+---------------
+
+The following sections provide details on the most important changes in Zarr-Python 3.
+
+Changes to the Array class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+Changes to the Group class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+Changes to the Store class
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some of the biggest changes in Zarr-Python 3 are found in the `Store` class. The most notable changes to the Store API are:
+
+1. Dropped the ``MutableMapping`` base class in favor of a custom abstract base class (``zarr.abc.store.Store``).
+2. Switched to a primarily Async interface.
+
+TODO
+
+Miscellaneous changes
+~~~~~~~~~~~~~~~~~~~~~
+
+TODO

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -18,7 +18,8 @@ Zarr-Python 3 represents a major refactor of the Zarr-Python codebase. Some of t
 
 Though these goals necessitated some breaking changes to the API (hence the major version update), we have tried to maintain
 backwards compatibility in the most widely used parts of the API including the `Array` and `Group` classes and the top-level
-API (e.g. `zarr.open_array` and `zarr.open_group`).
+API (e.g. `zarr.open_array` and `zarr.open_group`). It is worth noting that we significantly evolved the internal data model,
+moving away from a model that was tightly coupled to the v2 specification, and to a more generic representation of Zarr objects.
 
 Getting ready for 3.0
 ---------------------
@@ -44,11 +45,13 @@ Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take th
     - ``zarr.sync``
     - ``zarr.types``
     - ``zarr.util``
+    - ``zarr.n5``
 
 Continue using Zarr-Python 2
 ----------------------------
 
 Zarr-Python 2.x is still available, though we recommend migrating to Zarr-Python 3 for its improvements and new features.
+Security and bug fixes will be made to the 2.x series for at least 6 months following the first Zarr-Python 3 release.
 
 If you need to use the latest Zarr-Python 2 release, you can install it with:
 
@@ -63,12 +66,12 @@ The following sections provide details on the most important changes in Zarr-Pyt
 Changes to the Array class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+1. Disallow direct construction
 
 Changes to the Group class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+1. Disallow direct construction
 
 Changes to the Store class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -48,6 +48,7 @@ Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take th
 
 3. Test that your package works with v3. You can start testing against version 3 now (pre-releases are being published to PyPI weekly).
 4. Update the pin to zarr >=3
+
 Continue using Zarr-Python 2
 ----------------------------
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -5,21 +5,20 @@ Zarr-Python 3 introduces a number of changes to the API, including a number
 of significant breaking changes and pending deprecations.
 
 This page provides a guide highlighting the most notable changes to help you
-migrate your code from Zarr-Python 2.x to Zarr-Python 3.x.
+migrate your code from version 2 to version 3.
 
 Compatibility target
 --------------------
 
 Zarr-Python 3 represents a major refactor of the Zarr-Python codebase. Some of the goals motivating this refactor included:
 
-  - adding support for the V3 specification (alongside the V3 specification)
+  - adding support for the Zarr V3 specification (alongside the Zarr V2 specification)
   - cleaning up internal and user facing APIs
   - improving performance (particularly in high latency storage environments like cloud object store)
 
-Though these goals necessitated some breaking changes to the API (hence the major version update), we have tried to maintain
+These goals necessitated some breaking changes to the API (hence the major version update), but we have tried to maintain
 backwards compatibility in the most widely used parts of the API including the `Array` and `Group` classes and the top-level
-API (e.g. `zarr.open_array` and `zarr.open_group`). It is worth noting that we significantly evolved the internal data model,
-moving away from a model that was tightly coupled to the v2 specification, and to a more generic representation of Zarr objects.
+API (e.g. `zarr.open_array` and `zarr.open_group`).
 
 Getting ready for 3.0
 ---------------------
@@ -30,8 +29,8 @@ Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take th
 2. Limit your imports from the Zarr-Python package. Most of the primary API ``zarr.*`` will be compatible in 3.0. However, the following breaking API changes are planned:
    
    - ``numcodecs.*`` will no longer be available in ``zarr.*``. (Suggested action: transition to importing codecs from ``numcodecs`` directly.)
-   - The ``zarr.v3_api_available`` feature flag is being removed. (Suggested action: this experimental feature was deprecated in v2.18.)
-   - The following internal modules are being removed or significant changed:
+   - The ``zarr.v3_api_available`` feature flag is being removed. In zarr-python v3 the v3 API is always available, so you shouldn't need to use this flag.
+   - The following internal modules are being removed or significantly changed. If your application relies on imports from any of the below modules, you will need to either a) modify your application to no longer rely on these imports or b) vendor the parts of the specific modules that you need.
    
     - ``zarr.attrs``
     - ``zarr.codecs``
@@ -47,6 +46,8 @@ Ahead of the 3.0 release, we suggest projects that depend on Zarr-Python take th
     - ``zarr.util``
     - ``zarr.n5``
 
+3. Test that your package works with v3. You can start testing against version 3 now (pre-releases are being published to PyPI weekly).
+4. Update the pin to zarr >=3
 Continue using Zarr-Python 2
 ----------------------------
 


### PR DESCRIPTION
Over the past few weeks, we've had a number of conversations/questions about the policy for backward compatibility, deprecations, and breaking changes with the upcoming 3.0 release. This doc is meant to help us iterate toward common language. In its initial form, it is not complete.

Goals for the text here:

1. Developers of 2.18 and 3.0 should be able to decide if backward compatibility is a required attribute of a contribution
2. Users of Zarr should be able to understand if their application will be impacted by the upcoming 3.0 release
3. Users of Zarr should be able to make a plan for how they will adapt their usage of Zarr after the release
1. [non-goal] This is not meant to provide a comprehensive listing of the changes to the zarr API 

cc @zarr-developers/python-core-devs 
