### PR TITLE
Fix Array.__array__ for numpy 2.1

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,13 +24,22 @@ Release notes
 2.18.3
 ------
 
+Enhancements
+~~~~~~~~~~~~
+* Added support for creating a copy of data when converting a `zarr.Array`
+  to a numpy array.
+  By :user:`David Stansby <dstansby>`
+
 Maintenance
 ~~~~~~~~~~~
 * Removed support for Python 3.9.
   By :user:`David Stansby <dstansby>`
-  
+
 * Fix a regression when using orthogonal indexing with a scalar.
   By :user:`Deepak Cherian <dcherian>` :issue:`1931`
+
+* Added compatibility with numpy 2.1.
+  By :user:`David Stansby <dstansby>`
 
 
 .. _release_2.18.2:

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -576,13 +576,7 @@ class Array:
         )
 
     def __array__(self, dtype=None, copy=None):
-        a = self[...]
-        if dtype is not None:
-            a = a.astype(dtype=dtype)
-
-        if copy is not None and copy:
-            return a.copy()
-        return a
+        return np.array(self[...], dtype=dtype, copy=copy)
 
     def islice(self, start=None, end=None):
         """

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -575,10 +575,13 @@ class Array:
             # store comparison
         )
 
-    def __array__(self, *args):
+    def __array__(self, dtype=None, copy=None):
         a = self[...]
-        if args:
-            a = a.astype(args[0])
+        if dtype is not None:
+            a = a.astype(dtype=dtype)
+
+        if copy is not None and copy:
+            return a.copy()
         return a
 
     def islice(self, start=None, end=None):


### PR DESCRIPTION
This updates __array__ for numpy 2.1, specifically by implementing the copy keyword argument.

The one test failure is an issue with a new version of numcodecs (0.13.0) which is a simple fix, but easier to make when we bump the numocdecs version in the test dependencies, so I'd advocate for merging this PR and dealing with the numcodecs bump in a follow up PR.

TODO:
* [x] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
