### PR TITLE
Bump test version of numcodecs

### DIFF
--- a/requirements_dev_minimal.txt
+++ b/requirements_dev_minimal.txt
@@ -1,7 +1,7 @@
 # library requirements
 asciitree==0.3.3
 fasteners==0.19
-numcodecs==0.12.1
+numcodecs==0.13.0
 msgpack-python==0.5.6
 setuptools-scm==8.1.0
 # test requirements

--- a/zarr/tests/test_meta.py
+++ b/zarr/tests/test_meta.py
@@ -282,36 +282,28 @@ def test_encode_decode_array_dtype_shape_v3(cname):
         fill_value=None,
         chunk_memory_layout="C",
     )
-
-    meta_json = (
-        """{
+    meta_expected = {
         "attributes": {},
-        "chunk_grid": {
-            "chunk_shape": [10],
-            "separator": "/",
-            "type": "regular"
-        },
+        "chunk_grid": {"chunk_shape": [10], "separator": "/", "type": "regular"},
         "chunk_memory_layout": "C",
         "compressor": {
-        """
-        + f"""
-        "codec": "https://purl.org/zarr/spec/codec/{cname}/1.0",
-        """
-        + """
-            "configuration": {
-                "level": 1
-            }
+            "codec": f"https://purl.org/zarr/spec/codec/{cname}/1.0",
+            "configuration": {"level": 1},
         },
         "data_type": "<f8",
         "extensions": [],
-        "fill_value": null,
-        "shape": [100, 10, 10 ]
-    }"""
-    )
+        "fill_value": None,
+        "shape": [100, 10, 10],
+    }
+
+    if cname == "zstd":
+        meta_expected["compressor"]["configuration"]["checksum"] = False
+
+    meta_expected_json = json.dumps(meta_expected)
 
     # test encoding
     meta_enc = Metadata3.encode_array_metadata(meta)
-    assert_json_equal(meta_json, meta_enc)
+    assert_json_equal(meta_enc, meta_expected_json)
 
     # test decoding
     meta_dec = Metadata3.decode_array_metadata(meta_enc)


### PR DESCRIPTION
This bumps the test version of numcodecs to 0.13.0, and fixes a test where the output changed with 0.13.0. Along the way I made the test a bit simpler to avoid having to deal with multi-line strings.

TODO:
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
