### PR TITLE
fix: numpy 1.24 compat for Array.__array__

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -575,8 +575,8 @@ class Array:
             # store comparison
         )
 
-    def __array__(self, dtype=None, copy=None):
-        return np.array(self[...], dtype=dtype, copy=copy)
+    def __array__(self, *args, **kwargs):
+        return np.array(self[...], *args, **kwargs)
 
     def islice(self, start=None, end=None):
         """


### PR DESCRIPTION
This PR slightly modifies #2106 to allow for any args/kwargs to be passed to `__array__`.  Without this, earlier versions of NumPy error with the following traceback:

```
    def __array__(self, dtype=None, copy=None):
>       return np.array(self[...], dtype=dtype, copy=copy)
E       ValueError: NoneType copy mode not allowed.
```

@dstansby - mind giving this a look

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)

