### PR TITLE
Run tests on numpy 1.23

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,6 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
         numpy_version: ['>=1.24.0', '==1.23.*']
         exclude:
-          - python-version: '3.10'
-            numpy_version: '==1.23.*'
           - python-version: '3.11'
             numpy_version: '==1.23.*'
           - python-version: '3.12'


### PR DESCRIPTION
https://github.com/zarr-developers/zarr-python/pull/2123 fixed a bug that was introduced with an older version of numpy. This puts back numpy 1.23 in the test matrix on GitHub actions to catch stuff like this in the future.

I think this was previously enabled, but accidentally lost when Python 3.9 support was dropped.