### PR TITLE
Debug azure-storage-blob test failures

### DIFF
--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -5,9 +5,7 @@ lmdb==1.5.1; sys_platform != 'win32'
 ipytree==0.2.2
 ipywidgets==8.1.3
 # optional library requirements for services
-# don't let pyup change pinning for azure-storage-blob, need to pin to older
-# version to get compatibility with azure storage emulator on appveyor (FIXME)
-azure-storage-blob==12.16.0 # pyup: ignore
+azure-storage-blob==12.21.0
 redis==5.0.8
 types-redis
 types-setuptools


### PR DESCRIPTION
Hopefully get to the bottom of what's going on in https://github.com/zarr-developers/zarr-python/pull/2122...

I'm going to start by bisecting what version of `azure-storage-blob` first had an issue. For reference, changelog here: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-blob/CHANGELOG.md

The highest version that still works is 2.21.0, so I've set that as the pin here.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
