### PR TITLE
chore: bump minimum numpy version to 1.24

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        numpy_version: ['>=1.24.0', '==1.23.*']
+        numpy_version: ['>=2.1', '==1.24.*', '==1.26.*']
         exclude:
-          - python-version: '3.11'
-            numpy_version: '==1.23.*'
           - python-version: '3.12'
-            numpy_version: '==1.23.*'
+            numpy_version: '==1.24.*'
     services:
       redis:
         image: redis
@@ -61,7 +59,7 @@ jobs:
         conda activate zarr-env
         python -m pip install --upgrade pip
         python -m pip install -U pip setuptools wheel line_profiler
-        python -m pip install -rrequirements_dev_minimal.txt numpy${{matrix.numpy_version}} -rrequirements_dev_optional.txt pymongo redis
+        python -m pip install -r requirements_dev_minimal.txt numpy${{matrix.numpy_version}} -r requirements_dev_optional.txt pymongo redis
         python -m pip install -e .
         python -m pip freeze
     - name: Tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-        numpy_version: ['>=2.1', '==1.24.*', '==1.26.*']
+        numpy_version: ['>=2.1', '==1.24.*']
         exclude:
           - python-version: '3.12'
             numpy_version: '==1.24.*'

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -39,8 +39,11 @@ Maintenance
 * Fix a regression when using orthogonal indexing with a scalar.
   By :user:`Deepak Cherian <dcherian>` :issue:`1931`
 
-* Added compatibility with numpy 2.1.
+* Added compatibility with NumPy 2.1.
   By :user:`David Stansby <dstansby>`
+
+* Bump minimum NumPy version to 1.24.
+  :user:`Joe Hamman <jhamman>` (:issue:`2127`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 requires-python = ">=3.10"
 dependencies = [
     'asciitree',
-    'numpy>=1.23',
+    'numpy>=1.24',
     'fasteners; sys_platform != "emscripten"',
     'numcodecs>=0.10.0',
 ]


### PR DESCRIPTION
Updates minimum numpy version to 1.24.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
