### PR TITLE
[v3] h5py compat methods on Group

### DIFF
--- a/src/zarr/core/common.py
+++ b/src/zarr/core/common.py
@@ -28,6 +28,7 @@ ZGROUP_JSON = ".zgroup"
 ZATTRS_JSON = ".zattrs"
 
 BytesLike = bytes | bytearray | memoryview
+ShapeLike = tuple[int, ...] | int
 ChunkCoords = tuple[int, ...]
 ChunkCoordsLike = Iterable[int]
 ZarrFormat = Literal[2, 3]

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -345,18 +345,20 @@ class AsyncGroup:
             grp = await self.create_group(name, exists_ok=True)
         else:
             try:
-                grp = await self.getitem(name)
-                if not isinstance(grp, AsyncGroup):
+                item: AsyncGroup | AsyncArray = await self.getitem(name)
+                if not isinstance(item, AsyncGroup):
                     raise TypeError(
-                        f"Incompatible object ({grp.__class__.__name__}) already exists"
+                        f"Incompatible object ({item.__class__.__name__}) already exists"
                     )
+                assert isinstance(item, AsyncGroup)  # make mypy happy
+                grp = item
             except KeyError:
                 grp = await self.create_group(name)
         return grp
 
     async def require_groups(self, *names: str) -> tuple[AsyncGroup, ...]:
         """Convenience method to require multiple groups in a single call."""
-        return tuple(await concurrent_map(list(names), self.require_group))
+        return tuple(await concurrent_map([names], self.require_group))
 
     async def create_array(
         self,
@@ -457,7 +459,7 @@ class AsyncGroup:
         name : string
             Array name.
         kwargs : dict
-            Additional arguments passed to create_array()
+            Additional arguments passed to AsyncGroup.create_array()
 
         Returns
         -------
@@ -886,14 +888,14 @@ class Group(SyncMixin):
         """Create an array.
 
         Arrays are known as "datasets" in HDF5 terminology. For compatibility
-        with h5py, Zarr groups also implement the require_dataset() method.
+        with h5py, Zarr groups also implement the :func:`zarr.Group.require_dataset` method.
 
         Parameters
         ----------
         name : string
             Array name.
         kwargs : dict
-            Additional arguments passed to create_array()
+            Additional arguments passed to :func:`zarr.Group.create_array`
 
         Returns
         -------
@@ -905,7 +907,7 @@ class Group(SyncMixin):
         """Obtain an array, creating if it doesn't exist.
 
         Arrays are known as "datasets" in HDF5 terminology. For compatibility
-        with h5py, Zarr groups also implement the create_dataset() method.
+        with h5py, Zarr groups also implement the :func:`zarr.Group.create_dataset` method.
 
         Other `kwargs` are as per :func:`zarr.Group.create_dataset`.
 

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -452,14 +452,14 @@ class AsyncGroup:
         """Create an array.
 
         Arrays are known as "datasets" in HDF5 terminology. For compatibility
-        with h5py, Zarr groups also implement the require_dataset() method.
+        with h5py, Zarr groups also implement the :func:`zarr.AsyncGroup.require_dataset` method.
 
         Parameters
         ----------
         name : string
             Array name.
         kwargs : dict
-            Additional arguments passed to AsyncGroup.create_array()
+            Additional arguments passed to :func:`zarr.AsyncGroup.create_array`.
 
         Returns
         -------
@@ -479,9 +479,9 @@ class AsyncGroup:
         """Obtain an array, creating if it doesn't exist.
 
         Arrays are known as "datasets" in HDF5 terminology. For compatibility
-        with h5py, Zarr groups also implement the create_dataset() method.
+        with h5py, Zarr groups also implement the :func:`zarr.AsyncGroup.create_dataset` method.
 
-        Other `kwargs` are as per :func:`zarr.Group.create_dataset`.
+        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
 
         Parameters
         ----------
@@ -494,6 +494,10 @@ class AsyncGroup:
         exact : bool, optional
             If True, require `dtype` to match exactly. If false, require
             `dtype` can be cast from array dtype.
+
+        Returns
+        -------
+        a : AsyncArray
         """
         try:
             ds = await self.getitem(name)

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -451,7 +451,7 @@ class AsyncGroup:
             data=data,
         )
 
-    @deprecated("Use Group.create_array instead.")
+    @deprecated("Use AsyncGroup.create_array instead.")
     async def create_dataset(self, name: str, **kwargs: Any) -> AsyncArray:
         """Create an array.
 
@@ -470,11 +470,11 @@ class AsyncGroup:
         a : AsyncArray
 
         .. deprecated:: 3.0.0
-            The h5py compatibility methods will be removed in 3.1.0. Use `Group.create_array` instead.
+            The h5py compatibility methods will be removed in 3.1.0. Use `AsyncGroup.create_array` instead.
         """
         return await self.create_array(name, **kwargs)
 
-    @deprecated("Use Group.require_array instead.")
+    @deprecated("Use AsyncGroup.require_array instead.")
     async def require_dataset(
         self,
         name: str,
@@ -508,7 +508,7 @@ class AsyncGroup:
         a : AsyncArray
 
         .. deprecated:: 3.0.0
-            The h5py compatibility methods will be removed in 3.1.0. Use `Group.require_dataset` instead.
+            The h5py compatibility methods will be removed in 3.1.0. Use `AsyncGroup.require_dataset` instead.
         """
         return await self.require_array(name, shape=shape, dtype=dtype, exact=exact, **kwargs)
 
@@ -558,7 +558,7 @@ class AsyncGroup:
                 if not np.can_cast(ds.dtype, dtype):
                     raise TypeError(f"Incompatible dtype ({ds.dtype} vs {dtype})")
         except KeyError:
-            ds = await self.create_dataset(name, shape=shape, dtype=dtype, **kwargs)
+            ds = await self.create_array(name, shape=shape, dtype=dtype, **kwargs)
 
         return ds
 
@@ -981,6 +981,7 @@ class Group(SyncMixin):
             )
         )
 
+    @deprecated("Use Group.create_array instead.")
     def create_dataset(self, name: str, **kwargs: Any) -> Array:
         """Create an array.
 
@@ -997,9 +998,13 @@ class Group(SyncMixin):
         Returns
         -------
         a : Array
+
+        .. deprecated:: 3.0.0
+            The h5py compatibility methods will be removed in 3.1.0. Use `Group.create_array` instead.
         """
         return Array(self._sync(self._async_group.create_dataset(name, **kwargs)))
 
+    @deprecated("Use Group.require_array instead.")
     def require_dataset(self, name: str, **kwargs: Any) -> Array:
         """Obtain an array, creating if it doesn't exist.
 
@@ -1019,8 +1024,39 @@ class Group(SyncMixin):
         exact : bool, optional
             If True, require `dtype` to match exactly. If false, require
             `dtype` can be cast from array dtype.
+
+        Returns
+        -------
+        a : Array
+
+        .. deprecated:: 3.0.0
+            The h5py compatibility methods will be removed in 3.1.0. Use `Group.require_array` instead.
         """
-        return Array(self._sync(self._async_group.require_dataset(name, **kwargs)))
+        return Array(self._sync(self._async_group.require_array(name, **kwargs)))
+
+    def require_array(self, name: str, **kwargs: Any) -> Array:
+        """Obtain an array, creating if it doesn't exist.
+
+
+        Other `kwargs` are as per :func:`zarr.Group.create_array`.
+
+        Parameters
+        ----------
+        name : string
+            Array name.
+        shape : int or tuple of ints
+            Array shape.
+        dtype : string or dtype, optional
+            NumPy dtype.
+        exact : bool, optional
+            If True, require `dtype` to match exactly. If false, require
+            `dtype` can be cast from array dtype.
+
+        Returns
+        -------
+        a : Array
+        """
+        return Array(self._sync(self._async_group.require_array(name, **kwargs)))
 
     def empty(self, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty(**kwargs)))

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -252,7 +252,7 @@ class AsyncGroup:
             if zarray is not None:
                 # TODO: update this once the V2 array support is part of the primary array class
                 zarr_json = {**zarray, "attributes": zattrs}
-                return AsyncArray.from_dict(store_path, zarray)
+                return AsyncArray.from_dict(store_path, zarr_json)
             else:
                 zgroup = (
                     json.loads(zgroup_bytes.to_bytes())
@@ -502,7 +502,6 @@ class AsyncGroup:
         """
         try:
             ds = await self.getitem(name)
-            print("Found existing dataset", ds)
             if not isinstance(ds, AsyncArray):
                 raise TypeError(f"Incompatible object ({ds.__class__.__name__}) already exists")
 
@@ -518,7 +517,6 @@ class AsyncGroup:
                 if not np.can_cast(ds.dtype, dtype):
                     raise TypeError(f"Incompatible dtype ({ds.dtype} vs {dtype})")
         except KeyError:
-            print(f"Creating dataset {name} with shape {shape} and dtype {dtype}")
             ds = await self.create_dataset(name, shape=shape, dtype=dtype, **kwargs)
 
         return ds
@@ -670,8 +668,9 @@ class Group(SyncMixin):
     def open(
         cls,
         store: StoreLike,
+        zarr_format: Literal[2, 3, None] = 3,
     ) -> Group:
-        obj = sync(AsyncGroup.open(store))
+        obj = sync(AsyncGroup.open(store, zarr_format=zarr_format))
         return cls(obj)
 
     def __getitem__(self, path: str) -> Array | Group:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -451,6 +451,7 @@ class AsyncGroup:
             data=data,
         )
 
+    @deprecated("Use Group.create_array instead.")
     async def create_dataset(self, name: str, **kwargs: Any) -> AsyncArray:
         """Create an array.
 
@@ -467,9 +468,13 @@ class AsyncGroup:
         Returns
         -------
         a : AsyncArray
+
+        .. deprecated:: 3.0.0
+            The h5py compatibility methods will be removed in 3.1.0. Use `Group.create_array` instead.
         """
         return await self.create_array(name, **kwargs)
 
+    @deprecated("Use Group.require_array instead.")
     async def require_dataset(
         self,
         name: str,
@@ -483,6 +488,40 @@ class AsyncGroup:
 
         Arrays are known as "datasets" in HDF5 terminology. For compatibility
         with h5py, Zarr groups also implement the :func:`zarr.AsyncGroup.create_dataset` method.
+
+        Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
+
+        Parameters
+        ----------
+        name : string
+            Array name.
+        shape : int or tuple of ints
+            Array shape.
+        dtype : string or dtype, optional
+            NumPy dtype.
+        exact : bool, optional
+            If True, require `dtype` to match exactly. If false, require
+            `dtype` can be cast from array dtype.
+
+        Returns
+        -------
+        a : AsyncArray
+
+        .. deprecated:: 3.0.0
+            The h5py compatibility methods will be removed in 3.1.0. Use `Group.require_dataset` instead.
+        """
+        return await self.require_array(name, shape=shape, dtype=dtype, exact=exact, **kwargs)
+
+    async def require_array(
+        self,
+        name: str,
+        *,
+        shape: ChunkCoords,
+        dtype: npt.DTypeLike = None,
+        exact: bool = False,
+        **kwargs: Any,
+    ) -> AsyncArray:
+        """Obtain an array, creating if it doesn't exist.
 
         Other `kwargs` are as per :func:`zarr.AsyncGroup.create_dataset`.
 

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -794,26 +794,26 @@ async def test_create_dataset(store: LocalStore | MemoryStore, zarr_format: Zarr
         await root.create_dataset("bar", shape=(100,), dtype="int8")
 
 
-async def test_require_dataset(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+async def test_require_array(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
     root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
-    foo1 = await root.require_dataset("foo", shape=(10,), dtype="i8", attributes={"foo": 101})
+    foo1 = await root.require_array("foo", shape=(10,), dtype="i8", attributes={"foo": 101})
     assert foo1.attrs == {"foo": 101}
-    foo2 = await root.require_dataset("foo", shape=(10,), dtype="i8")
+    foo2 = await root.require_array("foo", shape=(10,), dtype="i8")
     assert foo2.attrs == {"foo": 101}
 
     # exact = False
-    _ = await root.require_dataset("foo", shape=10, dtype="f8")
+    _ = await root.require_array("foo", shape=10, dtype="f8")
 
     # errors w/ exact True
     with pytest.raises(TypeError, match="Incompatible dtype"):
-        await root.require_dataset("foo", shape=(10,), dtype="f8", exact=True)
+        await root.require_array("foo", shape=(10,), dtype="f8", exact=True)
 
     with pytest.raises(TypeError, match="Incompatible shape"):
-        await root.require_dataset("foo", shape=(100, 100), dtype="i8")
+        await root.require_array("foo", shape=(100, 100), dtype="i8")
 
     with pytest.raises(TypeError, match="Incompatible dtype"):
-        await root.require_dataset("foo", shape=(10,), dtype="f4")
+        await root.require_array("foo", shape=(10,), dtype="f4")
 
     _ = await root.create_group("bar")
     with pytest.raises(TypeError, match="Incompatible object"):
-        await root.require_dataset("bar", shape=(10,), dtype="int8")
+        await root.require_array("bar", shape=(10,), dtype="int8")

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -657,8 +657,7 @@ async def test_asyncgroup_update_attributes(
 
 async def test_require_group(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
     root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
-    with pytest.raises(KeyError):
-        await root.getitem("foo")
+
     # create foo group
     _ = await root.create_group("foo", attributes={"foo": 100})
 
@@ -720,14 +719,24 @@ async def test_create_dataset(store: LocalStore | MemoryStore, zarr_format: Zarr
 
 async def test_require_dataset(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
     root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
-    foo1 = await root.require_dataset("foo", shape=(10,), dtype="uint8", attributes={"foo": 101})
+    foo1 = await root.require_dataset("foo", shape=(10,), dtype="i8", attributes={"foo": 101})
     assert foo1.attrs == {"foo": 101}
-    foo2 = await root.require_dataset("foo", shape=(10,), dtype="uint8")
+    foo2 = await root.require_dataset("foo", shape=(10,), dtype="i8")
     assert foo2.attrs == {"foo": 101}
 
-    # with pytest.raises(TypeError):
-    #     await root.require_dataset("foo", shape=(100,), dtype="int8")
+    # exact = False
+    _ = await root.require_dataset("foo", shape=10, dtype="f8")
 
-    # _ = await root.create_group("bar")
-    # with pytest.raises(TypeError):
-    #     await root.require_dataset("bar", shape=(100,), dtype="int8")
+    # errors w/ exact True
+    with pytest.raises(TypeError, match="Incompatible dtype"):
+        await root.require_dataset("foo", shape=(10,), dtype="f8", exact=True)
+
+    with pytest.raises(TypeError, match="Incompatible shape"):
+        await root.require_dataset("foo", shape=(100, 100), dtype="i8")
+
+    with pytest.raises(TypeError, match="Incompatible dtype"):
+        await root.require_dataset("foo", shape=(10,), dtype="f4")
+
+    _ = await root.create_group("bar")
+    with pytest.raises(TypeError, match="Incompatible object"):
+        await root.require_dataset("bar", shape=(10,), dtype="int8")

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -653,3 +653,81 @@ async def test_asyncgroup_update_attributes(
 
     agroup_new_attributes = await agroup.update_attributes(attributes_new)
     assert agroup_new_attributes.attrs == attributes_new
+
+
+async def test_require_group(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+    root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
+    with pytest.raises(KeyError):
+        await root.getitem("foo")
+    # create foo group
+    _ = await root.create_group("foo", attributes={"foo": 100})
+
+    # test that we can get the group using require_group
+    foo_group = await root.require_group("foo")
+    assert foo_group.attrs == {"foo": 100}
+
+    # test that we can get the group using require_group and overwrite=True
+    foo_group = await root.require_group("foo", overwrite=True)
+
+    _ = await foo_group.create_array(
+        "bar", shape=(10,), dtype="uint8", chunk_shape=(2,), attributes={"foo": 100}
+    )
+
+    # test that overwriting a group w/ children fails
+    # TODO: figure out why ensure_no_existing_node is not catching the foo.bar array
+    #
+    # with pytest.raises(ContainsArrayError):
+    #     await root.require_group("foo", overwrite=True)
+
+    # test that requiring a group where an array is fails
+    with pytest.raises(TypeError):
+        await foo_group.require_group("bar")
+
+
+async def test_require_groups(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+    root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
+    # create foo group
+    _ = await root.create_group("foo", attributes={"foo": 100})
+    # create bar group
+    _ = await root.create_group("bar", attributes={"bar": 200})
+
+    foo_group, bar_group = await root.require_groups("foo", "bar")
+    assert foo_group.attrs == {"foo": 100}
+    assert bar_group.attrs == {"bar": 200}
+
+    # get a mix of existing and new groups
+    foo_group, spam_group = await root.require_groups("foo", "spam")
+    assert foo_group.attrs == {"foo": 100}
+    assert spam_group.attrs == {}
+
+    # no names
+    no_group = await root.require_groups()
+    assert no_group == ()
+
+
+async def test_create_dataset(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+    root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
+    foo = await root.create_dataset("foo", shape=(10,), dtype="uint8")
+    assert foo.shape == (10,)
+
+    with pytest.raises(ContainsArrayError):
+        await root.create_dataset("foo", shape=(100,), dtype="int8")
+
+    _ = await root.create_group("bar")
+    with pytest.raises(ContainsGroupError):
+        await root.create_dataset("bar", shape=(100,), dtype="int8")
+
+
+async def test_require_dataset(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
+    root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
+    foo1 = await root.require_dataset("foo", shape=(10,), dtype="uint8", attributes={"foo": 101})
+    assert foo1.attrs == {"foo": 101}
+    foo2 = await root.require_dataset("foo", shape=(10,), dtype="uint8")
+    assert foo2.attrs == {"foo": 101}
+
+    # with pytest.raises(TypeError):
+    #     await root.require_dataset("foo", shape=(100,), dtype="int8")
+
+    # _ = await root.create_group("bar")
+    # with pytest.raises(TypeError):
+    #     await root.require_dataset("bar", shape=(100,), dtype="int8")


### PR DESCRIPTION
This PR adds the h5py compat methods to the Zarr Group API from v2. 

The plan described in #1583 was to remove these but after looking into it, a bit more, I came to the conclusion that `require_group` and `require_dataset` are actually pretty useful. I'm open to adding deprecation warnings to `create_dataset` and `require_dataset` (perhaps replacing the latter with `require_array`) if we want to phase out the h5py specific language. 

closes #1597

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
