### PR TITLE
Fix dtype type error

### DIFF
--- a/src/zarr/core/metadata.py
+++ b/src/zarr/core/metadata.py
@@ -564,7 +564,7 @@ INTEGER_DTYPE = (
     | np.dtypes.Int16DType
     | np.dtypes.Int32DType
     | np.dtypes.Int64DType
-    | np.dtypes.UByteDType
+    | np.dtypes.UInt8DType
     | np.dtypes.UInt16DType
     | np.dtypes.UInt32DType
     | np.dtypes.UInt64DType


### PR DESCRIPTION
Fixes part of https://github.com/zarr-developers/zarr-python/issues/2131. `UByteDType` is a type alias for `UInt8DType`, so fine to change it and it's now recognised as a proper type.