### PR TITLE
fix: selection with zarr arrays

### DIFF
--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -34,7 +34,9 @@ if TYPE_CHECKING:
 IntSequence = list[int] | npt.NDArray[np.intp]
 ArrayOfIntOrBool = npt.NDArray[np.intp] | npt.NDArray[np.bool_]
 BasicSelector = int | slice | EllipsisType
-Selector = BasicSelector | ArrayOfIntOrBool
+Selector = (
+    BasicSelector | ArrayOfIntOrBool | Array
+)  # help! we want zarr.Array[np.intp] | zarr.Array[np.bool_]
 
 BasicSelection = BasicSelector | tuple[BasicSelector, ...]  # also used for BlockIndex
 CoordinateSelection = IntSequence | tuple[IntSequence, ...]
@@ -839,6 +841,10 @@ class OIndex:
     array: Array
 
     def __getitem__(self, selection: OrthogonalSelection) -> NDArrayLike:
+        from zarr.core.array import Array
+
+        if isinstance(selection, Array):
+            selection = np.asarray(selection)
         fields, new_selection = pop_fields(selection)
         new_selection = ensure_tuple(new_selection)
         new_selection = replace_lists(new_selection)
@@ -1127,6 +1133,10 @@ class VIndex:
     array: Array
 
     def __getitem__(self, selection: CoordinateSelection | MaskSelection) -> NDArrayLike:
+        from zarr.core.array import Array
+
+        if isinstance(selection, Array):
+            selection = np.asarray(selection)
         fields, new_selection = pop_fields(selection)
         new_selection = ensure_tuple(new_selection)
         new_selection = replace_lists(new_selection)

--- a/tests/v3/test_indexing.py
+++ b/tests/v3/test_indexing.py
@@ -1780,3 +1780,16 @@ def test_orthogonal_bool_indexing_like_numpy_ix(store, selection):
     # note: in python 3.10 z[*selection] is not valid unpacking syntax
     actual = z[(*selection,)]
     assert_array_equal(expected, actual, err_msg=f"{selection=}")
+
+
+def test_indexing_with_zarr_array(store) -> None:
+    # regression test for https://github.com/zarr-developers/zarr-python/issues/2133
+    a = np.arange(10)
+    za = zarr.array(a, chunks=2)
+    ix = [False, True, False, True, False, True, False, True, False, True]
+
+    zix = zarr.array(ix, chunks=2)
+    za = zarr.array(a, chunks=2)
+    assert_array_equal(a[ix], za[zix])
+    assert_array_equal(a[ix], za.oindex[zix])
+    assert_array_equal(a[ix], za.vindex[zix])


### PR DESCRIPTION
This is a partial solution to #2133. It works but does so in a potential suboptimal way -- materializing the entire indexer before indexing. A deeper solution would include streaming indexer chunks from the selector to oindex/vindex but I think that can wait until later.

closes #2133 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
