### PR TITLE
[docs] remove primary sidebar from tutorial

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,7 +195,9 @@ html_js_files = [
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+html_sidebars = {
+    "tutorial": []
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,9 +195,7 @@ html_js_files = [
 # html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    "tutorial": []
-}
+html_sidebars = {"tutorial": []}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
pydata-sphinx-theme has a dual-sidebar system that makes some pretty specific assumptions about the structure of docs to work well, but has some odd behaviors otherwise. This PR makes the tutorial page look a little tidier.

## Current Behavior

Currently on the tutorial page, the primary sidebar is totally empty. on wide screens, this is sort of a curiosity, but it becomes a nuisance on narrower screens. More than anything is just looks weird and unfinished (not your fault, byproduct of the theme)

Wider than medium breakpoint:
<img width="1243" alt="Screenshot 2024-08-30 at 2 41 44 PM" src="https://github.com/user-attachments/assets/c4b274e0-a244-403e-a3cc-c341dc9c8dc9">

Below medium breakpoint:
<img width="1000" alt="Screenshot 2024-08-30 at 2 42 10 PM" src="https://github.com/user-attachments/assets/19e3d552-3d87-46f7-9fe0-87bd775686a1">

## This PR

Thankfully pydata-sphinx-theme also gives us nice control over the sidebars! Simply removing the primary sidebar makes it look tidier and uses screen space better.

Wider than medium breakpoint:
<img width="1243" alt="Screenshot 2024-08-30 at 2 41 51 PM" src="https://github.com/user-attachments/assets/82fc31b7-15a3-411d-9734-94d0c2508a14">

Below medium breakpoint:
<img width="999" alt="Screenshot 2024-08-30 at 2 42 17 PM" src="https://github.com/user-attachments/assets/a2abd679-e9cc-4975-a44f-3e8f57d03f4a">

## Alternatively...

Another option is to move the page toc to the primary sidebar, which makes it stay visible at narrower widths:

```python
html_theme_options = {
    # ...
    "secondary_sidebar_items": {
        "tutorial": []
    }
}

html_sidebars = {
    "tutorial": ["page-toc"]
}
```

Below medium breakpoint:
<img width="1001" alt="Screenshot 2024-08-30 at 2 43 15 PM" src="https://github.com/user-attachments/assets/9df9e4c3-35f9-47e1-b2d6-f8dabeddaaf1">

Went with the first one, but can switch to the second easily if that's preferred. This is also true of the other pages in the docs, but didn't want to change too much at once before knowing if this is desirable or not.


TODO:
* [x] Add unit tests and/or doctests in docstrings (not needed)
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions (none modified)
* [x] New/modified features documented in docs/tutorial.rst (none modified)
* [x] Changes documented in docs/release.rst (it's a change to the docs layout! not documentable)
* [x] GitHub Actions have all passed (hopefully)
* [x] Test coverage is 100% (Codecov passes) (also hopefully)
