### PR TITLE
Fix new ruff/flake8-type-checking TCH003 error

### DIFF
--- a/tests/v3/test_buffer.py
+++ b/tests/v3/test_buffer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import types
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -22,6 +22,9 @@ from zarr.testing.buffer import (
     TestNDArrayLike,
 )
 from zarr.testing.utils import gpu_test
+
+if TYPE_CHECKING:
+    import types
 
 try:
     import cupy as cp


### PR DESCRIPTION
TCH003 Move standard library import into a type-checking block

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
