### PR TITLE
Fixed path segment duplication in open_array

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -897,7 +897,6 @@ async def open_array(
         if store_path.store.mode.create:
             return await create(
                 store=store_path,
-                path=path,
                 zarr_format=zarr_format,
                 overwrite=store_path.store.mode.overwrite,
                 **kwargs,


### PR DESCRIPTION
The `path` component was included twice when calling `create` from `open_array`, once in `store_path` and once in `path`.

The new test confirms that users can create an array at a given path and then read it at that same path.

Closes https://github.com/zarr-developers/zarr-python/issues/2166

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
