### PR TITLE
Fixed test warnings

### DIFF
--- a/src/zarr/testing/buffer.py
+++ b/src/zarr/testing/buffer.py
@@ -25,9 +25,13 @@ __all__ = [
 class TestNDArrayLike(np.ndarray):
     """An example of a ndarray-like class"""
 
+    __test__ = False
+
 
 class TestBuffer(cpu.Buffer):
     """Example of a custom Buffer that handles ArrayLike"""
+
+    __test__ = False
 
 
 class NDBufferUsingTestNDArrayLike(cpu.NDBuffer):

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -785,14 +785,15 @@ async def test_require_groups(store: LocalStore | MemoryStore, zarr_format: Zarr
 
 async def test_create_dataset(store: LocalStore | MemoryStore, zarr_format: ZarrFormat) -> None:
     root = await AsyncGroup.create(store=store, zarr_format=zarr_format)
-    foo = await root.create_dataset("foo", shape=(10,), dtype="uint8")
+    with pytest.warns(DeprecationWarning):
+        foo = await root.create_dataset("foo", shape=(10,), dtype="uint8")
     assert foo.shape == (10,)
 
-    with pytest.raises(ContainsArrayError):
+    with pytest.raises(ContainsArrayError), pytest.warns(DeprecationWarning):
         await root.create_dataset("foo", shape=(100,), dtype="int8")
 
     _ = await root.create_group("bar")
-    with pytest.raises(ContainsGroupError):
+    with pytest.raises(ContainsGroupError), pytest.warns(DeprecationWarning):
         await root.create_dataset("bar", shape=(100,), dtype="int8")
 
 


### PR DESCRIPTION
Fixes a few warnings I spotted in the tests:


```
  /Users/tom/gh/zarr-developers/zarr-python/src/zarr/testing/buffer.py:29: PytestCollectionWarning: cannot collect test class 'TestBuffer' because it has a __init__ constructor (from: tests/v3/test_buffer.py)
```

fixed by setting `__test__ = False` on those classes.

And a few of our deprecation warnings that weren't being silenced / asserted.

There's some remaining warnings in `test_remote` about not having running / not running event loops that I haven't debugged yet. Those can be done later.
