### PR TITLE
Deprecate zarr.storage

### DIFF
--- a/src/zarr/storage.py
+++ b/src/zarr/storage.py
@@ -1,0 +1,40 @@
+import importlib
+import warnings
+from typing import Any
+
+_names = [
+    "DictStore",
+    "KVStore",
+    "DirectoryStore",
+    "ZipStore",
+    "FSStore",
+]
+_mappings = {
+    "DictStore": ("memory", "MemoryStore"),
+    "KVStore": ("memory", "MemoryStore"),
+    "DirectoryStore": ("local", "LocalStore"),
+    "ZipStore": ("zip", "ZipStore"),
+    "FSStore": ("remote", "RemoteStore"),
+}
+
+
+def _deprecated_import(old: str) -> Any:
+    try:
+        submodule, new = _mappings[old]
+        mod = importlib.import_module(f"zarr.store.{submodule}")
+        store = getattr(mod, new)
+    except KeyError as e:
+        raise ImportError(f"cannot import name {old}") from e
+    else:
+        warnings.warn(
+            "'zarr.storage' is deprecated. Import from 'zarr.store' instead.",
+            FutureWarning,
+            stacklevel=3,
+        )
+        return store
+
+
+def __getattr__(name: str) -> Any:
+    if name in _names:
+        return _deprecated_import(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/v3/test_storage.py
+++ b/tests/v3/test_storage.py
@@ -1,0 +1,25 @@
+import importlib
+
+import pytest
+
+import zarr.store.local
+import zarr.store.memory
+import zarr.store.remote
+import zarr.store.zip
+
+
+@pytest.mark.parametrize(
+    ["name", "expected"],
+    [
+        ("DictStore", zarr.store.memory.MemoryStore),
+        ("KVStore", zarr.store.memory.MemoryStore),
+        ("DirectoryStore", zarr.store.local.LocalStore),
+        ("FSStore", zarr.store.remote.RemoteStore),
+        ("ZipStore", zarr.store.zip.ZipStore),
+    ],
+)
+def test_storage_deprecated(name: str, expected: type) -> None:
+    with pytest.warns(FutureWarning, match="zarr.store"):
+        result = getattr(importlib.import_module("zarr.storage"), name)
+
+    assert result == expected


### PR DESCRIPTION
This deprecates the usage of `zarr.storage`. For classes where we have a (roughly) equivalent `Store` in v3, a warning is emitted and the class from the new location is returned:

```python
In [1]: from zarr.storage import ZipStore
<ipython-input-1-f60ad0b873ae>:1: FutureWarning: 'zarr.storage' is deprecated. Import from 'zarr.store' instead.
  from zarr.storage import ZipStore
```

