### PR TITLE
Fixed codec for v2 data with no fill value

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -313,7 +313,7 @@ class AsyncArray:
             chunks=chunks,
             order=order,
             dimension_separator=dimension_separator,
-            fill_value=fill_value,
+            fill_value=0 if fill_value is None else fill_value,
             compressor=compressor,
             filters=filters,
             attributes=attributes,


### PR DESCRIPTION
Quick fix for the issue causing CI to fail. xref https://github.com/zarr-developers/zarr-python/pull/2179/files#r1765600769

Right now `ChunkSpec.fill_value` is `Any`, so mypy doesn't have a chance to catch this. I think we have a requirement that the type of `fill_value` somehow match / be compatible with the `dtype`. I don't know if we can do that yet, but we can address it once CI is passing again.