### PR TITLE
Handle fill_value for bytes dtype

### DIFF
--- a/src/zarr/abc/metadata.py
+++ b/src/zarr/abc/metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,8 @@ class Metadata:
             value = getattr(self, key)
             if isinstance(value, Metadata):
                 out_dict[field.name] = getattr(self, field.name).to_dict()
+            elif isinstance(value, bytes):
+                out_dict[key] = base64.b64encode(value)
             elif isinstance(value, str):
                 out_dict[key] = value
             elif isinstance(value, Sequence):

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -313,7 +313,7 @@ def parse_fill_value(
     """
     if fill_value is None:
         return dtype.type(0)
-    if isinstance(fill_value, Sequence) and not isinstance(fill_value, str):
+    if isinstance(fill_value, Sequence) and not isinstance(fill_value, str | bytes):
         if dtype in (np.complex64, np.complex128):
             dtype = cast(COMPLEX_DTYPE, dtype)
             if len(fill_value) == 2:


### PR DESCRIPTION
This *partly* fixes how we handle `bytes` dtype arrays. Pushing up early for a bit of a discussion around the spec:


AFAICT, `bytes` aren't a "required"(?) dtype for zarr v3. From https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value:

> Extensions to the spec that define new data types must also define the JSON fill value representation.

So the proper way to do this would be to

1. Define a zarr extension for bytes dtype (in this case, fixed-width null terminated bytes). Probably need to do the same for unicode
2. In the extension, define how the fill value should be encoded in JSON. Presumably as base64 encoded.
