### PR TITLE
[v3] Implement Group methods for empty, full, ones, and zeros

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -694,12 +694,12 @@ async def create(
         else:
             chunk_shape = shape
 
-    # if order is not None:
-    #     warnings.warn(
-    #         "order is deprecated, use config `array.order` instead",
-    #         DeprecationWarning,
-    #         stacklevel=2,
-    #     )
+    if order is not None:
+        warnings.warn(
+            "order is deprecated, use config `array.order` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if synchronizer is not None:
         warnings.warn("synchronizer is not yet implemented", RuntimeWarning, stacklevel=2)
     if chunk_store is not None:

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -575,7 +575,7 @@ async def create(
     chunks: ChunkCoords | None = None,  # TODO: v2 allowed chunks=True
     dtype: npt.DTypeLike | None = None,
     compressor: dict[str, JSON] | None = None,  # TODO: default and type change
-    fill_value: Any = 0,  # TODO: need type
+    fill_value: Any | None = 0,  # TODO: need type
     order: MemoryOrder | None = None,  # TODO: default change
     store: str | StoreLike | None = None,
     synchronizer: Any | None = None,
@@ -694,12 +694,12 @@ async def create(
         else:
             chunk_shape = shape
 
-    if order is not None:
-        warnings.warn(
-            "order is deprecated, use config `array.order` instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    # if order is not None:
+    #     warnings.warn(
+    #         "order is deprecated, use config `array.order` instead",
+    #         DeprecationWarning,
+    #         stacklevel=2,
+    #     )
     if synchronizer is not None:
         warnings.warn("synchronizer is not yet implemented", RuntimeWarning, stacklevel=2)
     if chunk_store is not None:
@@ -827,7 +827,7 @@ async def full_like(a: ArrayLike, **kwargs: Any) -> AsyncArray:
     """
     like_kwargs = _like_args(a, kwargs)
     if isinstance(a, AsyncArray):
-        kwargs.setdefault("fill_value", a.metadata.fill_value)
+        like_kwargs.setdefault("fill_value", a.metadata.fill_value)
     return await full(**like_kwargs)
 
 

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -706,45 +706,45 @@ class AsyncGroup:
         raise NotImplementedError
 
     async def empty(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.empty(shape=shape, path=path, **kwargs)
 
     async def zeros(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.zeros(shape=shape, path=path, **kwargs)
 
     async def ones(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.ones(shape=shape, path=path, **kwargs)
 
     async def full(
         self, *, name: str, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any
     ) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.full(shape=shape, fill_value=fill_value, path=path, **kwargs)
 
     async def empty_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.empty_like(a=prototype, path=path, **kwargs)
 
     async def zeros_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.zeros_like(a=prototype, path=path, **kwargs)
 
     async def ones_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.ones_like(a=prototype, path=path, **kwargs)
 
     async def full_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = self.store_path / name
+        path = str(self.store_path / name)
         return await async_api.full_like(a=prototype, path=path, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -714,17 +714,17 @@ class AsyncGroup:
     async def tree(self, expand: bool = False, level: int | None = None) -> Any:
         raise NotImplementedError
 
-    async def empty(self, **kwargs: Any) -> AsyncArray:
-        return await empty(**kwargs)
+    async def empty(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        return await empty(shape=shape, fill_value=None, **kwargs)
 
-    async def zeros(self, **kwargs: Any) -> AsyncArray:
-        return await zeros(**kwargs)
+    async def zeros(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        return await zeros(shape=shape, fill_value=0, **kwargs)
 
-    async def ones(self, **kwargs: Any) -> AsyncArray:
-        return await ones(**kwargs)
+    async def ones(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        return await ones(shape=shape, fill_value=1, **kwargs)
 
-    async def full(self, **kwargs: Any) -> AsyncArray:
-        return await full(**kwargs)
+    async def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> AsyncArray:
+        return await full(shape=shape, fill_value=fill_value, **kwargs)
 
     async def empty_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
         return await empty_like(prototype, kwargs)
@@ -1068,17 +1068,17 @@ class Group(SyncMixin):
         """
         return Array(self._sync(self._async_group.require_array(name, **kwargs)))
 
-    def empty(self, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.empty(**kwargs)))
+    def empty(self, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.empty(shape=shape, **kwargs)))
 
-    def zeros(self, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.zeros(**kwargs)))
+    def zeros(self, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.zeros(shape=shape, **kwargs)))
 
-    def ones(self, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.ones(**kwargs)))
+    def ones(self, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.ones(shape=shape, **kwargs)))
 
-    def full(self, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.full(**kwargs)))
+    def full(self, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.full(shape=shape, **kwargs)))
 
     def empty_like(self, prototype: AsyncArray, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty_like(prototype, **kwargs)))

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -705,29 +705,47 @@ class AsyncGroup:
     async def tree(self, expand: bool = False, level: int | None = None) -> Any:
         raise NotImplementedError
 
-    async def empty(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await async_api.empty(shape=shape, **kwargs)
+    async def empty(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.empty(shape=shape, path=path, **kwargs)
 
-    async def zeros(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await async_api.zeros(shape=shape, **kwargs)
+    async def zeros(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.zeros(shape=shape, path=path, **kwargs)
 
-    async def ones(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await async_api.ones(shape=shape, **kwargs)
+    async def ones(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.ones(shape=shape, path=path, **kwargs)
 
-    async def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> AsyncArray:
-        return await async_api.full(shape=shape, fill_value=fill_value, **kwargs)
+    async def full(
+        self, *, name: str, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any
+    ) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.full(shape=shape, fill_value=fill_value, path=path, **kwargs)
 
-    async def empty_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
-        return await async_api.empty_like(prototype, **kwargs)
+    async def empty_like(
+        self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
+    ) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.empty_like(a=prototype, path=path, **kwargs)
 
-    async def zeros_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
-        return await async_api.zeros_like(prototype, **kwargs)
+    async def zeros_like(
+        self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
+    ) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.zeros_like(a=prototype, path=path, **kwargs)
 
-    async def ones_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
-        return await async_api.ones_like(prototype, **kwargs)
+    async def ones_like(
+        self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
+    ) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.ones_like(a=prototype, path=path, **kwargs)
 
-    async def full_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
-        return await async_api.full_like(prototype, **kwargs)
+    async def full_like(
+        self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
+    ) -> AsyncArray:
+        path = self.store_path / name
+        return await async_api.full_like(a=prototype, path=path, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:
         raise NotImplementedError
@@ -1059,31 +1077,43 @@ class Group(SyncMixin):
         """
         return Array(self._sync(self._async_group.require_array(name, **kwargs)))
 
-    def empty(self, shape: ChunkCoords, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.empty(shape=shape, **kwargs)))
+    def empty(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.empty(name=name, shape=shape, **kwargs)))
 
-    def zeros(self, shape: ChunkCoords, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.zeros(shape=shape, **kwargs)))
+    def zeros(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.zeros(name=name, shape=shape, **kwargs)))
 
-    def ones(self, shape: ChunkCoords, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.ones(shape=shape, **kwargs)))
+    def ones(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.ones(name=name, shape=shape, **kwargs)))
 
-    def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> Array:
+    def full(
+        self, *, name: str, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any
+    ) -> Array:
         return Array(
-            self._sync(self._async_group.full(shape=shape, fill_value=fill_value, **kwargs))
+            self._sync(
+                self._async_group.full(name=name, shape=shape, fill_value=fill_value, **kwargs)
+            )
         )
 
-    def empty_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.empty_like(prototype, **kwargs)))
+    def empty_like(self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
+        return Array(
+            self._sync(self._async_group.empty_like(name=name, prototype=prototype, **kwargs))
+        )
 
-    def zeros_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.zeros_like(prototype, **kwargs)))
+    def zeros_like(self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
+        return Array(
+            self._sync(self._async_group.zeros_like(name=name, prototype=prototype, **kwargs))
+        )
 
-    def ones_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.ones_like(prototype, **kwargs)))
+    def ones_like(self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
+        return Array(
+            self._sync(self._async_group.ones_like(name=name, prototype=prototype, **kwargs))
+        )
 
-    def full_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.full_like(prototype, **kwargs)))
+    def full_like(self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
+        return Array(
+            self._sync(self._async_group.full_like(name=name, prototype=prototype, **kwargs))
+        )
 
     def move(self, source: str, dest: str) -> None:
         return self._sync(self._async_group.move(source, dest))

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -10,9 +10,9 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import deprecated
 
+import zarr.api.asynchronous as async_api
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import set_or_delete
-import zarr.api.asynchronous as async_api
 from zarr.core.array import Array, AsyncArray
 from zarr.core.attributes import Attributes
 from zarr.core.buffer import default_buffer_prototype
@@ -717,16 +717,16 @@ class AsyncGroup:
     async def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> AsyncArray:
         return await async_api.full(shape=shape, fill_value=fill_value, **kwargs)
 
-    async def empty_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+    async def empty_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
         return await async_api.empty_like(prototype, **kwargs)
 
-    async def zeros_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+    async def zeros_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
         return await async_api.zeros_like(prototype, **kwargs)
 
-    async def ones_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+    async def ones_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
         return await async_api.ones_like(prototype, **kwargs)
 
-    async def full_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+    async def full_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> AsyncArray:
         return await async_api.full_like(prototype, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:
@@ -1069,18 +1069,20 @@ class Group(SyncMixin):
         return Array(self._sync(self._async_group.ones(shape=shape, **kwargs)))
 
     def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.full(shape=shape, fill_value=fill_value, **kwargs)))
+        return Array(
+            self._sync(self._async_group.full(shape=shape, fill_value=fill_value, **kwargs))
+        )
 
-    def empty_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
+    def empty_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty_like(prototype, **kwargs)))
 
-    def zeros_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
+    def zeros_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.zeros_like(prototype, **kwargs)))
 
-    def ones_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
+    def ones_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.ones_like(prototype, **kwargs)))
 
-    def full_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
+    def full_like(self, prototype: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.full_like(prototype, **kwargs)))
 
     def move(self, source: str, dest: str) -> None:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -12,6 +12,16 @@ from typing_extensions import deprecated
 
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import set_or_delete
+from zarr.api.asynchronous import (
+    empty,
+    empty_like,
+    full,
+    full_like,
+    ones, 
+    ones_like,
+    zeros,
+    zeros_like
+)
 from zarr.core.array import Array, AsyncArray
 from zarr.core.attributes import Attributes
 from zarr.core.buffer import default_buffer_prototype
@@ -705,28 +715,28 @@ class AsyncGroup:
         raise NotImplementedError
 
     async def empty(self, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await empty(**kwargs)
 
     async def zeros(self, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await zeros(**kwargs)
 
     async def ones(self, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await ones(**kwargs)
 
     async def full(self, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await full(**kwargs)
 
     async def empty_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await empty_like(prototype, kwargs)
 
     async def zeros_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await zeros_like(prototype, **kwargs)
 
     async def ones_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await ones_like(prototype, **kwargs)
 
     async def full_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        raise NotImplementedError
+        return await full_like(prototype, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:
         raise NotImplementedError

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -706,46 +706,40 @@ class AsyncGroup:
         raise NotImplementedError
 
     async def empty(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.empty(shape=shape, path=path, **kwargs)
+        return await async_api.empty(shape=shape, store=self.store_path, path=name, **kwargs)
 
     async def zeros(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.zeros(shape=shape, path=path, **kwargs)
+        return await async_api.zeros(shape=shape, store=self.store_path, path=name, **kwargs)
 
     async def ones(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.ones(shape=shape, path=path, **kwargs)
+        return await async_api.ones(shape=shape, store=self.store_path, path=name, **kwargs)
 
     async def full(
         self, *, name: str, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any
     ) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.full(shape=shape, fill_value=fill_value, path=path, **kwargs)
+        return await async_api.full(
+            shape=shape, fill_value=fill_value, store=self.store_path, path=name, **kwargs
+        )
 
     async def empty_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.empty_like(a=prototype, path=path, **kwargs)
+        return await async_api.empty_like(a=prototype, store=self.store_path, path=name, **kwargs)
 
     async def zeros_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.zeros_like(a=prototype, path=path, **kwargs)
+        return await async_api.zeros_like(a=prototype, store=self.store_path, path=name, **kwargs)
 
     async def ones_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.ones_like(a=prototype, path=path, **kwargs)
+        return await async_api.ones_like(a=prototype, store=self.store_path, path=name, **kwargs)
 
     async def full_like(
         self, *, name: str, prototype: async_api.ArrayLike, **kwargs: Any
     ) -> AsyncArray:
-        path = str(self.store_path / name)
-        return await async_api.full_like(a=prototype, path=path, **kwargs)
+        return await async_api.full_like(a=prototype, store=self.store_path, path=name, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:
         raise NotImplementedError

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -12,16 +12,7 @@ from typing_extensions import deprecated
 
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import set_or_delete
-from zarr.api.asynchronous import (
-    empty,
-    empty_like,
-    full,
-    full_like,
-    ones, 
-    ones_like,
-    zeros,
-    zeros_like
-)
+import zarr.api.asynchronous as async_api
 from zarr.core.array import Array, AsyncArray
 from zarr.core.attributes import Attributes
 from zarr.core.buffer import default_buffer_prototype
@@ -715,28 +706,28 @@ class AsyncGroup:
         raise NotImplementedError
 
     async def empty(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await empty(shape=shape, fill_value=None, **kwargs)
+        return await async_api.empty(shape=shape, **kwargs)
 
     async def zeros(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await zeros(shape=shape, fill_value=0, **kwargs)
+        return await async_api.zeros(shape=shape, **kwargs)
 
     async def ones(self, shape: ChunkCoords, **kwargs: Any) -> AsyncArray:
-        return await ones(shape=shape, fill_value=1, **kwargs)
+        return await async_api.ones(shape=shape, **kwargs)
 
     async def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> AsyncArray:
-        return await full(shape=shape, fill_value=fill_value, **kwargs)
+        return await async_api.full(shape=shape, fill_value=fill_value, **kwargs)
 
-    async def empty_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        return await empty_like(prototype, kwargs)
+    async def empty_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+        return await async_api.empty_like(prototype, **kwargs)
 
-    async def zeros_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        return await zeros_like(prototype, **kwargs)
+    async def zeros_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+        return await async_api.zeros_like(prototype, **kwargs)
 
-    async def ones_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        return await ones_like(prototype, **kwargs)
+    async def ones_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+        return await async_api.ones_like(prototype, **kwargs)
 
-    async def full_like(self, prototype: AsyncArray, **kwargs: Any) -> AsyncArray:
-        return await full_like(prototype, **kwargs)
+    async def full_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> AsyncArray:
+        return await async_api.full_like(prototype, **kwargs)
 
     async def move(self, source: str, dest: str) -> None:
         raise NotImplementedError
@@ -1077,19 +1068,19 @@ class Group(SyncMixin):
     def ones(self, shape: ChunkCoords, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.ones(shape=shape, **kwargs)))
 
-    def full(self, shape: ChunkCoords, **kwargs: Any) -> Array:
-        return Array(self._sync(self._async_group.full(shape=shape, **kwargs)))
+    def full(self, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any) -> Array:
+        return Array(self._sync(self._async_group.full(shape=shape, fill_value=fill_value, **kwargs)))
 
-    def empty_like(self, prototype: AsyncArray, **kwargs: Any) -> Array:
+    def empty_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty_like(prototype, **kwargs)))
 
-    def zeros_like(self, prototype: AsyncArray, **kwargs: Any) -> Array:
+    def zeros_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.zeros_like(prototype, **kwargs)))
 
-    def ones_like(self, prototype: AsyncArray, **kwargs: Any) -> Array:
+    def ones_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.ones_like(prototype, **kwargs)))
 
-    def full_like(self, prototype: AsyncArray, **kwargs: Any) -> Array:
+    def full_like(self, prototype: npt.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.full_like(prototype, **kwargs)))
 
     def move(self, source: str, dest: str) -> None:

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -396,7 +396,6 @@ def test_group_array_creation(
 ):
     group = Group.create(store, zarr_format=zarr_format)
     shape = (10, 10)
-    # TODO: fix tests with path
     empty_array = group.empty(name="empty", shape=shape)
     assert isinstance(empty_array, Array)
     assert empty_array.fill_value == 0

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -400,51 +400,61 @@ def test_group_array_creation(
     assert isinstance(empty_array, Array)
     assert empty_array.fill_value == 0
     assert empty_array.shape == shape
+    assert empty_array.store_path.store == store
 
     empty_like_array = group.empty_like(name="empty_like", prototype=empty_array)
     assert isinstance(empty_like_array, Array)
     assert empty_like_array.fill_value == 0
     assert empty_like_array.shape == shape
+    assert empty_like_array.store_path.store == store
 
     empty_array_bool = group.empty(name="empty_bool", shape=shape, dtype=np.dtype("bool"))
     assert isinstance(empty_array_bool, Array)
     assert not empty_array_bool.fill_value
-    assert empty_array.shape == shape
+    assert empty_array_bool.shape == shape
+    assert empty_array_bool.store_path.store == store
 
     empty_like_array_bool = group.empty_like(name="empty_like_bool", prototype=empty_array_bool)
     assert isinstance(empty_like_array_bool, Array)
     assert not empty_like_array_bool.fill_value
-    assert empty_like_array.shape == shape
+    assert empty_like_array_bool.shape == shape
+    assert empty_like_array_bool.store_path.store == store
 
     zeros_array = group.zeros(name="zeros", shape=shape)
     assert isinstance(zeros_array, Array)
     assert zeros_array.fill_value == 0
     assert zeros_array.shape == shape
+    assert zeros_array.store_path.store == store
 
     zeros_like_array = group.zeros_like(name="zeros_like", prototype=zeros_array)
     assert isinstance(zeros_like_array, Array)
     assert zeros_like_array.fill_value == 0
     assert zeros_like_array.shape == shape
+    assert zeros_like_array.store_path.store == store
 
     ones_array = group.ones(name="ones", shape=shape)
     assert isinstance(ones_array, Array)
     assert ones_array.fill_value == 1
     assert ones_array.shape == shape
+    assert ones_array.store_path.store == store
 
-    ones_like_array = group.ones_like(name="ones", prototype=ones_array)
+    ones_like_array = group.ones_like(name="ones_like", prototype=ones_array)
     assert isinstance(ones_like_array, Array)
     assert ones_like_array.fill_value == 1
     assert ones_like_array.shape == shape
+    assert ones_like_array.store_path.store == store
 
     full_array = group.full(name="full", shape=shape, fill_value=42)
     assert isinstance(full_array, Array)
     assert full_array.fill_value == 42
     assert full_array.shape == shape
+    assert full_array.store_path.store == store
 
     full_like_array = group.full_like(name="full_like", prototype=full_array, fill_value=43)
     assert isinstance(full_like_array, Array)
     assert full_like_array.fill_value == 43
     assert full_like_array.shape == shape
+    assert full_like_array.store_path.store == store
 
 
 @pytest.mark.parametrize("store", ("local", "memory", "zip"), indirect=["store"])

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -407,11 +407,11 @@ def test_group_array_creation(
 
     empty_array_bool = group.empty(shape=shape, dtype=np.dtype("bool"))
     assert isinstance(empty_array_bool, Array)
-    assert empty_array_bool.fill_value == False
+    assert not empty_array_bool.fill_value
 
     empty_like_array_bool = group.empty_like(empty_array_bool)
     assert isinstance(empty_like_array_bool, Array)
-    assert empty_like_array_bool.fill_value == False
+    assert not empty_like_array_bool.fill_value
 
     zeros_array = group.zeros(shape=shape)
     assert isinstance(zeros_array, Array)

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -400,42 +400,52 @@ def test_group_array_creation(
     empty_array = group.empty(shape=shape)
     assert isinstance(empty_array, Array)
     assert empty_array.fill_value == 0
+    assert empty_array.shape == shape
 
     empty_like_array = group.empty_like(empty_array)
     assert isinstance(empty_like_array, Array)
     assert empty_like_array.fill_value == 0
+    assert empty_like_array.shape == shape
 
     empty_array_bool = group.empty(shape=shape, dtype=np.dtype("bool"))
     assert isinstance(empty_array_bool, Array)
     assert not empty_array_bool.fill_value
+    assert empty_array.shape == shape
 
     empty_like_array_bool = group.empty_like(empty_array_bool)
     assert isinstance(empty_like_array_bool, Array)
     assert not empty_like_array_bool.fill_value
+    assert empty_like_array.shape == shape
 
     zeros_array = group.zeros(shape=shape)
     assert isinstance(zeros_array, Array)
     assert zeros_array.fill_value == 0
+    assert zeros_array.shape == shape
 
     zeros_like_array = group.zeros_like(zeros_array)
     assert isinstance(zeros_like_array, Array)
     assert zeros_like_array.fill_value == 0
+    assert zeros_like_array.shape == shape
 
     ones_array = group.ones(shape=shape)
     assert isinstance(ones_array, Array)
     assert ones_array.fill_value == 1
+    assert ones_array.shape == shape
 
     ones_like_array = group.ones_like(ones_array)
     assert isinstance(ones_like_array, Array)
     assert ones_like_array.fill_value == 1
+    assert ones_like_array.shape == shape
 
     full_array = group.full(shape=shape, fill_value=42)
     assert isinstance(full_array, Array)
     assert full_array.fill_value == 42
+    assert full_array.shape == shape
 
     full_like_array = group.full_like(full_array, fill_value=43)
     assert isinstance(full_like_array, Array)
     assert full_like_array.fill_value == 43
+    assert full_like_array.shape == shape
 
 
 @pytest.mark.parametrize("store", ("local", "memory", "zip"), indirect=["store"])

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -403,7 +403,7 @@ def test_group_array_creation(
 
     empty_like_array = group.empty_like(empty_array)
     assert isinstance(empty_like_array, Array)
-    assert empty_array.fill_value == 0
+    assert empty_like_array.fill_value == 0
 
     empty_array_bool = group.empty(shape=shape, dtype=np.dtype("bool"))
     assert isinstance(empty_array_bool, Array)

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -390,6 +390,54 @@ def test_group_create_array(
     assert np.array_equal(array[:], data)
 
 
+def test_group_array_creation(
+    store: Store,
+    zarr_format: ZarrFormat,
+):
+    group = Group.create(store, zarr_format=zarr_format)
+    shape = (10, 10)
+
+    empty_array = group.empty(shape=shape)
+    assert isinstance(empty_array, Array)
+    assert empty_array.fill_value == 0
+
+    empty_like_array = group.empty_like(empty_array)
+    assert isinstance(empty_like_array, Array)
+    assert empty_array.fill_value == 0
+
+    empty_array_bool = group.empty(shape=shape, dtype=np.dtype("bool"))
+    assert isinstance(empty_array_bool, Array)
+    assert empty_array_bool.fill_value == False
+
+    empty_like_array_bool = group.empty_like(empty_array_bool)
+    assert isinstance(empty_like_array_bool, Array)
+    assert empty_like_array_bool.fill_value == False
+
+    zeros_array = group.zeros(shape=shape)
+    assert isinstance(zeros_array, Array)
+    assert zeros_array.fill_value == 0
+
+    zeros_like_array = group.zeros_like(zeros_array)
+    assert isinstance(zeros_like_array, Array)
+    assert zeros_like_array.fill_value == 0
+
+    ones_array = group.ones(shape=shape)
+    assert isinstance(ones_array, Array)
+    assert ones_array.fill_value == 1
+
+    ones_like_array = group.ones_like(ones_array)
+    assert isinstance(ones_like_array, Array)
+    assert ones_like_array.fill_value == 1
+
+    full_array = group.full(shape=shape, fill_value=42)
+    assert isinstance(full_array, Array)
+    assert full_array.fill_value == 42
+
+    full_like_array = group.full_like(full_array, fill_value=43)
+    assert isinstance(full_like_array, Array)
+    assert full_like_array.fill_value == 43
+
+
 @pytest.mark.parametrize("store", ("local", "memory", "zip"), indirect=["store"])
 @pytest.mark.parametrize("zarr_format", (2, 3))
 @pytest.mark.parametrize("exists_ok", [True, False])

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -396,53 +396,53 @@ def test_group_array_creation(
 ):
     group = Group.create(store, zarr_format=zarr_format)
     shape = (10, 10)
-
-    empty_array = group.empty(shape=shape)
+    # TODO: fix tests with path
+    empty_array = group.empty(name="empty", shape=shape)
     assert isinstance(empty_array, Array)
     assert empty_array.fill_value == 0
     assert empty_array.shape == shape
 
-    empty_like_array = group.empty_like(empty_array)
+    empty_like_array = group.empty_like(name="empty_like", prototype=empty_array)
     assert isinstance(empty_like_array, Array)
     assert empty_like_array.fill_value == 0
     assert empty_like_array.shape == shape
 
-    empty_array_bool = group.empty(shape=shape, dtype=np.dtype("bool"))
+    empty_array_bool = group.empty(name="empty_bool", shape=shape, dtype=np.dtype("bool"))
     assert isinstance(empty_array_bool, Array)
     assert not empty_array_bool.fill_value
     assert empty_array.shape == shape
 
-    empty_like_array_bool = group.empty_like(empty_array_bool)
+    empty_like_array_bool = group.empty_like(name="empty_like_bool", prototype=empty_array_bool)
     assert isinstance(empty_like_array_bool, Array)
     assert not empty_like_array_bool.fill_value
     assert empty_like_array.shape == shape
 
-    zeros_array = group.zeros(shape=shape)
+    zeros_array = group.zeros(name="zeros", shape=shape)
     assert isinstance(zeros_array, Array)
     assert zeros_array.fill_value == 0
     assert zeros_array.shape == shape
 
-    zeros_like_array = group.zeros_like(zeros_array)
+    zeros_like_array = group.zeros_like(name="zeros_like", prototype=zeros_array)
     assert isinstance(zeros_like_array, Array)
     assert zeros_like_array.fill_value == 0
     assert zeros_like_array.shape == shape
 
-    ones_array = group.ones(shape=shape)
+    ones_array = group.ones(name="ones", shape=shape)
     assert isinstance(ones_array, Array)
     assert ones_array.fill_value == 1
     assert ones_array.shape == shape
 
-    ones_like_array = group.ones_like(ones_array)
+    ones_like_array = group.ones_like(name="ones", prototype=ones_array)
     assert isinstance(ones_like_array, Array)
     assert ones_like_array.fill_value == 1
     assert ones_like_array.shape == shape
 
-    full_array = group.full(shape=shape, fill_value=42)
+    full_array = group.full(name="full", shape=shape, fill_value=42)
     assert isinstance(full_array, Array)
     assert full_array.fill_value == 42
     assert full_array.shape == shape
 
-    full_like_array = group.full_like(full_array, fill_value=43)
+    full_like_array = group.full_like(name="full_like", prototype=full_array, fill_value=43)
     assert isinstance(full_like_array, Array)
     assert full_like_array.fill_value == 43
     assert full_like_array.shape == shape


### PR DESCRIPTION
This PR implements `Group.{empty,zeros,ones,full,empty_like, zeros_like,onest_like,full_like}` for V3. Here we simply call the top-level functions from `zarr.api.asynchronous` to accomplish this. 

Closes #2125 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
