### PR TITLE
Added Attributes.asdict

### DIFF
--- a/src/zarr/core/attributes.py
+++ b/src/zarr/core/attributes.py
@@ -51,3 +51,6 @@ class Attributes(MutableMapping[str, JSON]):
            {'a': 3, 'c': 4}
         """
         self._obj = self._obj.update_attributes(d)
+
+    def asdict(self) -> dict[str, JSON]:
+        return dict(self._obj.metadata.attributes)

--- a/tests/v3/test_attributes.py
+++ b/tests/v3/test_attributes.py
@@ -11,3 +11,12 @@ def test_put() -> None:
     attrs.put({"a": 3, "c": 4})
     expected = {"a": 3, "c": 4}
     assert dict(attrs) == expected
+
+
+def test_asdict() -> None:
+    store = zarr.store.MemoryStore({}, mode="w")
+    attrs = zarr.core.attributes.Attributes(
+        zarr.Group.from_store(store, attributes={"a": 1, "b": 2})
+    )
+    result = attrs.asdict()
+    assert result == {"a": 1, "b": 2}


### PR DESCRIPTION
Restores Attributes.asdict, for zarr v2 compatibility.

xref #2214, which has some open questions about Group.attrs vs. AsyncGroup.attrs.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
