### PR TITLE
Use `map(str, *)` in `test_accessed_chunks`

### DIFF
--- a/tests/v3/test_indexing.py
+++ b/tests/v3/test_indexing.py
@@ -1783,7 +1783,7 @@ async def test_accessed_chunks(
         # Combine and generate the cartesian product to determine the chunks keys that
         # will be accessed
         chunks_accessed = [
-            ".".join([str(ci) for ci in comb]) for comb in itertools.product(*chunks_per_dim)
+            ".".join(map(str, comb)) for comb in itertools.product(*chunks_per_dim)
         ]
 
         counts_before = store.counter.copy()

--- a/tests/v3/test_indexing.py
+++ b/tests/v3/test_indexing.py
@@ -1782,9 +1782,7 @@ async def test_accessed_chunks(
 
         # Combine and generate the cartesian product to determine the chunks keys that
         # will be accessed
-        chunks_accessed = [
-            ".".join(map(str, comb)) for comb in itertools.product(*chunks_per_dim)
-        ]
+        chunks_accessed = [".".join(map(str, comb)) for comb in itertools.product(*chunks_per_dim)]
 
         counts_before = store.counter.copy()
 


### PR DESCRIPTION
Slight simplification of logic in `test_accessed_chunks`

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
