### PR TITLE
Update V2 codec pipeline to use concrete classes

### DIFF
--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -100,6 +100,8 @@ class ArrayV2Metadata(ArrayMetadata):
                     return o.str
                 else:
                     return o.descr
+            if isinstance(o, numcodecs.abc.Codec):
+                return o.get_config()
             if np.isscalar(o):
                 out: Any
                 if hasattr(o, "dtype") and o.dtype.kind == "M" and hasattr(o, "view"):

--- a/tests/v3/test_v2.py
+++ b/tests/v3/test_v2.py
@@ -2,7 +2,10 @@ from collections.abc import Iterator
 
 import numpy as np
 import pytest
+from numcodecs import Delta
+from numcodecs.blosc import Blosc
 
+import zarr
 from zarr import Array
 from zarr.store import MemoryStore, StorePath
 
@@ -26,3 +29,20 @@ def test_simple(store: StorePath) -> None:
 
     a[:, :] = data
     assert np.array_equal(data, a[:, :])
+
+
+def test_codec_pipeline() -> None:
+    # https://github.com/zarr-developers/zarr-python/issues/2243
+    store = MemoryStore(mode="w")
+    array = zarr.create(
+        store=store,
+        shape=(1,),
+        dtype="i4",
+        zarr_format=2,
+        filters=[Delta(dtype="i4").get_config()],
+        compressor=Blosc().get_config(),
+    )
+    array[:] = 1
+    result = array[:]
+    expected = np.ones(1)
+    np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Closes #2243 

The previous implementation used the codec config, rather than the codec itself. In memory, ArrayV2Metadata has the concrete codec, so we'll just use that.

cc @normanrz.
