### PR TITLE
Added a new issue template for documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: X's behavior is deviating from its documented behavior.
+description: Report incorrect behaviour in the library.
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: 🐛 File a bug report
+name: File a bug report
 description: X's behavior is deviating from its documented behavior.
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: File a bug report
+name: Bug Report
 description: X's behavior is deviating from its documented behavior.
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: ✨ Propose a new major feature
+  - name: Propose a new major feature
     url: https://github.com/zarr-developers/zarr-specs
     about: A new major feature should be discussed in the Zarr specifications repository.
-  - name: ❓ Discuss something on gitter
+  - name: Discuss something on gitter
     url: https://gitter.im/zarr-developers/community
     about: For questions like "How do I do X with Zarr?", you can move to our Gitter channel.
-  - name: ❓ Discuss something on GitHub Discussions
+  - name: Discuss something on GitHub Discussions
     url: https://github.com/zarr-developers/zarr-python/discussions
     about: For questions like "How do I do X with Zarr?", you can move to GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,17 @@
+name: Documentation Improvement
+description: Report missing or wrong documentation. Alternatively, you can just open a pull request with the suggested change.
+labels: [documentation, help wanted]
+
+body:
+- type: textarea
+  attributes:
+    label: Describe the issue linked to the documentation
+    description: >
+      Please provide a description of what documentation you believe needs to be fixed/improved.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggested fix for documentation
+    description: >
+      Please explain the suggested fix and why it's better than the existing documentation.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,6 @@
 name: Documentation Improvement
 description: Report missing or wrong documentation. Alternatively, you can just open a pull request with the suggested change.
+title: "DOC: "
 labels: [documentation, help wanted]
 
 body:


### PR DESCRIPTION
Added a new issue template for documentation-related issues. Looks something like:

<img width="1255" alt="Screenshot 2024-09-26 at 02 14 00" src="https://github.com/user-attachments/assets/581767b0-7187-4281-ad88-34fa86767880">

<img width="1280" alt="Screenshot 2024-09-26 at 02 14 12" src="https://github.com/user-attachments/assets/d2d34d8c-5e56-46ca-a29d-cb9f302cdcf6">

Please review. Thanks!

TODO:

* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
