### PR TITLE
Apply ruff/flake8-annotations rule ANN204

### DIFF
--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -52,7 +52,7 @@ class ArrayV2Metadata(ArrayMetadata):
         compressor: numcodecs.abc.Codec | dict[str, JSON] | None = None,
         filters: Iterable[numcodecs.abc.Codec | dict[str, JSON]] | None = None,
         attributes: dict[str, JSON] | None = None,
-    ):
+    ) -> None:
         """
         Metadata for a Zarr version 2 array.
         """

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -72,7 +72,7 @@ def parse_dimension_names(data: object) -> tuple[str | None, ...] | None:
 
 
 class V3JsonEncoder(json.JSONEncoder):
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.indent = kwargs.pop("indent", config.get("json_indent"))
         super().__init__(*args, **kwargs)
 

--- a/src/zarr/store/zip.py
+++ b/src/zarr/store/zip.py
@@ -56,7 +56,7 @@ class ZipStore(Store):
         mode: ZipStoreAccessModeLiteral = "r",
         compression: int = zipfile.ZIP_STORED,
         allowZip64: bool = True,
-    ):
+    ) -> None:
         super().__init__(mode=mode)
 
         if isinstance(path, str):


### PR DESCRIPTION
ANN204 Missing return type annotation for special method `__init__`

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
