### PR TITLE
No need to run DeepSource any more - we use ruff

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,0 @@
-version = 1
-
-test_patterns = ["zarr/tests/test_*.py"]
-
-[[analyzers]]
-name = "python"
-enabled = true


### PR DESCRIPTION
Get rid of `.deepsource.toml`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
