### PR TITLE
Fix low contrast box titles

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -74,7 +74,6 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 .sd-card .sd-card-header {
   border: none;
   background-color: white;
-  color: #150458 !important;
   font-size: var(--pst-font-size-h5);
   font-weight: bold;
   padding: 2.5rem 0rem 0.5rem 0rem;
@@ -107,7 +106,6 @@ html[data-theme=dark] .sd-shadow-sm {
 
 html[data-theme=dark] .sd-card .sd-card-header {
   background-color:var(--pst-color-background);
-  color: #150458 !important;
 }
 
 html[data-theme=dark] .sd-card .sd-card-footer {


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/2285. In general hard coding colours is a bad idea. I think these should just be deleted, but if we want to customize anything like this it's best to use the variables available in pydata-sphinx-theme: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/styling.html#css-theme-variables