### PR TITLE
Ignore extra keys in v2 metadata

### DIFF
--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -145,6 +145,10 @@ class ArrayV2Metadata(ArrayMetadata):
         # We don't want the ArrayV2Metadata constructor to fail just because someone put an
         # extra key in the metadata.
         expected = {x.name for x in fields(cls)}
+        # https://github.com/zarr-developers/zarr-python/issues/2269
+        # add some extra
+        expected |= {"dtype", "chunks"}
+
         _data = {k: v for k, v in _data.items() if k in expected}
 
         return cls(**_data)

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from zarr.core.common import JSON, ChunkCoords
 
 import json
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 
 import numcodecs
 import numpy as np
@@ -140,6 +140,13 @@ class ArrayV2Metadata(ArrayMetadata):
         _data = data.copy()
         # check that the zarr_format attribute is correct
         _ = parse_zarr_format(_data.pop("zarr_format"))
+
+        # zarr v2 allowed arbitrary keys here.
+        # We don't want the ArrayV2Metadata constructor to fail just because someone put an
+        # extra key in the metadata.
+        expected = {x.name for x in fields(cls)}
+        _data = {k: v for k, v in _data.items() if k in expected}
+
         return cls(**_data)
 
     def to_dict(self) -> dict[str, JSON]:

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -146,7 +146,7 @@ class ArrayV2Metadata(ArrayMetadata):
         # extra key in the metadata.
         expected = {x.name for x in fields(cls)}
         # https://github.com/zarr-developers/zarr-python/issues/2269
-        # add some extra
+        # handle the renames
         expected |= {"dtype", "chunks"}
 
         _data = {k: v for k, v in _data.items() if k in expected}

--- a/tests/v3/test_array.py
+++ b/tests/v3/test_array.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import zarr.api.asynchronous
+import zarr.storage
 from zarr import Array, AsyncArray, Group
 from zarr.codecs.bytes import BytesCodec
 from zarr.core.array import chunks_initialized

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -963,3 +963,15 @@ async def test_open_mutable_mapping():
 def test_open_mutable_mapping_sync():
     group = zarr.open_group(store={}, mode="w")
     assert isinstance(group.store_path.store, MemoryStore)
+
+
+class TestGroupMetadata:
+    def test_from_dict_extra_fields(self):
+        data = {
+            "attributes": {"key": "value"},
+            "_nczarr_superblock": {"version": "2.0.0"},
+            "zarr_format": 2,
+        }
+        result = GroupMetadata.from_dict(data)
+        expected = GroupMetadata(attributes={"key": "value"}, zarr_format=2)
+        assert result == expected

--- a/tests/v3/test_metadata/test_v2.py
+++ b/tests/v3/test_metadata/test_v2.py
@@ -92,7 +92,7 @@ def test_from_dict_extra_fields() -> None:
     expected = ArrayV2Metadata(
         attributes={"key": "value"},
         shape=(8,),
-        data_type="float64",
+        dtype="float64",
         chunk_grid=(8,),
         fill_value=0.0,
         order="C",

--- a/tests/v3/test_metadata/test_v2.py
+++ b/tests/v3/test_metadata/test_v2.py
@@ -93,7 +93,7 @@ def test_from_dict_extra_fields() -> None:
         attributes={"key": "value"},
         shape=(8,),
         dtype="float64",
-        chunk_grid=(8,),
+        chunks=(8,),
         fill_value=0.0,
         order="C",
     )

--- a/tests/v3/test_metadata/test_v2.py
+++ b/tests/v3/test_metadata/test_v2.py
@@ -72,3 +72,29 @@ def test_metadata_to_dict(
         observed.pop("dimension_separator")
 
     assert observed == expected
+
+
+def test_from_dict_extra_fields() -> None:
+    data = {
+        "_nczarr_array": {"dimrefs": ["/dim1", "/dim2"], "storage": "chunked"},
+        "attributes": {"key": "value"},
+        "chunks": [8],
+        "compressor": None,
+        "dtype": "<f8",
+        "fill_value": 0.0,
+        "filters": None,
+        "order": "C",
+        "shape": [8],
+        "zarr_format": 2,
+    }
+
+    result = ArrayV2Metadata.from_dict(data)
+    expected = ArrayV2Metadata(
+        attributes={"key": "value"},
+        shape=(8,),
+        data_type="float64",
+        chunk_grid=(8,),
+        fill_value=0.0,
+        order="C",
+    )
+    assert result == expected


### PR DESCRIPTION
Ignore unexpected keys in Zarr V2 metadata, to enable reading zarr files written by other systems, which might store additional data in the top level of the `.zgroup` and `.zarray` files`

Closes https://github.com/zarr-developers/zarr-python/issues/2296