### PR TITLE
Add maximum character length for signatures in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -255,6 +255,8 @@ html_js_files = [
 # Output file base name for HTML help builder.
 htmlhelp_basename = "zarrdoc"
 
+maximum_signature_line_length = 80
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
Fixes (partially) https://github.com/zarr-developers/zarr-python/issues/2294. Here's an example with this change:

<img width="752" alt="Screenshot 2024-10-02 at 22 13 57" src="https://github.com/user-attachments/assets/f0027f97-e0f6-4679-8e1c-1a4471994f0f">
