### PR TITLE
fix(storage): change StoreTests get/set methods to async

### DIFF
--- a/tests/v3/test_store/test_local.py
+++ b/tests/v3/test_store/test_local.py
@@ -11,10 +11,10 @@ class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
     store_cls = LocalStore
     buffer_cls = cpu.Buffer
 
-    def get(self, store: LocalStore, key: str) -> Buffer:
+    async def get(self, store: LocalStore, key: str) -> Buffer:
         return self.buffer_cls.from_bytes((store.root / key).read_bytes())
 
-    def set(self, store: LocalStore, key: str, value: Buffer) -> None:
+    async def set(self, store: LocalStore, key: str, value: Buffer) -> None:
         parent = (store.root / key).parent
         if not parent.exists():
             parent.mkdir(parents=True)

--- a/tests/v3/test_store/test_memory.py
+++ b/tests/v3/test_store/test_memory.py
@@ -52,10 +52,10 @@ class TestGpuMemoryStore(StoreTests[GpuMemoryStore, gpu.Buffer]):
     store_cls = GpuMemoryStore
     buffer_cls = gpu.Buffer
 
-    def set(self, store: GpuMemoryStore, key: str, value: Buffer) -> None:
+    async def set(self, store: GpuMemoryStore, key: str, value: Buffer) -> None:
         store._store_dict[key] = value
 
-    def get(self, store: MemoryStore, key: str) -> Buffer:
+    async def get(self, store: MemoryStore, key: str) -> Buffer:
         return store._store_dict[key]
 
     @pytest.fixture(params=[None, True])

--- a/tests/v3/test_store/test_memory.py
+++ b/tests/v3/test_store/test_memory.py
@@ -12,10 +12,10 @@ class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
     store_cls = MemoryStore
     buffer_cls = cpu.Buffer
 
-    def set(self, store: MemoryStore, key: str, value: Buffer) -> None:
+    async def set(self, store: MemoryStore, key: str, value: Buffer) -> None:
         store._store_dict[key] = value
 
-    def get(self, store: MemoryStore, key: str) -> Buffer:
+    async def get(self, store: MemoryStore, key: str) -> Buffer:
         return store._store_dict[key]
 
     @pytest.fixture(params=[None, True])

--- a/tests/v3/test_store/test_remote.py
+++ b/tests/v3/test_store/test_remote.py
@@ -117,14 +117,14 @@ class TestRemoteStoreS3(StoreTests[RemoteStore, cpu.Buffer]):
     def store(self, store_kwargs: dict[str, str | bool]) -> RemoteStore:
         return self.store_cls(**store_kwargs)
 
-    def get(self, store: RemoteStore, key: str) -> Buffer:
+    async def get(self, store: RemoteStore, key: str) -> Buffer:
         #  make a new, synchronous instance of the filesystem because this test is run in sync code
         new_fs = fsspec.filesystem(
             "s3", endpoint_url=store.fs.endpoint_url, anon=store.fs.anon, asynchronous=False
         )
         return self.buffer_cls.from_bytes(new_fs.cat(f"{store.path}/{key}"))
 
-    def set(self, store: RemoteStore, key: str, value: Buffer) -> None:
+    async def set(self, store: RemoteStore, key: str, value: Buffer) -> None:
         #  make a new, synchronous instance of the filesystem because this test is run in sync code
         new_fs = fsspec.filesystem(
             "s3", endpoint_url=store.fs.endpoint_url, anon=store.fs.anon, asynchronous=False

--- a/tests/v3/test_store/test_zip.py
+++ b/tests/v3/test_store/test_zip.py
@@ -29,10 +29,10 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
 
         return {"path": temp_path, "mode": "w"}
 
-    def get(self, store: ZipStore, key: str) -> Buffer:
+    async def get(self, store: ZipStore, key: str) -> Buffer:
         return store._get(key, prototype=default_buffer_prototype())
 
-    def set(self, store: ZipStore, key: str, value: Buffer) -> None:
+    async def set(self, store: ZipStore, key: str, value: Buffer) -> None:
         return store._set(key, value)
 
     def test_store_mode(self, store: ZipStore, store_kwargs: dict[str, Any]) -> None:


### PR DESCRIPTION
Small change that supports storage backends that don't have a synchronous interface

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
