### PR TITLE
fix(store): speed up Store.open by avoiding empty/clear calls unless needed

### DIFF
--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -69,13 +69,10 @@ class Store(ABC):
     async def _open(self) -> None:
         if self._is_open:
             raise ValueError("store is already open")
-        if not await self.empty():
-            if self.mode.update or self.mode.readonly:
-                pass
-            elif self.mode.overwrite:
-                await self.clear()
-            else:
-                raise FileExistsError("Store already exists")
+        if self.mode.str == "w":
+            await self.clear()
+        elif self.mode.str == "w-" and not await self.empty():
+            raise FileExistsError("Store already exists")
         self._is_open = True
 
     async def _ensure_open(self) -> None:

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -70,6 +70,15 @@ class StoreTests(Generic[S, B]):
         with pytest.raises(AttributeError):
             store.mode = AccessMode.from_literal("w")  # type: ignore[misc]
 
+    @pytest.mark.parametrize("mode", ["r", "r+", "a", "w", "w-"])
+    async def test_store_open_mode(
+        self, store_kwargs: dict[str, Any], mode: AccessModeLiteral
+    ) -> None:
+        store_kwargs["mode"] = mode
+        store = await self.store_cls.open(**store_kwargs)
+        assert store._is_open
+        assert store.mode == AccessMode.from_literal(mode)
+
     async def test_not_writable_store_raises(self, store_kwargs: dict[str, Any]) -> None:
         kwargs = {**store_kwargs, "mode": "r"}
         store = await self.store_cls.open(**kwargs)

--- a/tests/v3/test_store/test_zip.py
+++ b/tests/v3/test_store/test_zip.py
@@ -100,3 +100,7 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
     async def test_with_mode(self, store: ZipStore) -> None:
         with pytest.raises(NotImplementedError, match="new mode"):
             await super().test_with_mode(store)
+
+    @pytest.mark.parametrize("mode", ["a", "w"])
+    async def test_store_open_mode(self, store_kwargs: dict[str, Any], mode: str) -> None:
+        super().test_store_open_mode(store_kwargs, mode)


### PR DESCRIPTION
We were calling `store.empty` and `store.clear` more than we needed to. This changes the open logic to only call `clear` when `mode='w'` and only call `empty` when `mode='w-'`. 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
