### PR TITLE
Unnecessary lambda expression

### DIFF
--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -60,7 +60,7 @@ node_names = st.text(zarr_key_chars, min_size=1).filter(
 )
 array_names = node_names
 attrs = st.none() | st.dictionaries(_attr_keys, _attr_values)
-keys = st.lists(node_names, min_size=1).map(lambda x: "/".join(x))
+keys = st.lists(node_names, min_size=1).map("/".join)
 paths = st.just("/") | keys
 stores = st.builds(MemoryStore, st.just({}), mode=st.just("w"))
 compressors = st.sampled_from([None, "default"])


### PR DESCRIPTION
A lambda that calls a function without modifying any of its parameters is unnecessary. Python functions are first-class objects and can be passed around in the same way as the resulting lambda. It is recommended to remove the lambda and use the function directly.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
