### PR TITLE
Ensure path created for LocalStore when not in readonly mode.

### DIFF
--- a/src/zarr/storage/local.py
+++ b/src/zarr/storage/local.py
@@ -94,6 +94,11 @@ class LocalStore(Store):
         assert isinstance(root, Path)
         self.root = root
 
+    async def _open(self) -> None:
+        if not self.mode.readonly:
+            self.root.mkdir(parents=True, exist_ok=True)
+        return await super()._open()
+
     async def clear(self) -> None:
         self._check_writable()
         shutil.rmtree(self.root)

--- a/tests/v3/test_store/test_local.py
+++ b/tests/v3/test_store/test_local.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
+import zarr
 from zarr.core.buffer import Buffer, cpu
 from zarr.storage.local import LocalStore
 from zarr.testing.store import StoreTests
+
+if TYPE_CHECKING:
+    import pathlib
 
 
 class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
@@ -40,3 +46,10 @@ class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
         assert await store.empty()
         (store.root / "foo/bar").mkdir(parents=True)
         assert await store.empty()
+
+    def test_creates_new_directory(self, tmp_path: pathlib.Path):
+        target = tmp_path.joinpath("a", "b", "c")
+        assert not target.exists()
+
+        store = self.store_cls(root=target, mode="w")
+        zarr.group(store=store)


### PR DESCRIPTION
Closes https://github.com/zarr-developers/zarr-python/issues/2334