### PR TITLE
Add Python 3.13, drop Python 3.10

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
     attributes:
       label: Python Version
       description: Version of Python interpreter
-      placeholder: 3.10, 3.11, 3.12 etc.
+      placeholder: 3.11, 3.12, 3.13 etc.
     validations:
       required: true
   - type: input

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
         numpy_version: ['>=2.1', '==1.24.*']
         exclude:
           - python-version: '3.12'
+            numpy_version: '==1.24.*'
+          - python-version: '3.13'
             numpy_version: '==1.24.*'
     services:
       redis:
@@ -50,7 +52,7 @@ jobs:
     - name: Create Conda environment with the rights deps
       shell: "bash -l {0}"
       run: |
-        conda create -n zarr-env python==${{matrix.python-version}} bsddb3 pip nodejs
+        conda create -n zarr-env python==${{matrix.python-version}} pip nodejs
         conda activate zarr-env
         npm install -g azurite
     - name: Install dependencies

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: True
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -25,9 +25,13 @@ Release notes
 
 Enhancements
 ~~~~~~~~~~~~
+* Added testing on Python 3.13.
 
 Maintenance
 ~~~~~~~~~~~
+* Dropped support for Python 3.10.
+* Removed testing for compatibility with the ``bsddb3`` package.
+  ``bsddb3`` was last released four years ago.
 
 Deprecations
 ~~~~~~~~~~~~
@@ -41,7 +45,7 @@ Enhancements
 ~~~~~~~~~~~~
 * Added support for creating a copy of data when converting a `zarr.Array`
   to a numpy array.
-  By :user:`David Stansby <dstansby>` (:issue:`2106`) and 
+  By :user:`David Stansby <dstansby>` (:issue:`2106`) and
   :user:`Joe Hamman <jhamman>` (:issue:`2123`).
 
 Maintenance

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -30,8 +30,12 @@ Enhancements
 Maintenance
 ~~~~~~~~~~~
 * Dropped support for Python 3.10.
+  By :user:`David Stansby <dstansby>` (:issue:`2344`).
 * Removed testing for compatibility with the ``bsddb3`` package.
-  ``bsddb3`` was last released four years ago.
+  ``bsddb3`` was last released four years ago, and should still work with
+  ``zarr-python`` if you can install it, but to reduce our maintenance
+  burden we will no longer run our compatibility tests for it.
+  By :user:`David Stansby <dstansby>` (:issue:`2344`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -811,6 +811,8 @@ storing an array or group. Here is an example using a Berkeley DB B-tree
 database for storage (requires `bsddb3
 <https://www.jcea.es/programacion/pybsddb.htm>`_ to be installed)::
 
+.. doctest-requires:: bsddb3
+
     >>> import bsddb3
     >>> store = zarr.DBMStore('data/example.bdb', open=bsddb3.btopen)
     >>> root = zarr.group(store=store, overwrite=True)
@@ -1009,12 +1011,12 @@ class from ``fsspec``. The following example demonstrates how to access
 a ZIP-archived Zarr group on s3 using `s3fs <https://s3fs.readthedocs.io/en/latest/>`_ and ``ZipFileSystem``:
 
     >>> s3_path = "s3://path/to/my.zarr.zip"
-    >>> 
+    >>>
     >>> s3 = s3fs.S3FileSystem()
     >>> f = s3.open(s3_path)
     >>> fs = ZipFileSystem(f, mode="r")
     >>> store = FSMap("", fs, check=False)
-    >>> 
+    >>>
     >>> # caching may improve performance when repeatedly reading the same data
     >>> cache = zarr.storage.LRUStoreCache(store, max_size=2**28)
     >>> z = zarr.group(store=cache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,15 @@ build-backend = "setuptools.build_meta"
 name = "zarr"
 description = "An implementation of chunked, compressed, N-dimensional arrays for Python"
 readme = { file = "README.md", content-type = "text/markdown" }
-maintainers = [
-    { name = "Alistair Miles", email = "alimanfoo@googlemail.com" }
-]
-requires-python = ">=3.10"
+maintainers = [{ name = "Alistair Miles", email = "alimanfoo@googlemail.com" }]
+requires-python = ">=3.11"
 dependencies = [
     'asciitree',
     'numpy>=1.24',
     'fasteners; sys_platform != "emscripten"',
     'numcodecs>=0.10.0',
 ]
-dynamic = [
-  "version",
-]
+dynamic = ["version"]
 classifiers = [
     'Development Status :: 6 - Mature',
     'Intended Audience :: Developers',
@@ -30,18 +26,14 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Operating System :: Unix',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 license = { text = "MIT" }
 
 [project.optional-dependencies]
-jupyter = [
-    'notebook',
-    'ipytree>=0.2.2',
-    'ipywidgets>=8.0.0',
-]
+jupyter = ['notebook', 'ipytree>=0.2.2', 'ipywidgets>=8.0.0']
 docs = [
     'sphinx',
     'sphinx-automodapi',
@@ -64,14 +56,11 @@ Homepage = "https://github.com/zarr-developers/zarr-python"
 exclude_lines = [
     "pragma: no cover",
     "pragma: ${PY_MAJOR_VERSION} no cover",
-    '.*\.\.\.' # Ignore "..." lines
+    '.*\.\.\.',                             # Ignore "..." lines
 ]
 
 [tool.coverage.run]
-omit = [
-    "zarr/meta_v1.py",
-    "bench/compress_normal.py",
-]
+omit = ["zarr/meta_v1.py", "bench/compress_normal.py"]
 
 [tool.setuptools]
 packages = ["zarr", "zarr._storage", "zarr.tests"]
@@ -100,14 +89,12 @@ exclude = [
     "build",
     "dist",
     "venv",
-    "docs"
+    "docs",
 ]
 
 [tool.ruff.lint]
-extend-select = [
-    "B"
-]
-ignore = ["B905"] # zip-without-explicit-strict
+extend-select = ["B"]
+ignore = ["B905"]     # zip-without-explicit-strict
 
 [tool.black]
 line-length = 100
@@ -136,9 +123,7 @@ doctest_optionflags = [
     "ELLIPSIS",
     "IGNORE_EXCEPTION_DETAIL",
 ]
-addopts = [
-    "--durations=10",
-]
+addopts = ["--durations=10"]
 filterwarnings = [
     "error:::zarr.*",
     "ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning",
@@ -146,9 +131,9 @@ filterwarnings = [
     "ignore:The .* is deprecated and will be removed in a Zarr-Python version 3*:FutureWarning",
     "ignore:The experimental Zarr V3 implementation in this version .*:FutureWarning",
 ]
-doctest_subpackage_requires =[
+doctest_subpackage_requires = [
     "zarr/core.py = numpy>=2",
-    "zarr/creation.py = numpy>=2"
+    "zarr/creation.py = numpy>=2",
 ]
 
 

--- a/zarr/storage.py
+++ b/zarr/storage.py
@@ -1686,7 +1686,6 @@ class NestedDirectoryStore(DirectoryStore):
     def __init__(
         self, path, normalize_keys=False, dimension_separator: Optional[DIMENSION_SEPARATOR] = "/"
     ):
-
         warnings.warn(
             V3_DEPRECATION_MESSAGE.format(store=self.__class__.__name__),
             FutureWarning,
@@ -2069,6 +2068,8 @@ class DBMStore(Store):
     the `open` parameter. For example, if the `bsddb3
     <https://www.jcea.es/programacion/pybsddb.htm>`_ package is installed, a
     Berkeley DB database can be used::
+
+    .. doctest-requires:: bsddb3
 
         >>> import bsddb3
         >>> store = zarr.DBMStore('data/array.bdb', open=bsddb3.btopen)


### PR DESCRIPTION
As per SPEC 0 we can drop Python 3.10, and this also adds tests for Python 3.13. Fixes https://github.com/zarr-developers/zarr-python/issues/2317
