### PR TITLE
ci: run test actions on support branch

### DIFF
--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,9 +4,9 @@ name: Minimal installation
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
 
 jobs:
   minimum_build:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -4,9 +4,9 @@ name: Minimal installation
 
 on:
   push:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2 ]
   pull_request:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2 ]
 
 jobs:
   minimum_build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Linux Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,9 @@ name: Linux Testing
 
 on:
   push:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2]
   pull_request:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2]
 
 jobs:
   build:

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2 ]
   pull_request:
-    branches: [ main, support/2.x ]
+    branches: [ support/v2 ]
 
 jobs:
   windows:

--- a/.github/workflows/windows-testing.yml
+++ b/.github/workflows/windows-testing.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, support/2.x ]
 
 jobs:
   windows:


### PR DESCRIPTION
Run's CI on support branch. Wait to merge until after #2345 is settled.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
