### PR TITLE
Fix logo height in doc navbar

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,12 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
 
-.navbar-brand img {
-   height: 75px;
-}
-.navbar-brand {
-   height: 75px;
-}
-
 body {
   font-family: 'Open Sans', sans-serif;
 }


### PR DESCRIPTION
Before:
<img width="265" alt="Screenshot 2024-10-13 at 08 55 46" src="https://github.com/user-attachments/assets/5c860a89-7a04-447c-8920-c18ea557b5dd">

After:

<img width="194" alt="Screenshot 2024-10-13 at 08 56 01" src="https://github.com/user-attachments/assets/abacc1eb-96eb-423c-a2a4-fd90085cb5da">
