### PR TITLE
fix(consolidated metadata): skip .zmetadata key in members search

### DIFF
--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -1139,7 +1139,8 @@ class AsyncGroup:
             raise ValueError(msg)
         # would be nice to make these special keys accessible programmatically,
         # and scoped to specific zarr versions
-        _skip_keys = ("zarr.json", ".zgroup", ".zattrs")
+        # especially true for `.zmetadata` which is configurable
+        _skip_keys = ("zarr.json", ".zgroup", ".zattrs", ".zmetadata")
 
         # hmm lots of I/O and logic interleaved here.
         # We *could* have an async gen over self.metadata.consolidated_metadata.metadata.keys()

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -4,6 +4,7 @@ import asyncio
 import itertools
 import json
 import logging
+import warnings
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field, fields, replace
 from typing import TYPE_CHECKING, Literal, TypeVar, assert_never, cast, overload
@@ -1170,9 +1171,10 @@ class AsyncGroup:
                 # keyerror is raised when `key` names an object (in the object storage sense),
                 # as opposed to a prefix, in the store under the prefix associated with this group
                 # in which case `key` cannot be the name of a sub-array or sub-group.
-                logger.warning(
-                    "Object at %s is not recognized as a component of a Zarr hierarchy.",
-                    key,
+                warnings.warn(
+                    f"Object at {key} is not recognized as a component of a Zarr hierarchy.",
+                    UserWarning,
+                    stacklevel=1,
                 )
 
     def _members_consolidated(


### PR DESCRIPTION
Small patch on the back of #1161. 

Without this change, the logic in `members` was identifying `.zmetadata` as a valid key in the store and looking for its children (e.g. `foo/.zmetadata/.zarray`). The result was a bunch of noisy warnings about unrecognized keys.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
