### PR TITLE
Use lazy % formatting in logging functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ extend-select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "FLY", # flynt
+    "G",   # flake8-logging-format
     "I",   # isort
     "ISC", # flake8-implicit-str-concat
     "PGH", # pygrep-hooks

--- a/src/zarr/core/sync.py
+++ b/src/zarr/core/sync.py
@@ -133,7 +133,7 @@ def sync(
 
     finished, unfinished = wait([future], return_when=asyncio.ALL_COMPLETED, timeout=timeout)
     if len(unfinished) > 0:
-        raise TimeoutError(f"Coroutine {coro} failed to finish in within {timeout}s")
+        raise TimeoutError(f"Coroutine {coro} failed to finish in within {timeout} s")
     assert len(finished) == 1
     return_result = next(iter(finished)).result()
 

--- a/src/zarr/storage/logging.py
+++ b/src/zarr/storage/logging.py
@@ -84,14 +84,14 @@ class LoggingStore(Store):
         op = f"{type(self._store).__name__}.{method}"
         if hint:
             op += f"({hint})"
-        self.logger.info(f"Calling {op}")
+        self.logger.info("Calling %s", op)
         start_time = time.time()
         try:
             self.counter[method] += 1
             yield
         finally:
             end_time = time.time()
-            self.logger.info(f"Finished {op} [{end_time - start_time:.2f}s]")
+            self.logger.info("Finished %s [%.2fs]", op, end_time - start_time)
 
     @property
     def supports_writes(self) -> bool:

--- a/src/zarr/storage/logging.py
+++ b/src/zarr/storage/logging.py
@@ -83,7 +83,7 @@ class LoggingStore(Store):
         method = inspect.stack()[2].function
         op = f"{type(self._store).__name__}.{method}"
         if hint:
-            op += f"({hint})"
+            op = f"{op}({hint})"
         self.logger.info("Calling %s", op)
         start_time = time.time()
         try:

--- a/src/zarr/storage/logging.py
+++ b/src/zarr/storage/logging.py
@@ -91,7 +91,7 @@ class LoggingStore(Store):
             yield
         finally:
             end_time = time.time()
-            self.logger.info("Finished %s [%.2fs]", op, end_time - start_time)
+            self.logger.info("Finished %s [%.2f s]", op, end_time - start_time)
 
     @property
     def supports_writes(self) -> bool:


### PR DESCRIPTION
TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
