### PR TITLE
Imported name is not used anywhere in the module

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ import sphinx.application
 
 from importlib.metadata import version as get_version
 
-import zarr
 import sphinx
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tests/v3/test_array.py
+++ b/tests/v3/test_array.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import zarr.api.asynchronous
-import zarr.storage
 from zarr import Array, AsyncArray, Group
 from zarr.codecs import BytesCodec, VLenBytesCodec
 from zarr.core.array import chunks_initialized

--- a/tests/v3/test_v2.py
+++ b/tests/v3/test_v2.py
@@ -9,8 +9,6 @@ from numcodecs import Delta
 from numcodecs.blosc import Blosc
 
 import zarr
-import zarr.core.buffer.cpu
-import zarr.core.metadata
 import zarr.storage
 from zarr import Array
 from zarr.storage import MemoryStore, StorePath


### PR DESCRIPTION
TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
