### PR TITLE
deps: remove fasteners from list of dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
           - asciitree
           - crc32c
           - donfig
-          - fasteners
           - numcodecs
           - numpy
           - typing_extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.11"
 dependencies = [
     'asciitree',
     'numpy>=1.25',
-    'fasteners',
     'numcodecs>=0.10.2',
     'fsspec>2024',
     'crc32c',


### PR DESCRIPTION
This is no longer used in Zarr and can be safely removed.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
