### PR TITLE
Enforce ruff/flake8-pyi rule PYI013

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,6 @@ ignore = [
     "PT005",  # deprecated
     "PT011",  # TODO: apply this rule
     "PT012",  # TODO: apply this rule
-    "PYI013",
     "RET505",
     "RET506",
     "RUF005",

--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -156,19 +156,13 @@ class BaseCodec(Metadata, Generic[CodecInput, CodecOutput]):
 class ArrayArrayCodec(BaseCodec[NDBuffer, NDBuffer]):
     """Base class for array-to-array codecs."""
 
-    ...
-
 
 class ArrayBytesCodec(BaseCodec[NDBuffer, Buffer]):
     """Base class for array-to-bytes codecs."""
 
-    ...
-
 
 class BytesBytesCodec(BaseCodec[Buffer, Buffer]):
     """Base class for bytes-to-bytes codecs."""
-
-    ...
 
 
 Codec = ArrayArrayCodec | ArrayBytesCodec | BytesBytesCodec


### PR DESCRIPTION
PYI013 Non-empty class body must not contain `...`

Note that documentation is enough to fill the class body.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
