### PR TITLE
Added info for Group and Array

### DIFF
--- a/src/zarr/__init__.py
+++ b/src/zarr/__init__.py
@@ -1,3 +1,4 @@
+from zarr._info import GroupInfo
 from zarr._version import version as __version__
 from zarr.api.synchronous import (
     array,
@@ -38,6 +39,7 @@ __all__ = [
     "AsyncArray",
     "AsyncGroup",
     "Group",
+    "GroupInfo",
     "__version__",
     "array",
     "config",

--- a/src/zarr/_info.py
+++ b/src/zarr/_info.py
@@ -2,18 +2,37 @@ import dataclasses
 import textwrap
 from typing import Literal
 
-# Group
-# Name        : /
-# Type        : zarr.hierarchy.Group
-# Read-only   : False
-# Store type  : zarr.storage.MemoryStore
-# No. members : 0
-# No. arrays  : 0
-# No. groups  : 0
-
 
 @dataclasses.dataclass(kw_only=True)
 class GroupInfo:
+    """
+    Information about a group.
+
+    Parameters
+    ----------
+    name : str
+        The path of the group within the Store
+    type : "Group"
+    zarr_format : {2, 3}
+        The zarr format of the Group.
+    read_only : bool
+        Whether the Group's access mode is read only.
+    store_type : str
+        The name of the Store class containing this group.
+    count_members : int, optional
+        The number of child members below this group. This
+        will be set when the Group has consolidated metadata
+        or when using :class:`Group.info_complete`.
+    count_arrays : int, optional
+        The number of child arrays below this group. This
+        will be set when the Group has consolidated metadata
+        or when using :class:`Group.info_complete`.
+    count_groups : int, optional
+        The number of child groups below this group. This
+        will be set when the Group has consolidated metadata
+        or when using :class:`Group.info_complete`.
+    """
+
     name: str
     type: Literal["Group"] = "Group"
     zarr_format: Literal[2, 3]

--- a/src/zarr/_info.py
+++ b/src/zarr/_info.py
@@ -1,0 +1,60 @@
+import dataclasses
+import textwrap
+from typing import Literal
+
+import zarr.abc.store
+
+# Group
+# Name        : /
+# Type        : zarr.hierarchy.Group
+# Read-only   : False
+# Store type  : zarr.storage.MemoryStore
+# No. members : 0
+# No. arrays  : 0
+# No. groups  : 0
+
+
+# In [19]: z.info
+# Out[19]:
+# Type               : zarr.core.Array
+# Data type          : int32
+# Shape              : (1000000,)
+# Chunk shape        : (100000,)
+# Order              : C
+# Read-only          : False
+# Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
+# Store type         : zarr.storage.KVStore
+# No. bytes          : 4000000 (3.8M)
+# No. bytes stored   : 320
+# Storage ratio      : 12500.0
+# Chunks initialized : 0/10
+
+
+@dataclasses.dataclass(kw_only=True)
+class GroupInfo:
+    name: str
+    type: Literal["Group"] = "Group"
+    read_only: bool
+    store_type: str
+    count_members: int | None = None
+    count_arrays: int | None = None
+    count_groups: int | None = None
+
+    def __repr__(self) -> str:
+        template = textwrap.dedent("""\
+        Name        : {name}
+        Type        : {type}
+        Read-only   : {read_only}
+        Store type  : {store_type}""")
+
+        if self.count_members is not None:
+            template += ("\nNo. members : {count_members}")
+        if self.count_arrays is not None:
+            template += ("\nNo. arrays  : {count_arrays}")
+        if self.count_groups is not None:
+            template += ("\nNo. groups  : {count_groups}")
+        return template.format(
+            **dataclasses.asdict(self)
+        )
+
+    # def _repr_html_(self): ...

--- a/src/zarr/_info.py
+++ b/src/zarr/_info.py
@@ -57,7 +57,7 @@ def human_readable_size(size: int) -> str:
 
 def byte_info(size: int) -> str:
     if size < 2**10:
-        return size
+        return str(size)
     else:
         return f"{size} ({human_readable_size(size)})"
 
@@ -67,8 +67,8 @@ class ArrayInfo:
     type: Literal["Array"] = "Array"
     zarr_format: Literal[2, 3]
     data_type: str
-    shape: tuple[int,]
-    chunk_shape: tuple[int,]
+    shape: tuple[int, ...]
+    chunk_shape: tuple[int, ...] | None = None
     order: Literal["C", "F"]
     read_only: bool
     store_type: str
@@ -91,6 +91,9 @@ class ArrayInfo:
         Store type         : {store_type}""")
 
         kwargs = dataclasses.asdict(self)
+        if self.chunk_shape is None:
+            # for non-regular chunk grids
+            kwargs["chunk_shape"] = "<variable>"
         if self.compressor is not None:
             template += "\nCompressor         : {compressor}"
 

--- a/src/zarr/_info.py
+++ b/src/zarr/_info.py
@@ -2,8 +2,6 @@ import dataclasses
 import textwrap
 from typing import Literal
 
-import zarr.abc.store
-
 # Group
 # Name        : /
 # Type        : zarr.hierarchy.Group
@@ -14,26 +12,11 @@ import zarr.abc.store
 # No. groups  : 0
 
 
-# In [19]: z.info
-# Out[19]:
-# Type               : zarr.core.Array
-# Data type          : int32
-# Shape              : (1000000,)
-# Chunk shape        : (100000,)
-# Order              : C
-# Read-only          : False
-# Compressor         : Blosc(cname='lz4', clevel=5, shuffle=SHUFFLE, blocksize=0)
-# Store type         : zarr.storage.KVStore
-# No. bytes          : 4000000 (3.8M)
-# No. bytes stored   : 320
-# Storage ratio      : 12500.0
-# Chunks initialized : 0/10
-
-
 @dataclasses.dataclass(kw_only=True)
 class GroupInfo:
     name: str
     type: Literal["Group"] = "Group"
+    zarr_format: Literal[2, 3]
     read_only: bool
     store_type: str
     count_members: int | None = None
@@ -44,17 +27,95 @@ class GroupInfo:
         template = textwrap.dedent("""\
         Name        : {name}
         Type        : {type}
+        Zarr format : {zarr_format}
         Read-only   : {read_only}
         Store type  : {store_type}""")
 
         if self.count_members is not None:
-            template += ("\nNo. members : {count_members}")
+            template += "\nNo. members : {count_members}"
         if self.count_arrays is not None:
-            template += ("\nNo. arrays  : {count_arrays}")
+            template += "\nNo. arrays  : {count_arrays}"
         if self.count_groups is not None:
-            template += ("\nNo. groups  : {count_groups}")
-        return template.format(
-            **dataclasses.asdict(self)
-        )
+            template += "\nNo. groups  : {count_groups}"
+        return template.format(**dataclasses.asdict(self))
 
-    # def _repr_html_(self): ...
+
+def human_readable_size(size: int) -> str:
+    if size < 2**10:
+        return f"{size}"
+    elif size < 2**20:
+        return f"{size / float(2**10):.1f}K"
+    elif size < 2**30:
+        return f"{size / float(2**20):.1f}M"
+    elif size < 2**40:
+        return f"{size / float(2**30):.1f}G"
+    elif size < 2**50:
+        return f"{size / float(2**40):.1f}T"
+    else:
+        return f"{size / float(2**50):.1f}P"
+
+
+def byte_info(size: int) -> str:
+    if size < 2**10:
+        return size
+    else:
+        return f"{size} ({human_readable_size(size)})"
+
+
+@dataclasses.dataclass(kw_only=True)
+class ArrayInfo:
+    type: Literal["Array"] = "Array"
+    zarr_format: Literal[2, 3]
+    data_type: str
+    shape: tuple[int,]
+    chunk_shape: tuple[int,]
+    order: Literal["C", "F"]
+    read_only: bool
+    store_type: str
+    compressor: str | None = None
+    filters: list[str] | None = None
+    codecs: list[str] | None = None
+    count_bytes: int | None = None
+    count_bytes_stored: int | None = None
+    count_chunks_initialized: int | None = None
+
+    def __repr__(self) -> str:
+        template = textwrap.dedent("""\
+        Type               : {type}
+        Zarr format        : {zarr_format}
+        Data type          : {data_type}
+        Shape              : {shape}
+        Chunk shape        : {chunk_shape}
+        Order              : {order}
+        Read-only          : {read_only}
+        Store type         : {store_type}""")
+
+        kwargs = dataclasses.asdict(self)
+        if self.compressor is not None:
+            template += "\nCompressor         : {compressor}"
+
+        if self.filters is not None:
+            template += "\nFilters            : {filters}"
+
+        if self.codecs is not None:
+            template += "\nCodecs             : {codecs}"
+
+        if self.count_bytes is not None:
+            template += "\nNo. bytes          : {count_bytes}"
+            kwargs["count_bytes"] = byte_info(self.count_bytes)
+
+        if self.count_bytes_stored is not None:
+            template += "\nNo. bytes stored   : {count_bytes_stored}"
+            kwargs["count_stored"] = byte_info(self.count_bytes_stored)
+
+        if (
+            self.count_bytes is not None
+            and self.count_bytes_stored is not None
+            and self.count_bytes_stored > 0
+        ):
+            template += "\nStorage ratio      : {storage_ratio}"
+            kwargs["storage_ratio"] = f"{self.count_bytes / self.count_bytes_stored:.1f}"
+
+        if self.count_chunks_initialized is not None:
+            template += "\nChunks Initialized : {count_chunks_initialized}"
+        return template.format(**kwargs)

--- a/src/zarr/_info.py
+++ b/src/zarr/_info.py
@@ -93,7 +93,7 @@ class ArrayInfo:
     store_type: str
     compressor: str | None = None
     filters: list[str] | None = None
-    codecs: list[str] | None = None
+    codecs: str | None = None
     count_bytes: int | None = None
     count_bytes_stored: int | None = None
     count_chunks_initialized: int | None = None

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1145,7 +1145,11 @@ class AsyncArray(Generic[T_ArrayMetadata]):
     def __repr__(self) -> str:
         return f"<AsyncArray {self.store_path} shape={self.shape} dtype={self.dtype}>"
 
-    async def info(self) -> None:
+    @property
+    def info(self) -> ...:
+        ...
+
+    async def info_full(self) -> None:
         raise NotImplementedError
 
 
@@ -2818,10 +2822,12 @@ class Array:
     def __repr__(self) -> str:
         return f"<Array {self.store_path} shape={self.shape} dtype={self.dtype}>"
 
+    @property
     def info(self) -> None:
-        return sync(
-            self._async_array.info(),
-        )
+        return self._async_array.info
+
+    def info_full(self) -> None:
+        ...
 
 
 def nchunks_initialized(

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1151,9 +1151,8 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         return self._info()
 
     async def info_complete(self) -> ArrayInfo:
-        # do the I/O to get the extra
-        extra: dict[str, int] = {}
-        return self._info(extra=extra)
+        # TODO: get the size of the object from the store.
+        raise NotImplementedError
 
     def _info(self, extra: dict[str, int] | None = None) -> ArrayInfo:
         kwargs: dict[str, Any] = {}
@@ -1164,13 +1163,13 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             if self.metadata.filters is not None:
                 kwargs["filters"] = str(self.metadata.filters)
             kwargs["data_type"] = str(self.metadata.dtype)
-            kwargs["chunks"] = self.metadata.chunks
+            kwargs["chunk_shape"] = self.metadata.chunks
         else:
             kwargs["codecs"] = str(self.metadata.codecs)
             kwargs["data_type"] = str(self.metadata.data_type)
             # just regular?
             if isinstance(self.metadata.chunk_grid, RegularChunkGrid):
-                kwargs["chunks"] = self.metadata.chunk_grid.chunk_shape
+                kwargs["chunk_shape"] = self.metadata.chunk_grid.chunk_shape
 
         return ArrayInfo(
             zarr_format=self.metadata.zarr_format,

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -794,6 +794,20 @@ class AsyncGroup:
 
     @property
     def info(self) -> GroupInfo:
+        """
+        Return the statically known information for a group.
+
+        Returns
+        -------
+        GroupInfo
+
+        See Also
+        --------
+        AsyncGroup.info_complete
+            All information about a group, including dynamic information
+            like the children members.
+        """
+
         if self.metadata.consolidated_metadata:
             members = list(self.metadata.consolidated_metadata.flattened_metadata.values())
         else:
@@ -801,6 +815,20 @@ class AsyncGroup:
         return self._info(members=members)
 
     async def info_complete(self) -> GroupInfo:
+        """
+        Return information for a group.
+
+        If this group doesn't contain consolidated metadata then
+        this will need to read from the backing Store.
+
+        Returns
+        -------
+        GroupInfo
+
+        See Also
+        --------
+        AsyncGroup.info
+        """
         members = [x[1].metadata async for x in self.members(max_depth=None)]
         return self._info(members=members)
 
@@ -1473,9 +1501,36 @@ class Group(SyncMixin):
 
     @property
     def info(self) -> GroupInfo:
+        """
+        Return the statically known information for a group.
+
+        Returns
+        -------
+        GroupInfo
+
+        See Also
+        --------
+        Group.info_complete
+            All information about a group, including dynamic information
+            like the children members.
+        """
         return self._async_group.info
 
     def info_complete(self) -> GroupInfo:
+        """
+        Return information for a group.
+
+        If this group doesn't contain consolidated metadata then
+        this will need to read from the backing Store.
+
+        Returns
+        -------
+        GroupInfo
+
+        See Also
+        --------
+        Group.info
+        """
         return self._sync(self._async_group.info_complete())
 
     @property

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -825,7 +825,8 @@ class AsyncGroup:
             read_only=self.store_path.store.mode.readonly,
             store_type=type(self.store_path.store).__name__,
             zarr_format=self.metadata.zarr_format,
-            **kwargs,
+            # maybe do a typeddict
+            **kwargs,  # type: ignore[arg-type]
         )
 
     @property

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -13,8 +13,8 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import deprecated
 
-from zarr._info import GroupInfo
 import zarr.api.asynchronous as async_api
+from zarr._info import GroupInfo
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import Store, set_or_delete
 from zarr.core.array import Array, AsyncArray, _build_parents
@@ -804,7 +804,9 @@ class AsyncGroup:
         members = [x[1].metadata async for x in self.members(max_depth=None)]
         return self._info(members=members)
 
-    def _info(self, members: list[ArrayV2Metadata | ArrayV3Metadata | GroupMetadata] | None = None) -> GroupInfo:
+    def _info(
+        self, members: list[ArrayV2Metadata | ArrayV3Metadata | GroupMetadata] | None = None
+    ) -> GroupInfo:
         kwargs = {}
         if members is not None:
             kwargs["count_members"] = len(members)
@@ -822,7 +824,8 @@ class AsyncGroup:
             name=self.store_path.path,
             read_only=self.store_path.store.mode.readonly,
             store_type=type(self.store_path.store).__name__,
-            **kwargs
+            zarr_format=self.metadata.zarr_format,
+            **kwargs,
         )
 
     @property

--- a/tests/v3/test_array.py
+++ b/tests/v3/test_array.py
@@ -7,6 +7,7 @@ import pytest
 
 import zarr.api.asynchronous
 from zarr import Array, AsyncArray, Group
+from zarr._info import ArrayInfo
 from zarr.codecs import BytesCodec, VLenBytesCodec
 from zarr.core.array import chunks_initialized
 from zarr.core.buffer.cpu import NDBuffer
@@ -417,3 +418,34 @@ def test_update_attrs(zarr_format: int) -> None:
 
     arr2 = zarr.open_array(store=store, zarr_format=zarr_format)
     assert arr2.attrs["foo"] == "bar"
+
+
+class TestInfo:
+    def test_info_v2(self) -> None:
+        arr = zarr.create(shape=(4, 4), chunks=(2, 2), zarr_format=2)
+        result = arr.info
+        expected = ArrayInfo(
+            zarr_format=2,
+            data_type="float64",
+            shape=(4, 4),
+            chunk_shape=(2, 2),
+            order="C",
+            read_only=False,
+            store_type="MemoryStore",
+        )
+        assert result == expected
+
+    def test_info_v3(self) -> None:
+        arr = zarr.create(shape=(4, 4), chunks=(2, 2), zarr_format=3)
+        result = arr.info
+        expected = ArrayInfo(
+            zarr_format=3,
+            data_type="DataType.float64",
+            shape=(4, 4),
+            chunk_shape=(2, 2),
+            order="C",
+            read_only=False,
+            store_type="MemoryStore",
+            codecs="[BytesCodec(endian=<Endian.little: 'little'>)]",
+        )
+        assert result == expected

--- a/tests/v3/test_group.py
+++ b/tests/v3/test_group.py
@@ -9,17 +9,17 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr._info import GroupInfo
 import zarr.api.asynchronous
 import zarr.api.synchronous
+import zarr.storage
 from zarr import Array, AsyncArray, AsyncGroup, Group
+from zarr._info import GroupInfo
 from zarr.abc.store import Store
 from zarr.core.buffer import default_buffer_prototype
 from zarr.core.group import ConsolidatedMetadata, GroupMetadata
 from zarr.core.sync import sync
 from zarr.errors import ContainsArrayError, ContainsGroupError
 from zarr.storage import LocalStore, MemoryStore, StorePath, ZipStore
-import zarr.storage
 from zarr.storage.common import make_store_path
 
 from .conftest import parse_store
@@ -1342,6 +1342,7 @@ class TestInfo:
             count_groups=1,
         )
         assert result == expected
+
 
 def test_update_attrs() -> None:
     # regression test for https://github.com/zarr-developers/zarr-python/issues/2328

--- a/tests/v3/test_info.py
+++ b/tests/v3/test_info.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from zarr._info import ArrayInfo, GroupInfo
+from zarr._info import ArrayInfo, GroupInfo, human_readable_size
 from zarr.core.common import ZarrFormat
 
 ZARR_FORMATS = [2, 3]
@@ -111,3 +111,19 @@ def test_array_info_complete(
         No. bytes stored   : {count_bytes_stored_formatted}
         Storage ratio      : {storage_ratio_formatted}
         Chunks Initialized : 5""")
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (1, "1"),
+        (2**10, "1.0K"),
+        (2**20, "1.0M"),
+        (2**30, "1.0G"),
+        (2**40, "1.0T"),
+        (2**50, "1.0P"),
+    ],
+)
+def test_human_readable_size(size: int, expected: str) -> None:
+    result = human_readable_size(size)
+    assert result == expected

--- a/tests/v3/test_info.py
+++ b/tests/v3/test_info.py
@@ -1,11 +1,9 @@
 import textwrap
-from typing import Literal
 
 import pytest
 
-from zarr.core.common import ZarrFormat
 from zarr._info import ArrayInfo, GroupInfo
-
+from zarr.core.common import ZarrFormat
 
 ZARR_FORMATS = [2, 3]
 
@@ -48,7 +46,7 @@ def test_group_info_complete(zarr_format: ZarrFormat) -> None:
 
 
 @pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
-def test_array_info(zarr_format: ZarrFormat):
+def test_array_info(zarr_format: ZarrFormat) -> None:
     info = ArrayInfo(
         zarr_format=zarr_format,
         data_type="int32",
@@ -73,10 +71,10 @@ def test_array_info(zarr_format: ZarrFormat):
 
 
 @pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
-@pytest.mark.parametrize("bytes_things", [(1_000_000, "976.6K", 500_000, "5", "2.0", 5)])
+@pytest.mark.parametrize("bytes_things", [(1_000_000, "976.6K", 500_000, "500000", "2.0", 5)])
 def test_array_info_complete(
     zarr_format: ZarrFormat, bytes_things: tuple[int, str, int, str, str, int]
-):
+) -> None:
     (
         count_bytes,
         count_bytes_formatted,
@@ -109,7 +107,7 @@ def test_array_info_complete(
         Read-only          : True
         Store type         : MemoryStore
         Codecs             : ["BytesCodec(endian=<Endian.little: 'little'>"]
-        No. bytes          : 1000000 (976.6K)
-        No. bytes stored   : 500000
-        Storage ratio      : 2.0
+        No. bytes          : {count_bytes} ({count_bytes_formatted})
+        No. bytes stored   : {count_bytes_stored_formatted}
+        Storage ratio      : {storage_ratio_formatted}
         Chunks Initialized : 5""")

--- a/tests/v3/test_info.py
+++ b/tests/v3/test_info.py
@@ -1,25 +1,44 @@
 import textwrap
+from typing import Literal
 
-from zarr._info import GroupInfo
+import pytest
+
+from zarr.core.common import ZarrFormat
+from zarr._info import ArrayInfo, GroupInfo
 
 
-def test_group_info_repr() -> None:
-    info = GroupInfo(name="a", store_type="MemoryStore", read_only=False)
+ZARR_FORMATS = [2, 3]
+
+
+@pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
+def test_group_info_repr(zarr_format: ZarrFormat) -> None:
+    info = GroupInfo(name="a", store_type="MemoryStore", read_only=False, zarr_format=zarr_format)
     result = repr(info)
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(f"""\
         Name        : a
         Type        : Group
+        Zarr format : {zarr_format}
         Read-only   : False
         Store type  : MemoryStore""")
     assert result == expected
 
 
-def test_group_info_complete() -> None:
-    info = GroupInfo(name="a", store_type="MemoryStore", read_only=False, count_arrays=10, count_groups=4, count_members=14)
+@pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
+def test_group_info_complete(zarr_format: ZarrFormat) -> None:
+    info = GroupInfo(
+        name="a",
+        store_type="MemoryStore",
+        zarr_format=zarr_format,
+        read_only=False,
+        count_arrays=10,
+        count_groups=4,
+        count_members=14,
+    )
     result = repr(info)
-    expected = textwrap.dedent("""\
+    expected = textwrap.dedent(f"""\
         Name        : a
         Type        : Group
+        Zarr format : {zarr_format}
         Read-only   : False
         Store type  : MemoryStore
         No. members : 14
@@ -27,3 +46,70 @@ def test_group_info_complete() -> None:
         No. groups  : 4""")
     assert result == expected
 
+
+@pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
+def test_array_info(zarr_format: ZarrFormat):
+    info = ArrayInfo(
+        zarr_format=zarr_format,
+        data_type="int32",
+        shape=(100, 100),
+        chunk_shape=(10, 100),
+        order="C",
+        read_only=True,
+        store_type="MemoryStore",
+        codecs=["BytesCodec(endian=<Endian.little: 'little'>"],
+    )
+    result = repr(info)
+    assert result == textwrap.dedent(f"""\
+        Type               : Array
+        Zarr format        : {zarr_format}
+        Data type          : int32
+        Shape              : (100, 100)
+        Chunk shape        : (10, 100)
+        Order              : C
+        Read-only          : True
+        Store type         : MemoryStore
+        Codecs             : ["BytesCodec(endian=<Endian.little: 'little'>"]""")
+
+
+@pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
+@pytest.mark.parametrize("bytes_things", [(1_000_000, "976.6K", 500_000, "5", "2.0", 5)])
+def test_array_info_complete(
+    zarr_format: ZarrFormat, bytes_things: tuple[int, str, int, str, str, int]
+):
+    (
+        count_bytes,
+        count_bytes_formatted,
+        count_bytes_stored,
+        count_bytes_stored_formatted,
+        storage_ratio_formatted,
+        count_chunks_initialized,
+    ) = bytes_things
+    info = ArrayInfo(
+        zarr_format=zarr_format,
+        data_type="int32",
+        shape=(100, 100),
+        chunk_shape=(10, 100),
+        order="C",
+        read_only=True,
+        store_type="MemoryStore",
+        codecs=["BytesCodec(endian=<Endian.little: 'little'>"],
+        count_bytes=count_bytes,
+        count_bytes_stored=count_bytes_stored,
+        count_chunks_initialized=count_chunks_initialized,
+    )
+    result = repr(info)
+    assert result == textwrap.dedent(f"""\
+        Type               : Array
+        Zarr format        : {zarr_format}
+        Data type          : int32
+        Shape              : (100, 100)
+        Chunk shape        : (10, 100)
+        Order              : C
+        Read-only          : True
+        Store type         : MemoryStore
+        Codecs             : ["BytesCodec(endian=<Endian.little: 'little'>"]
+        No. bytes          : 1000000 (976.6K)
+        No. bytes stored   : 500000
+        Storage ratio      : 2.0
+        Chunks Initialized : 5""")

--- a/tests/v3/test_info.py
+++ b/tests/v3/test_info.py
@@ -1,0 +1,29 @@
+import textwrap
+
+from zarr._info import GroupInfo
+
+
+def test_group_info_repr() -> None:
+    info = GroupInfo(name="a", store_type="MemoryStore", read_only=False)
+    result = repr(info)
+    expected = textwrap.dedent("""\
+        Name        : a
+        Type        : Group
+        Read-only   : False
+        Store type  : MemoryStore""")
+    assert result == expected
+
+
+def test_group_info_complete() -> None:
+    info = GroupInfo(name="a", store_type="MemoryStore", read_only=False, count_arrays=10, count_groups=4, count_members=14)
+    result = repr(info)
+    expected = textwrap.dedent("""\
+        Name        : a
+        Type        : Group
+        Read-only   : False
+        Store type  : MemoryStore
+        No. members : 14
+        No. arrays  : 10
+        No. groups  : 4""")
+    assert result == expected
+


### PR DESCRIPTION
Quick pass at adding `.info` to Group and Array. Like 2.x, `info` is a property, but it will only contain information that's known statically. I've added a `Group.info_complete` method that actually calls the store to get dynamic information (for group this is children).

I've punted on a similar `Array.info_complete`. For that, we'll need to expand the Store ABC to give us an `nbytes` method to get the size of the array in bytes. Maybe similar for the actual number of chunks written. Doable, but separate from this PR I think .

Closes https://github.com/zarr-developers/zarr-python/issues/2135