### PR TITLE
fix(group): deprecate positional args in Group.{zeros,ones,etc.}

### DIFF
--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -14,6 +14,7 @@ import numpy.typing as npt
 from typing_extensions import deprecated
 
 import zarr.api.asynchronous as async_api
+from zarr._compat import _deprecate_positional_args
 from zarr.abc.metadata import Metadata
 from zarr.abc.store import Store, set_or_delete
 from zarr.core.array import Array, AsyncArray, _build_parents
@@ -1533,6 +1534,7 @@ class Group(SyncMixin):
         # Backwards compatibility for 2.x
         return self.create_array(*args, **kwargs)
 
+    @_deprecate_positional_args
     def create_array(
         self,
         name: str,
@@ -1704,15 +1706,19 @@ class Group(SyncMixin):
         """
         return Array(self._sync(self._async_group.require_array(name, **kwargs)))
 
+    @_deprecate_positional_args
     def empty(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty(name=name, shape=shape, **kwargs)))
 
+    @_deprecate_positional_args
     def zeros(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.zeros(name=name, shape=shape, **kwargs)))
 
+    @_deprecate_positional_args
     def ones(self, *, name: str, shape: ChunkCoords, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.ones(name=name, shape=shape, **kwargs)))
 
+    @_deprecate_positional_args
     def full(
         self, *, name: str, shape: ChunkCoords, fill_value: Any | None, **kwargs: Any
     ) -> Array:
@@ -1722,22 +1728,28 @@ class Group(SyncMixin):
             )
         )
 
+    @_deprecate_positional_args
     def empty_like(self, *, name: str, data: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.empty_like(name=name, data=data, **kwargs)))
 
+    @_deprecate_positional_args
     def zeros_like(self, *, name: str, data: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.zeros_like(name=name, data=data, **kwargs)))
 
+    @_deprecate_positional_args
     def ones_like(self, *, name: str, data: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.ones_like(name=name, data=data, **kwargs)))
 
+    @_deprecate_positional_args
     def full_like(self, *, name: str, data: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.full_like(name=name, data=data, **kwargs)))
 
+    @_deprecate_positional_args
     def move(self, source: str, dest: str) -> None:
         return self._sync(self._async_group.move(source, dest))
 
     @deprecated("Use Group.create_array instead.")
+    @_deprecate_positional_args
     def array(
         self,
         name: str,

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -1744,7 +1744,6 @@ class Group(SyncMixin):
     def full_like(self, *, name: str, data: async_api.ArrayLike, **kwargs: Any) -> Array:
         return Array(self._sync(self._async_group.full_like(name=name, data=data, **kwargs)))
 
-    @_deprecate_positional_args
     def move(self, source: str, dest: str) -> None:
         return self._sync(self._async_group.move(source, dest))
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1329,3 +1329,23 @@ def test_update_attrs() -> None:
     )
     root.attrs["foo"] = "bar"
     assert root.attrs["foo"] == "bar"
+
+
+@pytest.mark.parametrize("method", ["empty", "zeros", "ones", "full"])
+def test_group_deprecated_positional_args(method: str) -> None:
+    if method == "full":
+        kwargs = {"fill_value": 0}
+    else:
+        kwargs = {}
+
+    root = zarr.group()
+    with pytest.warns(FutureWarning, match=r"Pass name=.* as keyword args."):
+        arr = getattr(root, method)("foo", shape=1, **kwargs)
+        assert arr.shape == (1,)
+
+    method += "_like"
+    data = np.ones(1)
+
+    with pytest.warns(FutureWarning, match=r"Pass name=.*, data=.* as keyword args."):
+        arr = getattr(root, method)("foo_like", data, **kwargs)
+        assert arr.shape == data.shape


### PR DESCRIPTION
Fixes #2402

Thanks @TomAugspurger for adding `_deprecate_positional_args`!

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] GitHub Actions have all passed
