### PR TITLE
Support using dev versions of numcodecs with zstd

### DIFF
--- a/src/zarr/codecs/zstd.py
+++ b/src/zarr/codecs/zstd.py
@@ -43,7 +43,7 @@ class ZstdCodec(BytesBytesCodec):
 
     def __init__(self, *, level: int = 0, checksum: bool = False) -> None:
         # numcodecs 0.13.0 introduces the checksum attribute for the zstd codec
-        _numcodecs_version = tuple(map(int, version("numcodecs").split(".")))
+        _numcodecs_version = tuple(map(int, version("numcodecs").split(".")[:3]))
         if _numcodecs_version < (0, 13, 0):  # pragma: no cover
             raise RuntimeError(
                 "numcodecs version >= 0.13.0 is required to use the zstd codec. "


### PR DESCRIPTION
I received the following error when using zstd with `'0.13.2.dev40'` (from `pip install git+https://github.com/zarr-developers/numcodecs@zarr3-codecs`). This change only uses the `X.Y.Z` part from the version when checking compatibility:

```bash
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[11], line 12
      8 ds = xr.open_zarr(virtual_store, zarr_version=3, consolidated=False)
      9 ds = ds.drop_encoding()
     10 encoding = {
     11     variable: {
---> 12         "codecs": [zarr.codecs.BytesCodec(), zarr.codecs.ZstdCodec()],
     13         "chunks": (1, 4096, 4096)
     14     }
     15 }
     16 ds.to_zarr(output_uri, zarr_version=3, mode="w", encoding=encoding, storage_options={"use_listings_cache": False})

File /opt/conda/lib/python3.11/site-packages/zarr/codecs/zstd.py:46, in ZstdCodec.__init__(self, level, checksum)
     44 def __init__(self, *, level: int = 0, checksum: bool = False) -> None:
     45     # numcodecs 0.13.0 introduces the checksum attribute for the zstd codec
---> 46     _numcodecs_version = tuple(map(int, version("numcodecs").split(".")))
     47     if _numcodecs_version < (0, 13, 0):  # pragma: no cover
     48         raise RuntimeError(
     49             "numcodecs version >= 0.13.0 is required to use the zstd codec. "
     50             f"Version {_numcodecs_version} is currently installed."
     51         )

ValueError: invalid literal for int() with base 10: 'dev40'
```