### PR TITLE
Build the docs with nitpicky = True

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,9 @@ templates_path = ["_templates"]
 # source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 
+# Fail the build on broken links
+nitpicky = True
+
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 


### PR DESCRIPTION
xref https://github.com/zarr-developers/zarr-python/issues/1888. This should fail the doc build on broken links. Perhaps it's not worth fixing these on the `v2` branch, but I thought we could at least see how bad it is.