### PR TITLE
Fix JSON encoding of complex fill values

### DIFF
--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -492,7 +492,7 @@ def parse_fill_value(
         if not np.isclose(fill_value, casted_value, equal_nan=True):
             raise ValueError(f"fill value {fill_value!r} is not valid for dtype {data_type}")
     elif np_dtype.kind == "c":
-        # confusingly np.isclose(np.inf, np.inf + 0j) is False, so compare real and imag parts
+        # confusingly np.isclose(np.inf, np.inf + 0j) is False on numpy<2, so compare real and imag parts
         # explicitly.
         if not (
             np.isclose(np.real(fill_value), np.real(casted_value), equal_nan=True)

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -149,7 +149,7 @@ class V3JsonEncoder(json.JSONEncoder):
                 if isinstance(out, complex):
                     # python complex types are not JSON serializable, so we use the
                     # serialization defined in the zarr v3 spec
-                    return [out.real, out.imag]
+                    return _replace_special_floats([out.real, out.imag])
                 elif np.isnan(out):
                     return "NaN"
                 elif np.isinf(out):

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -485,11 +485,19 @@ def parse_fill_value(
         pass
     elif fill_value in ["Infinity", "-Infinity"] and not np.isfinite(casted_value):
         pass
-    elif np_dtype.kind in "cf":
+    elif np_dtype.kind == "f":
         # float comparison is not exact, especially when dtype <float64
-        # so we us np.isclose for this comparison.
+        # so we use np.isclose for this comparison.
         # this also allows us to compare nan fill_values
         if not np.isclose(fill_value, casted_value, equal_nan=True):
+            raise ValueError(f"fill value {fill_value!r} is not valid for dtype {data_type}")
+    elif np_dtype.kind == "c":
+        # confusingly np.isclose(np.inf, np.inf + 0j) is False, so compare real and imag parts
+        # explicitly.
+        if not (
+            np.isclose(np.real(fill_value), np.real(casted_value), equal_nan=True)
+            and np.isclose(np.imag(fill_value), np.imag(casted_value), equal_nan=True)
+        ):
             raise ValueError(f"fill value {fill_value!r} is not valid for dtype {data_type}")
     else:
         if fill_value != casted_value:

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,5 +1,4 @@
 import json
-import math
 import pickle
 from itertools import accumulate
 from typing import Any, Literal
@@ -449,7 +448,7 @@ def test_array_create_order(
         (np.inf, ["Infinity", 0.0]),
         (np.inf * 1j, ["NaN", "Infinity"]),
         (-np.inf, ["-Infinity", 0.0]),
-        (math.inf, ["Infinity", 0.0]),
+        # (math.inf, ["Infinity", 0.0]),
     ],
 )
 async def test_special_complex_fill_values_roundtrip(fill_value: Any, expected: list[Any]) -> None:

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,4 +1,5 @@
 import json
+import math
 import pickle
 from itertools import accumulate
 from typing import Any, Literal
@@ -448,7 +449,7 @@ def test_array_create_order(
         (np.inf, ["Infinity", 0.0]),
         (np.inf * 1j, ["NaN", "Infinity"]),
         (-np.inf, ["-Infinity", 0.0]),
-        # (math.inf, ["Infinity", 0.0]),
+        (math.inf, ["Infinity", 0.0]),
     ],
 )
 async def test_special_complex_fill_values_roundtrip(fill_value: Any, expected: list[Any]) -> None:


### PR DESCRIPTION
We were not replacing NaNs and Infs with the string versions.

[Description of PR]

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
