### PR TITLE
add mode argument to zarr.save

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -346,7 +346,7 @@ async def save(
         NumPy arrays with data to save.
     zarr_format : {2, 3, None}, optional
         The zarr format to use when saving.
-    mode: {'r', 'r+', 'a', 'w', 'w-'}, optional
+    mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
         read/write (must exist); 'a' means read/write (create if doesn't
         exist); 'w' means create (overwrite if exists); 'w-' means create
@@ -395,7 +395,7 @@ async def save_array(
         NumPy array with data to save.
     zarr_format : {2, 3, None}, optional
         The zarr format to use when saving.
-    mode: {'r', 'r+', 'a', 'w', 'w-'}, optional
+    mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
         read/write (must exist); 'a' means read/write (create if doesn't
         exist); 'w' means create (overwrite if exists); 'w-' means create
@@ -446,7 +446,7 @@ async def save_group(
         NumPy arrays with data to save.
     zarr_format : {2, 3, None}, optional
         The zarr format to use when saving.
-    mode: {'r', 'r+', 'a', 'w', 'w-'}, optional
+    mode : {'r', 'r+', 'a', 'w', 'w-'}, optional
         Persistence mode: 'r' means read only (must exist); 'r+' means
         read/write (must exist); 'a' means read/write (create if doesn't
         exist); 'w' means create (overwrite if exists); 'w-' means create

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -101,12 +101,19 @@ def save(
     *args: NDArrayLike,
     zarr_version: ZarrFormat | None = None,  # deprecated
     zarr_format: ZarrFormat | None = None,
+    mode: AccessModeLiteral | None = None,
     path: str | None = None,
     **kwargs: Any,  # TODO: type kwargs as valid args to async_api.save
 ) -> None:
     return sync(
         async_api.save(
-            store, *args, zarr_version=zarr_version, zarr_format=zarr_format, path=path, **kwargs
+            store,
+            *args,
+            zarr_version=zarr_version,
+            zarr_format=zarr_format,
+            mode=mode,
+            path=path,
+            **kwargs,
         )
     )
 
@@ -118,6 +125,7 @@ def save_array(
     *,
     zarr_version: ZarrFormat | None = None,  # deprecated
     zarr_format: ZarrFormat | None = None,
+    mode: AccessModeLiteral | None = None,
     path: str | None = None,
     **kwargs: Any,  # TODO: type kwargs as valid args to async_api.save_array
 ) -> None:
@@ -127,6 +135,7 @@ def save_array(
             arr=arr,
             zarr_version=zarr_version,
             zarr_format=zarr_format,
+            mode=mode,
             path=path,
             **kwargs,
         )
@@ -138,6 +147,7 @@ def save_group(
     *args: NDArrayLike,
     zarr_version: ZarrFormat | None = None,  # deprecated
     zarr_format: ZarrFormat | None = None,
+    mode: AccessModeLiteral | None = None,
     path: str | None = None,
     storage_options: dict[str, Any] | None = None,
     **kwargs: NDArrayLike,
@@ -148,6 +158,7 @@ def save_group(
             *args,
             zarr_version=zarr_version,
             zarr_format=zarr_format,
+            mode=mode,
             path=path,
             storage_options=storage_options,
             **kwargs,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1006,4 +1006,4 @@ async def test_metadata_validation_error() -> None:
 def test_zarr_save(store: Store) -> None:
     a = np.arange(1000).reshape(10, 10, 10)
     zarr.save(StorePath(store), a, mode="w")
-    assert_array_equal(zarr.load(store)[...], a) # type: ignore[index]
+    assert_array_equal(zarr.load(store)[...], a)  # type: ignore[index]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1006,4 +1006,4 @@ async def test_metadata_validation_error() -> None:
 def test_zarr_save(store: Store) -> None:
     a = np.arange(1000).reshape(10, 10, 10)
     zarr.save(StorePath(store), a, mode="w")
-    assert_array_equal(zarr.load(store), a)
+    assert_array_equal(zarr.load(store)[:], a)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,7 @@ from zarr.api.synchronous import (
 )
 from zarr.core.common import MemoryOrder, ZarrFormat
 from zarr.errors import MetadataValidationError
+from zarr.storage import StorePath
 from zarr.storage._utils import normalize_path
 from zarr.storage.memory import MemoryStore
 
@@ -999,3 +1000,10 @@ async def test_metadata_validation_error() -> None:
         match="Invalid value for 'zarr_format'. Expected '2, 3, or None'. Got '3.0'.",
     ):
         await zarr.api.asynchronous.open_array(shape=(1,), zarr_format="3.0")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("store", ["local"], indirect=["store"])
+def test_zarr_save(store: Store) -> None:
+    a = np.arange(1000).reshape(10, 10, 10)
+    zarr.save(StorePath(store), a, mode="w")
+    assert_array_equal(zarr.load(store), a)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1006,4 +1006,4 @@ async def test_metadata_validation_error() -> None:
 def test_zarr_save(store: Store) -> None:
     a = np.arange(1000).reshape(10, 10, 10)
     zarr.save(StorePath(store), a, mode="w")
-    assert_array_equal(zarr.load(store)[:], a)
+    assert_array_equal(zarr.load(store)[...], a) # type: ignore[index]


### PR DESCRIPTION
fixes #2403 

### changes
- checks if all args, kwargs are numpy arrays
- add argument `mode` to `zarr.save`

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
