### PR TITLE
V2 group read file not found error

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -306,10 +306,11 @@ async def open(
 
     try:
         return await open_array(store=store_path, zarr_format=zarr_format, **kwargs)
-    except (KeyError, NodeTypeValidationError):
+    except (KeyError, NodeTypeValidationError, FileNotFoundError):
         # KeyError for a missing key
         # NodeTypeValidationError for failing to parse node metadata as an array when it's
         # actually a group
+        # FileNotFoundError for v2 when opening a group
         return await open_group(store=store_path, zarr_format=zarr_format, **kwargs)
 
 

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -11,7 +11,7 @@ from numcodecs.blosc import Blosc
 import zarr
 import zarr.storage
 from zarr import Array
-from zarr.storage import MemoryStore, StorePath, LocalStore
+from zarr.storage import LocalStore, MemoryStore, StorePath
 
 
 @pytest.fixture

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -11,7 +11,7 @@ from numcodecs.blosc import Blosc
 import zarr
 import zarr.storage
 from zarr import Array
-from zarr.storage import MemoryStore, StorePath
+from zarr.storage import MemoryStore, StorePath, LocalStore
 
 
 @pytest.fixture
@@ -33,6 +33,13 @@ def test_simple(store: StorePath) -> None:
 
     a[:, :] = data
     assert np.array_equal(data, a[:, :])
+
+
+def test_simple_group(tmp_path) -> None:
+    store = LocalStore(tmp_path, mode="w")
+    zarr.group(store=store, zarr_format=2)
+    root_group = zarr.open(tmp_path, zarr_format=2)
+    assert root_group is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This aims to fix an issue I reported at https://github.com/zarr-developers/zarr-python/issues/2412#issuecomment-2462633090
which is causing a lot of test failures when updating ome-zarr-py to use zarr v3 at https://github.com/ome/ome-zarr-py/pull/404

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
