### PR TITLE
handle empty string prefix in zipstore delete dir

### DIFF
--- a/src/zarr/storage/zip.py
+++ b/src/zarr/storage/zip.py
@@ -215,7 +215,7 @@ class ZipStore(Store):
     async def delete_dir(self, prefix: str) -> None:
         # only raise NotImplementedError if any keys are found
         self._check_writable()
-        if not prefix.endswith("/"):
+        if prefix != "" and not prefix.endswith("/"):
             prefix += "/"
         async for _ in self.list_prefix(prefix):
             raise NotImplementedError


### PR DESCRIPTION
Zipstore's implementation of `delete_dir` was not normalizing input paths correctly, resulting in the empty string '' being replaced with '/', which would fail to match anything.