### PR TITLE
don't normalize paths in StorePath.delete_dir

### DIFF
--- a/src/zarr/storage/common.py
+++ b/src/zarr/storage/common.py
@@ -160,10 +160,7 @@ class StorePath:
         """
         Delete all keys with the given prefix from the store.
         """
-        path = self.path
-        if not path.endswith("/"):
-            path += "/"
-        await self.store.delete_dir(path)
+        await self.store.delete_dir(self.path)
 
     async def set_if_not_exists(self, default: Buffer) -> None:
         """


### PR DESCRIPTION
`StorePath.delete_dir` does not need to normalize paths, because it calls  `store.delete_dir`, which does its own path normalization. 
 
TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
