### PR TITLE
fix open_array for mode r+

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -1097,7 +1097,7 @@ async def open_array(
     try:
         return await AsyncArray.open(store_path, zarr_format=zarr_format)
     except FileNotFoundError:
-        if not store_path.read_only:
+        if not store_path.read_only and mode in _CREATE_MODES:
             exists_ok = _infer_exists_ok(mode)
             _zarr_format = zarr_format or _default_zarr_version()
             return await create(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1030,3 +1030,19 @@ async def test_metadata_validation_error() -> None:
         match="Invalid value for 'zarr_format'. Expected '2, 3, or None'. Got '3.0'.",
     ):
         await zarr.api.asynchronous.open_array(shape=(1,), zarr_format="3.0")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "store",
+    ["local", "memory", "zip"],
+    indirect=True,
+)
+def test_open_array_with_mode_r_plus(store: Store) -> None:
+    # 'r+' means read/write (must exist)
+    with pytest.raises(FileNotFoundError):
+        zarr.open_array(store=store, mode="r+")
+    zarr.ones(store=store, shape=(3, 3))
+    z2 = zarr.open_array(store=store, mode="r+")
+    assert isinstance(z2, Array)
+    assert (z2[:] == 1).all()
+    z2[:] = 3

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -36,6 +36,7 @@ def test_simple(store: StorePath) -> None:
     assert np.array_equal(data, a[:, :])
 
 
+@pytest.mark.parametrize("store", ["memory"], indirect=True)
 @pytest.mark.parametrize(
     ("dtype", "fill_value"),
     [
@@ -48,7 +49,7 @@ def test_simple(store: StorePath) -> None:
         (str, ""),
     ],
 )
-def test_implicit_fill_value(store: StorePath, dtype: str, fill_value: Any) -> None:
+def test_implicit_fill_value(store: MemoryStore, dtype: str, fill_value: Any) -> None:
     arr = zarr.open_array(store=store, shape=(4,), fill_value=None, zarr_format=2, dtype=dtype)
     assert arr.metadata.fill_value is None
     assert arr.metadata.to_dict()["fill_value"] is None

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -50,7 +50,7 @@ def test_simple(store: StorePath) -> None:
     ],
 )
 def test_implicit_fill_value(store: MemoryStore, dtype: str, fill_value: Any) -> None:
-    arr = zarr.open_array(store=store, shape=(4,), fill_value=None, zarr_format=2, dtype=dtype)
+    arr = zarr.create(store=store, shape=(4,), fill_value=None, zarr_format=2, dtype=dtype)
     assert arr.metadata.fill_value is None
     assert arr.metadata.to_dict()["fill_value"] is None
     result = arr[:]


### PR DESCRIPTION
Raises `FileNotFoundError` if `open_array` is invoked with `mode=r+` when no extant array is found.

Fixes #2491 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
