### PR TITLE
deprecate(chunkstore): add deprecation warning for chunk_store kwarg

### DIFF
--- a/zarr/core.py
+++ b/zarr/core.py
@@ -4,6 +4,7 @@ import itertools
 import math
 import operator
 import re
+import warnings
 from functools import reduce
 from typing import Any
 
@@ -78,6 +79,10 @@ class Array:
     chunk_store : MutableMapping, optional
         Separate storage for chunks. If not provided, `store` will be used
         for storage of both chunks and metadata.
+        [DEPRECATED since version 2.18.4] This argument is deprecated and will be
+        removed in version 3.0. See
+        `GH2495 <https://github.com/zarr-developers/zarr-python/issues/2495>`_
+        for more information.
     synchronizer : object, optional
         Array synchronizer.
     cache_metadata : bool, optional
@@ -139,6 +144,12 @@ class Array:
             assert_zarr_v3_api_available()
 
         if chunk_store is not None:
+            warnings.warn(
+                "chunk_store is deprecated and will be removed in a Zarr-Python version 3, see "
+                "https://github.com/zarr-developers/zarr-python/issues/2495 for more information.",
+                FutureWarning,
+                stacklevel=2,
+            )
             chunk_store = normalize_store_arg(chunk_store, zarr_version=zarr_version)
 
         self._store = store

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -519,6 +519,10 @@ def open_array(
         A codec to encode object arrays, only needed if dtype=object.
     chunk_store : MutableMapping or string, optional
         Store or path to directory in file system or name of zip file.
+        [DEPRECATED since version 2.18.4] This argument is deprecated and will be
+        removed in version 3.0. See
+        `GH2495 <https://github.com/zarr-developers/zarr-python/issues/2495>`_
+        for more information.
     storage_options : dict
         If using an fsspec URL to create the store, these will be passed to
         the backend implementation. Ignored otherwise.

--- a/zarr/hierarchy.py
+++ b/zarr/hierarchy.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import MutableMapping
 from itertools import islice
 
@@ -73,6 +74,10 @@ class Group(MutableMapping):
     chunk_store : MutableMapping, optional
         Separate storage for chunks. If not provided, `store` will be used
         for storage of both chunks and metadata.
+        [DEPRECATED since version 2.18.4] This argument is deprecated and will be
+        removed in version 3.0. See
+        `GH2495 <https://github.com/zarr-developers/zarr-python/issues/2495>`_
+        for more information.
     cache_attrs : bool, optional
         If True (default), user attributes will be cached for attribute read
         operations. If False, user attributes are reloaded from the store prior
@@ -156,6 +161,12 @@ class Group(MutableMapping):
             assert_zarr_v3_api_available()
 
         if chunk_store is not None:
+            warnings.warn(
+                "chunk_store is deprecated and will be removed in a Zarr-Python version 3, see "
+                "https://github.com/zarr-developers/zarr-python/issues/2495 for more information.",
+                FutureWarning,
+                stacklevel=2,
+            )
             chunk_store: BaseStore = _normalize_store_arg(chunk_store, zarr_version=zarr_version)
         self._store = store
         self._chunk_store = chunk_store


### PR DESCRIPTION
This PR adds deprecation warnings to for the `chunk_store` keyword in Zarr 2. 

See https://github.com/zarr-developers/zarr-python/issues/2495 for details.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
