### PR TITLE
Refactor/narrow array name type

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -810,7 +810,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         return self.store_path.path
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Array name following h5py convention.
 
         Returns
@@ -818,16 +818,14 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         str
             The name of the array.
         """
-        if self.path:
-            # follow h5py convention: add leading slash
-            name = self.path
-            if name[0] != "/":
-                name = "/" + name
-            return name
-        return None
+        # follow h5py convention: add leading slash
+        name = self.path
+        if not name.startswith("/"):
+            name = "/" + name
+        return name
 
     @property
-    def basename(self) -> str | None:
+    def basename(self) -> str:
         """Final component of name.
 
         Returns
@@ -835,9 +833,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         str
             The basename or final component of the array name.
         """
-        if self.name is not None:
-            return self.name.split("/")[-1]
-        return None
+        return self.name.split("/")[-1]
 
     @property
     def cdata_shape(self) -> ChunkCoords:
@@ -1626,8 +1622,7 @@ class Array:
         return self._async_array.path
 
     @property
-    def name(self) -> str | None:
-        """Array name following h5py convention."""
+    def name(self) -> str:
         return self._async_array.name
 
     @property

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -153,7 +153,7 @@ def arrays(
     assert isinstance(a, Array)
     if a.metadata.zarr_format == 3:
         assert a.fill_value is not None
-        assert a.name is not None
+    assert a.name is not None
     assert isinstance(root[array_path], Array)
     assert nparray.shape == a.shape
     assert chunks == a.chunks

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -153,6 +153,7 @@ def arrays(
     assert isinstance(a, Array)
     if a.metadata.zarr_format == 3:
         assert a.fill_value is not None
+        assert a.name is not None
     assert isinstance(root[array_path], Array)
     assert nparray.shape == a.shape
     assert chunks == a.chunks

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -122,8 +122,8 @@ def test_array_name_properties_no_group(
 ) -> None:
     arr = Array.create(store=store, shape=(100,), chunks=(10,), zarr_format=zarr_format, dtype="i4")
     assert arr.path == ""
-    assert arr.name is None
-    assert arr.basename is None
+    assert arr.name == "/"
+    assert arr.basename == ""
 
 
 @pytest.mark.parametrize("store", ["local", "memory", "zip"], indirect=["store"])


### PR DESCRIPTION
Remove the possibility that `Array.name` is `None`. In situations when `Array.name` would be `None` (i.e., when the array is at the root of the store), it will be the empty string ''.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
