### PR TITLE
Apply ruff preview rule RUF036

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -604,7 +604,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         dtype: npt.DTypeLike,
         chunks: ChunkCoords,
         dimension_separator: Literal[".", "/"] | None = None,
-        fill_value: None | float = None,
+        fill_value: float | None = None,
         order: MemoryOrder | None = None,
         filters: list[dict[str, JSON]] | None = None,
         compressor: dict[str, JSON] | None = None,

--- a/src/zarr/core/common.py
+++ b/src/zarr/core/common.py
@@ -36,7 +36,7 @@ ChunkCoords = tuple[int, ...]
 ChunkCoordsLike = Iterable[int]
 ZarrFormat = Literal[2, 3]
 NodeType = Literal["array", "group"]
-JSON = None | str | int | float | Mapping[str, "JSON"] | tuple["JSON", ...]
+JSON = str | int | float | Mapping[str, "JSON"] | tuple["JSON", ...] | None
 MemoryOrder = Literal["C", "F"]
 AccessModeLiteral = Literal["r", "r+", "a", "w", "w-"]
 

--- a/src/zarr/core/metadata/common.py
+++ b/src/zarr/core/metadata/common.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from zarr.core.common import JSON
 
 
-def parse_attributes(data: None | dict[str, JSON]) -> dict[str, JSON]:
+def parse_attributes(data: dict[str, JSON] | None) -> dict[str, JSON]:
     if data is None:
         return {}
 

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -44,7 +44,7 @@ class ArrayV2Metadata(Metadata):
     shape: ChunkCoords
     chunks: tuple[int, ...]
     dtype: np.dtype[Any]
-    fill_value: None | int | float | str | bytes = 0
+    fill_value: int | float | str | bytes | None = 0
     order: MemoryOrder = "C"
     filters: tuple[numcodecs.abc.Codec, ...] | None = None
     dimension_separator: Literal[".", "/"] = "."

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -225,9 +225,9 @@ class ArrayV3Metadata(Metadata):
         chunk_key_encoding: dict[str, JSON] | ChunkKeyEncoding,
         fill_value: Any,
         codecs: Iterable[Codec | dict[str, JSON]],
-        attributes: None | dict[str, JSON],
-        dimension_names: None | Iterable[str],
-        storage_transformers: None | Iterable[dict[str, JSON]] = None,
+        attributes: dict[str, JSON] | None,
+        dimension_names: Iterable[str] | None,
+        storage_transformers: Iterable[dict[str, JSON]] | None = None,
     ) -> None:
         """
         Because the class is a frozen dataclass, we set attributes using object.__setattr__
@@ -540,7 +540,7 @@ class DataType(Enum):
     bytes = "bytes"
 
     @property
-    def byte_count(self) -> None | int:
+    def byte_count(self) -> int | None:
         data_type_byte_counts = {
             DataType.bool: 1,
             DataType.int8: 1,
@@ -626,7 +626,7 @@ class DataType(Enum):
         return DataType[dtype_to_data_type[dtype.str]]
 
     @classmethod
-    def parse(cls, dtype: None | DataType | Any) -> DataType:
+    def parse(cls, dtype: DataType | Any | None) -> DataType:
         if dtype is None:
             return DataType[DEFAULT_DTYPE]
         if isinstance(dtype, DataType):

--- a/src/zarr/storage/_utils.py
+++ b/src/zarr/storage/_utils.py
@@ -45,7 +45,7 @@ def normalize_path(path: str | bytes | Path | None) -> str:
 
 
 def _normalize_interval_index(
-    data: Buffer, interval: None | tuple[int | None, int | None]
+    data: Buffer, interval: tuple[int | None, int | None] | None
 ) -> tuple[int, int]:
     """
     Convert an implicit interval into an explicit start and length

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -106,7 +106,7 @@ class StoreTests(Generic[S, B]):
     @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
     @pytest.mark.parametrize("byte_range", [None, (0, None), (1, None), (1, 2), (None, 1)])
     async def test_get(
-        self, store: S, key: str, data: bytes, byte_range: None | tuple[int | None, int | None]
+        self, store: S, key: str, data: bytes, byte_range: tuple[int | None, int | None] | None
     ) -> None:
         """
         Ensure that data can be read from the store using the store.get method.

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -117,7 +117,7 @@ def arrays(
     shapes: st.SearchStrategy[tuple[int, ...]] = array_shapes,
     compressors: st.SearchStrategy = compressors,
     stores: st.SearchStrategy[StoreLike] = stores,
-    paths: st.SearchStrategy[None | str] = paths,
+    paths: st.SearchStrategy[str | None] = paths,
     array_names: st.SearchStrategy = array_names,
     arrays: st.SearchStrategy | None = None,
     attrs: st.SearchStrategy = attrs,

--- a/tests/test_codecs/test_vlen.py
+++ b/tests/test_codecs/test_vlen.py
@@ -25,7 +25,7 @@ else:
 @pytest.mark.parametrize("as_object_array", [False, True])
 @pytest.mark.parametrize("codecs", [None, [VLenUTF8Codec()], [VLenUTF8Codec(), ZstdCodec()]])
 def test_vlen_string(
-    store: Store, dtype: None | np.dtype[Any], as_object_array: bool, codecs: None | list[Codec]
+    store: Store, dtype: np.dtype[Any] | None, as_object_array: bool, codecs: list[Codec] | None
 ) -> None:
     strings = ["hello", "world", "this", "is", "a", "test"]
     data = np.array(strings, dtype=dtype).reshape((2, 3))
@@ -62,7 +62,7 @@ def test_vlen_string(
 @pytest.mark.parametrize("store", ["memory", "local"], indirect=["store"])
 @pytest.mark.parametrize("as_object_array", [False, True])
 @pytest.mark.parametrize("codecs", [None, [VLenBytesCodec()], [VLenBytesCodec(), ZstdCodec()]])
-def test_vlen_bytes(store: Store, as_object_array: bool, codecs: None | list[Codec]) -> None:
+def test_vlen_bytes(store: Store, as_object_array: bool, codecs: list[Codec] | None) -> None:
     bstrings = [b"hello", b"world", b"this", b"is", b"a", b"test"]
     data = np.array(bstrings).reshape((2, 3))
     assert data.dtype == "|S5"

--- a/tests/test_metadata/test_v2.py
+++ b/tests/test_metadata/test_v2.py
@@ -43,7 +43,7 @@ def test_metadata_to_dict(
     fill_value: Any,
     order: Literal["C", "F"],
     dimension_separator: Literal[".", "/"] | None,
-    attributes: None | dict[str, Any],
+    attributes: dict[str, Any] | None,
 ) -> None:
     shape = (1, 2, 3)
     chunks = (1,) * len(shape)

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -240,8 +240,8 @@ def test_metadata_to_dict(
     chunk_key_encoding: Literal["v2", "default"],
     dimension_separator: Literal[".", "/"] | None,
     dimension_names: Literal["nones", "strings", "missing"],
-    attributes: None | dict[str, Any],
-    storage_transformers: None | tuple[dict[str, JSON]],
+    attributes: dict[str, Any] | None,
+    storage_transformers: tuple[dict[str, JSON]] | None,
 ) -> None:
     shape = (1, 2, 3)
     data_type = DataType.uint8

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -21,14 +21,14 @@ class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
     @pytest.fixture(params=[None, True])
     def store_kwargs(
         self, request: pytest.FixtureRequest
-    ) -> dict[str, str | None | dict[str, Buffer]]:
+    ) -> dict[str, str | dict[str, Buffer] | None]:
         kwargs = {"store_dict": None}
         if request.param is True:
             kwargs["store_dict"] = {}
         return kwargs
 
     @pytest.fixture
-    def store(self, store_kwargs: str | None | dict[str, Buffer]) -> MemoryStore:
+    def store(self, store_kwargs: str | dict[str, Buffer] | None) -> MemoryStore:
         return self.store_cls(**store_kwargs)
 
     def test_store_repr(self, store: MemoryStore) -> None:
@@ -61,14 +61,14 @@ class TestGpuMemoryStore(StoreTests[GpuMemoryStore, gpu.Buffer]):
     @pytest.fixture(params=[None, True])
     def store_kwargs(
         self, request: pytest.FixtureRequest
-    ) -> dict[str, str | None | dict[str, Buffer]]:
+    ) -> dict[str, str | dict[str, Buffer] | None]:
         kwargs = {"store_dict": None}
         if request.param is True:
             kwargs["store_dict"] = {}
         return kwargs
 
     @pytest.fixture
-    def store(self, store_kwargs: str | None | dict[str, gpu.Buffer]) -> GpuMemoryStore:
+    def store(self, store_kwargs: str | dict[str, gpu.Buffer] | None) -> GpuMemoryStore:
         return self.store_cls(**store_kwargs)
 
     def test_store_repr(self, store: GpuMemoryStore) -> None:


### PR DESCRIPTION
The `None` literal represents the absence of a value. For readability, it's preferred to write the more informative type expressions first.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
