### PR TITLE
Wrap sync fs for xarray.to_zarr

### DIFF
--- a/src/zarr/storage/remote.py
+++ b/src/zarr/storage/remote.py
@@ -166,6 +166,9 @@ class RemoteStore(Store):
         opts = {"asynchronous": True, **opts}
 
         fs, path = url_to_fs(url, **opts)
+        if not fs.async_impl:
+            from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+            fs = AsyncFileSystemWrapper(fs)
 
         # fsspec is not consistent about removing the scheme from the path, so check and strip it here
         # https://github.com/fsspec/filesystem_spec/issues/1722


### PR DESCRIPTION
This PR automatically wraps synchronous filesystems in the `RemoteStore.from_url` function. This is necessary unless we provide a `force_async` argument on `fsspec`s `url_to_fs` function.

I'm not sure adding more flags (even if we sugar them with default values) is the best move. Another option might be to implement a `url_to_asyncfs` method that simply wraps `url_to_fs` and wraps any synchronous filesystems that come out automatically but that, too, would require changes here.

This PR is in service of downstream kerchunk compatibility: https://github.com/fsspec/kerchunk/pull/516