### PR TITLE
[v3] implement / deprecate zarr.tree

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
+from typing_extensions import deprecated
 
 from zarr.core.array import Array, AsyncArray, get_array_metadata
 from zarr.core.buffer import NDArrayLike
@@ -493,6 +494,7 @@ async def save_group(
     await asyncio.gather(*aws)
 
 
+@deprecated("Use AsyncGroup.tree instead.")
 async def tree(grp: AsyncGroup, expand: bool | None = None, level: int | None = None) -> Any:
     """Provide a rich display of the hierarchy.
 
@@ -514,11 +516,6 @@ async def tree(grp: AsyncGroup, expand: bool | None = None, level: int | None = 
         `zarr.tree()` is deprecated and will be removed in a future release.
         Use `group.tree()` instead.
     """
-    warnings.warn(
-        "zarr.tree() is deprecated and will be removed in a future release. Use group.tree() instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     return await grp.tree(expand=expand, level=level)
 
 

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -493,8 +493,33 @@ async def save_group(
     await asyncio.gather(*aws)
 
 
-async def tree(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError
+async def tree(grp: AsyncGroup, expand: bool | None = None, level: int | None = None) -> Any:
+    """Provide a rich display of the hierarchy.
+
+    Parameters
+    ----------
+    grp : Group
+        Zarr or h5py group.
+    expand : bool, optional
+        Only relevant for HTML representation. If True, tree will be fully expanded.
+    level : int, optional
+        Maximum depth to descend into hierarchy.
+
+    Returns
+    -------
+    TreeRepr
+        A pretty-printable object displaying the hierarchy.
+
+    .. deprecated:: 3.0.0
+        `zarr.tree()` is deprecated and will be removed in a future release.
+        Use `group.tree()` instead.
+    """
+    warnings.warn(
+        "zarr.tree() is deprecated and will be removed in a future release. Use group.tree() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return await grp.tree(expand=expand, level=level)
 
 
 async def array(

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from typing_extensions import deprecated
+
 import zarr.api.asynchronous as async_api
 from zarr._compat import _deprecate_positional_args
 from zarr.core.array import Array, AsyncArray
@@ -155,6 +157,7 @@ def save_group(
     )
 
 
+@deprecated("Use Group.tree instead.")
 def tree(grp: Group, expand: bool | None = None, level: int | None = None) -> Any:
     return sync(async_api.tree(grp._async_group, expand=expand, level=level))
 

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -155,8 +155,8 @@ def save_group(
     )
 
 
-def tree(*args: Any, **kwargs: Any) -> None:
-    return sync(async_api.tree(*args, **kwargs))
+def tree(grp: Group, expand: bool | None = None, level: int | None = None) -> Any:
+    return sync(async_api.tree(grp._async_group, expand=expand, level=level))
 
 
 # TODO: add type annotations for kwargs

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -1449,7 +1449,7 @@ class AsyncGroup:
         from zarr.core._tree import group_tree_async
 
         if expand is not None:
-            raise NotImplementedError("'expanded' is not yet implemented.")
+            raise NotImplementedError("'expand' is not yet implemented.")
         return await group_tree_async(self, max_depth=level)
 
     async def empty(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -294,6 +294,7 @@ def test_load_array(memory_store: Store) -> None:
 
 
 def test_tree() -> None:
+    pytest.importorskip("rich")
     g1 = zarr.group()
     g1.create_group("foo")
     g3 = g1.create_group("bar")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,9 +300,9 @@ def test_tree() -> None:
     g3.create_group("baz")
     g5 = g3.create_group("qux")
     g5.create_array("baz", shape=100, chunks=10)
-    # TODO: complete after tree has been reimplemented
-    # assert repr(zarr.tree(g1)) == repr(g1.tree())
-    # assert str(zarr.tree(g1)) == str(g1.tree())
+    with pytest.warns(DeprecationWarning):
+        assert repr(zarr.tree(g1)) == repr(g1.tree())
+        assert str(zarr.tree(g1)) == str(g1.tree())
 
 
 # @pytest.mark.parametrize("stores_from_path", [False, True])


### PR DESCRIPTION
We probably should have deprecated this in 2.18 but alas, here we are. This PR uses `Group.tree` for `zarr.tree` but adds a deprecation warning stating that we'll remove this after 3.0.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
