### PR TITLE
Improve installation page

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 Contributing to Zarr
 ====================
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,5 +1,3 @@
-.. _contributing:
-
 Contributing to Zarr
 ====================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,33 +1,34 @@
 Installation
 ============
 
-Zarr depends on NumPy. It is generally best to `install NumPy
-<https://numpy.org/doc/stable/user/install.html>`_ first using whatever method is most
-appropriate for your operating system and Python distribution. Other dependencies should be
-installed automatically if using one of the installation methods below.
-
-Note: Zarr has endorsed `Scientific-Python SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_ and now follows the version support window as outlined below:
-
-- Python: 36 months after initial release
-- Core package dependencies (e.g. NumPy): 24 months after initial release
-
-Install Zarr from PyPI:
+From PyPI using pip:
 
 .. code-block:: console
 
     $ pip install zarr
 
-Alternatively, install Zarr via conda:
+From conda-forge using conda:
 
 .. code-block:: console
 
     $ conda install -c conda-forge zarr
 
-To install the latest development version of Zarr, you can use pip with the
-latest GitHub main:
+Optional dependencies
+---------------------
+There are a number of optional dependency groups you can install for extra functionality.
+These can be installed using ``pip install "zarr[<extra>]"``, e.g. ``pip install "zarr[gpu]"``
 
-.. code-block:: console
+- ``gpu``: support for GPUs
+- ``fsspec``: support for reading/writing to remote data stores
+- ``tree``: support for pretty printing of directory trees
 
-    $ pip install git+https://github.com/zarr-developers/zarr-python.git
+Dependency support
+------------------
+Zarr has endorsed `Scientific-Python SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_ and now follows the version support window as outlined below:
 
-To work with Zarr source code in development, see `Contributing <contributing.html>`_.
+- Python: 36 months after initial release
+- Core package dependencies (e.g. NumPy): 24 months after initial release
+
+Development
+-----------
+To install the latest development version of Zarr, see :ref:`contributing`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,4 +34,4 @@ Zarr has endorsed `Scientific-Python SPEC 0 <https://scientific-python.org/specs
 
 Development
 -----------
-To install the latest development version of Zarr, see :ref:`contributing`.
+To install the latest development version of Zarr, see `the contributing guide <contributing.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,21 +6,27 @@ Zarr depends on NumPy. It is generally best to `install NumPy
 appropriate for your operating system and Python distribution. Other dependencies should be
 installed automatically if using one of the installation methods below.
 
-Note: Zarr has endorsed `Scientific-Python SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_ and now follows the version support window as outlined below: 
+Note: Zarr has endorsed `Scientific-Python SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_ and now follows the version support window as outlined below:
 
 - Python: 36 months after initial release
 - Core package dependencies (e.g. NumPy): 24 months after initial release
 
-Install Zarr from PyPI::
+Install Zarr from PyPI:
+
+.. code-block:: console
 
     $ pip install zarr
 
-Alternatively, install Zarr via conda::
+Alternatively, install Zarr via conda:
+
+.. code-block:: console
 
     $ conda install -c conda-forge zarr
 
 To install the latest development version of Zarr, you can use pip with the
-latest GitHub main::
+latest GitHub main:
+
+.. code-block:: console
 
     $ pip install git+https://github.com/zarr-developers/zarr-python.git
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,26 +1,29 @@
 Installation
 ============
 
-From PyPI using pip:
+pip
+---
 
 .. code-block:: console
 
     $ pip install zarr
 
-From conda-forge using conda:
-
-.. code-block:: console
-
-    $ conda install -c conda-forge zarr
-
-Optional dependencies
----------------------
 There are a number of optional dependency groups you can install for extra functionality.
 These can be installed using ``pip install "zarr[<extra>]"``, e.g. ``pip install "zarr[gpu]"``
 
 - ``gpu``: support for GPUs
 - ``fsspec``: support for reading/writing to remote data stores
 - ``tree``: support for pretty printing of directory trees
+
+conda
+-----
+
+.. code-block:: console
+
+    $ conda install -c conda-forge zarr
+
+Conda does not support optional dependencies, so you will have to manually install any packages
+needed to enable extra functionality.
 
 Dependency support
 ------------------

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -1847,8 +1847,8 @@ class Group(SyncMixin):
     async def update_attributes_async(self, new_attributes: dict[str, Any]) -> Group:
         """Update the attributes of this group.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import zarr
         >>> group = zarr.group()
         >>> await group.update_attributes_async({"foo": "bar"})
@@ -1947,8 +1947,9 @@ class Group(SyncMixin):
 
     def update_attributes(self, new_attributes: dict[str, Any]) -> Group:
         """Update the attributes of this group.
-        Example
-        -------
+
+        Examples
+        --------
         >>> import zarr
         >>> group = zarr.group()
         >>> group.update_attributes({"foo": "bar"})
@@ -2027,8 +2028,8 @@ class Group(SyncMixin):
     def groups(self) -> Generator[tuple[str, Group], None]:
         """Return the sub-groups of this group as a generator of (name, group) pairs.
 
-        Example
-        -------
+        Examples
+        --------
         >>> import zarr
         >>> group = zarr.group()
         >>> group.create_group("subgroup")


### PR DESCRIPTION
This improves the installation page by:

- Removing dev installation steps, instead link to the contribution guide
- Split into pip/conda sections, which enables:
- Documenting the pip extras available