### PR TITLE
Raise an exception for previously set key

### DIFF
--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -319,8 +319,9 @@ class StoreTests(Generic[S, B]):
         data_buf = self.buffer_cls.from_bytes(b"0000")
         await self.set(store, key, data_buf)
 
-        new = self.buffer_cls.from_bytes(b"1111")
-        await store.set_if_not_exists("k", new)  # no error
+        with pytest.raises(Exception):
+            new = self.buffer_cls.from_bytes(b"1111")
+            await store.set_if_not_exists("k", new)
 
         result = await store.get(key, default_buffer_prototype())
         assert result == data_buf

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -321,7 +321,7 @@ class StoreTests(Generic[S, B]):
 
         with pytest.raises(Exception):
             new = self.buffer_cls.from_bytes(b"1111")
-            await store.set_if_not_exists("k", new)
+            await store.set_if_not_exists(key, new)
 
         result = await store.get(key, default_buffer_prototype())
         assert result == data_buf


### PR DESCRIPTION
I think this tests was not correctly checking the behavior because the data at `k` was previously set, so calling `set_if_not_exists` on that same key should actually raise an exception. The behavior for obstore in https://github.com/zarr-developers/zarr-python/pull/1661 and https://github.com/kylebarron/zarr-python/pull/3 seem correct, in contrast to the fsspec-based stores which now fail on this test.