### PR TITLE
Shorten contributing page title

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,5 +1,5 @@
-Contributing to Zarr
-====================
+Contributing
+============
 
 Zarr is a community maintained project. We welcome contributions in the form of bug
 reports, bug fixes, documentation, enhancement proposals and more. This page provides


### PR DESCRIPTION
This shortens the title a bit, so it takes up less room in the top navigation bar.