### PR TITLE
Remove config warning if only one implementation exists

### DIFF
--- a/src/zarr/registry.py
+++ b/src/zarr/registry.py
@@ -138,6 +138,8 @@ def get_codec_class(key: str, reload_config: bool = False) -> type[Codec]:
 
     config_entry = config.get("codecs", {}).get(key)
     if config_entry is None:
+        if len(codec_classes) == 1:
+            return next(iter(codec_classes.values()))
         warnings.warn(
             f"Codec '{key}' not configured in config. Selecting any implementation.", stacklevel=2
         )


### PR DESCRIPTION
- contributes to #2509 by removing a UserWarning if no codec implementation was selected in config but only 1 is registered 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
