### PR TITLE
Warn the user when shape or chunks contains float values

### DIFF
--- a/zarr/tests/test_creation.py
+++ b/zarr/tests/test_creation.py
@@ -2,6 +2,7 @@ import atexit
 import os.path
 import shutil
 import warnings
+import numbers
 
 import numpy as np
 import pytest
@@ -762,7 +763,13 @@ def test_create_with_storage_transformers(at_root):
 )
 def test_shape_chunk_ints(init_shape, init_chunks, shape, chunks):
     g = open_group()
-    array = g.create_dataset("ds", shape=init_shape, chunks=init_chunks, dtype=np.uint8)
+    if not isinstance(init_shape[0], numbers.Integral) or not isinstance(
+        init_chunks[0], numbers.Integral
+    ):
+        with pytest.warns(UserWarning):
+            array = g.create_dataset("ds", shape=init_shape, chunks=init_chunks, dtype=np.uint8)
+    else:
+        array = g.create_dataset("ds", shape=init_shape, chunks=init_chunks, dtype=np.uint8)
 
     assert all(
         isinstance(s, int) for s in array.shape

--- a/zarr/tests/test_util.py
+++ b/zarr/tests/test_util.py
@@ -44,7 +44,8 @@ def test_normalize_shape():
     with pytest.raises(TypeError):
         normalize_shape(None)
     with pytest.raises(ValueError):
-        normalize_shape("foo")
+        with pytest.warns(UserWarning):
+            normalize_shape("foo")
 
 
 def test_normalize_chunks():

--- a/zarr/util.py
+++ b/zarr/util.py
@@ -18,6 +18,7 @@ from typing import (
     Iterable,
     cast,
 )
+import warnings
 
 import numpy as np
 from asciitree import BoxStyle, LeftAligned
@@ -88,6 +89,8 @@ def normalize_shape(shape: Union[int, Tuple[int, ...], None]) -> Tuple[int, ...]
 
     # normalize
     shape = cast(Tuple[int, ...], shape)
+    if not all(isinstance(s, numbers.Integral) for s in shape):
+        warnings.warn("shape contains non-integer value(s)", UserWarning, stacklevel=2)
     shape = tuple(int(s) for s in shape)
     return shape
 
@@ -175,6 +178,9 @@ def normalize_chunks(chunks: Any, shape: Tuple[int, ...], typesize: int) -> Tupl
     # handle None or -1 in chunks
     if -1 in chunks or None in chunks:
         chunks = tuple(s if c == -1 or c is None else int(c) for s, c in zip(shape, chunks))
+
+    if not all(isinstance(c, numbers.Integral) for c in chunks):
+        warnings.warn("chunks contains non-integer value(s)", UserWarning, stacklevel=2)
 
     chunks = tuple(int(c) for c in chunks)
     return chunks


### PR DESCRIPTION
When shape or chunks contains float values, the digits after the decimal point are trimmed.
This pull request generates a UserWarning when one or multiple values in shape or chunks are non-integer.
The problem is described in more detail in #2530 and is already fixed in v3 by PR #2535.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
