### PR TITLE
docs: add new top level about page

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,0 +1,22 @@
+About
+=====
+
+Zarr is a format for the storage of chunked, compressed, N-dimensional arrays
+inspired by `HDF5 <https://www.hdfgroup.org/HDF5/>`_, `h5py
+<https://www.h5py.org/>`_ and `bcolz <https://bcolz.readthedocs.io/>`_.
+
+These documents describe the Zarr Python implementation. More information
+about the Zarr format can be found on the `main website <https://zarr.dev>`_.
+
+If you are using Zarr, we would `love to hear about it
+<https://github.com/zarr-developers/community/issues/19>`_.
+
+Funding
+-------
+The project is fiscally sponsored by `NumFOCUS <https://numfocus.org/>`_, a US
+501(c)(3) public charity, and development is supported by the
+`MRC Centre for Genomics and Global Health <https://www.cggh.org>`_
+and the `Chan Zuckerberg Initiative <https://chanzuckerberg.com/>`_.
+
+
+.. _NumCodecs: https://numcodecs.readthedocs.io/

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -5,7 +5,7 @@ Zarr is a format for the storage of chunked, compressed, N-dimensional arrays
 inspired by `HDF5 <https://www.hdfgroup.org/HDF5/>`_, `h5py
 <https://www.h5py.org/>`_ and `bcolz <https://bcolz.readthedocs.io/>`_.
 
-These documents describe the Zarr Python implementation. More information
+These documents describe the Zarr-Python implementation. More information
 about the Zarr format can be found on the `main website <https://zarr.dev>`_.
 
 Projects using Zarr

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -8,7 +8,10 @@ inspired by `HDF5 <https://www.hdfgroup.org/HDF5/>`_, `h5py
 These documents describe the Zarr Python implementation. More information
 about the Zarr format can be found on the `main website <https://zarr.dev>`_.
 
-If you are using Zarr, we would `love to hear about it
+Projects using Zarr
+-------------------
+
+If you are using Zarr-Python, we would `love to hear about it
 <https://github.com/zarr-developers/community/issues/19>`_.
 
 Funding
@@ -17,6 +20,5 @@ The project is fiscally sponsored by `NumFOCUS <https://numfocus.org/>`_, a US
 501(c)(3) public charity, and development is supported by the
 `MRC Centre for Genomics and Global Health <https://www.cggh.org>`_
 and the `Chan Zuckerberg Initiative <https://chanzuckerberg.com/>`_.
-
 
 .. _NumCodecs: https://numcodecs.readthedocs.io/

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,12 +19,6 @@ Feedback and bug reports are very welcome, please get in touch via
 the `GitHub issue tracker <https://github.com/zarr-developers/zarr-python/issues>`_. See
 :doc:`contributing` for further information about contributing to Zarr.
 
-Projects using Zarr
--------------------
-
-If you are using Zarr, we would `love to hear about it
-<https://github.com/zarr-developers/community/issues/19>`_.
-
 .. toctree::
     :caption: Getting Started
     :hidden:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,18 +1,6 @@
 Getting Started
 ===============
 
-Zarr is a format for the storage of chunked, compressed, N-dimensional arrays
-inspired by `HDF5 <https://www.hdfgroup.org/HDF5/>`_, `h5py
-<https://www.h5py.org/>`_ and `bcolz <https://bcolz.readthedocs.io/>`_.
-
-The project is fiscally sponsored by `NumFOCUS <https://numfocus.org/>`_, a US
-501(c)(3) public charity, and development is supported by the
-`MRC Centre for Genomics and Global Health <https://www.cggh.org>`_
-and the `Chan Zuckerberg Initiative <https://chanzuckerberg.com/>`_.
-
-These documents describe the Zarr Python implementation. More information
-about the Zarr format can be found on the `main website <https://zarr.dev>`_.
-
 Highlights
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Zarr-Python
     :hidden:
 
     getting_started
+    about
     user-guide/index
     api/index
     release


### PR DESCRIPTION
This PR adds a new `about` page to Zarr's documentation. 

Notes for reviewers:

- This was split out from https://github.com/zarr-developers/zarr-python/pull/2568 and builds on https://github.com/zarr-developers/zarr-python/pull/2589.
- This content was previously part of the `getting-started` page which is turning into the `quickstart` page in #2590. 