### PR TITLE
docs: update doc homepage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,25 +9,23 @@ Zarr-Python
     :hidden:
 
     quickstart
+    about
     user-guide/index
     api/index
-    release
-    contributing
-    roadmap
-    installation
+    developers/index
+    developers/release
 
 **Version**: |version|
 
-**Download documentation**: `PDF/Zipped HTML <https://readthedocs.org/projects/zarr/downloads/>`_
+Zarr is a storage format for chunked, compressed, N-dimensional arrays based on an open-source specification. Highlights include:
 
-**Useful links**:
-`Installation <installation.html>`_ |
-`Source Repository <https://github.com/zarr-developers/zarr-python>`_ |
-`Issue Tracker <https://github.com/zarr-developers/zarr-python/issues>`_ |
-`Zulip Chat <https://ossci.zulipchat.com/>`_ |
-`Zarr specifications <https://zarr-specs.readthedocs.io>`_
-
-Zarr is a file storage format for chunked, compressed, N-dimensional arrays based on an open-source specification.
+* Create N-dimensional arrays with any NumPy dtype.
+* Chunk arrays along any dimension.
+* Compress and/or filter chunks using any NumCodecs_ codec.
+* Store arrays in memory, on disk, inside a Zip file, on S3, ...
+* Read an array concurrently from multiple threads or processes.
+* Write to an array concurrently from multiple threads or processes.
+* Organize arrays into hierarchies via groups.
 
 .. grid:: 2
 
@@ -85,21 +83,33 @@ Zarr is a file storage format for chunked, compressed, N-dimensional arrays base
             :color: dark
             :click-parent:
 
-            To the api reference guide
+            To the API reference guide
 
     .. grid-item-card::
         :img-top: _static/index_contribute.svg
 
-        Contributor's Guide
-        ^^^^^^^^^^^^^^^^^^^
+        Developer's Guide
+        ^^^^^^^^^^^^^^^^^
 
-        Want to contribute to Zarr? We welcome contributions in the form of bug reports, bug fixes, documentation, enhancement proposals and more. The contributing guidelines will guide you through the process of improving Zarr.
+        Want to contribute to Zarr? We welcome contributions in the form of bug reports,
+        bug fixes, documentation, enhancement proposals and more. The contributing
+        guidelines will guide you through the process of improving Zarr.
 
         +++
 
-        .. button-ref:: contributing
+        .. button-ref:: developers/index
             :expand:
             :color: dark
             :click-parent:
 
-            To the contributor's guide
+            To the developers's guide
+
+**Useful links**:
+`Source Repository <https://github.com/zarr-developers/zarr-python>`_ |
+`Issue Tracker <https://github.com/zarr-developers/zarr-python/issues>`_ |
+`Zulip Chat <https://ossci.zulipchat.com/>`_ |
+`Zarr specifications <https://zarr-specs.readthedocs.io>`_
+
+**Download documentation**: `PDF/Zipped HTML <https://readthedocs.org/projects/zarr/downloads/>`_
+
+.. _NumCodecs: https://numcodecs.readthedocs.io


### PR DESCRIPTION
This PR updates Zarr's documentation homepage. 

Notes for reviewers:

- This was split off from https://github.com/zarr-developers/zarr-python/pull/2568
- The main motivation here was to provide the core of Zarr's value prop above the fold, as well as links to further reading/documentation.
- I didn't spend time on the styling but I'm open to someone coming along with an opinion on how to improve this.

Marked as a draft until #2590 and #2592 are merged.