### PR TITLE
Improve deprecation of zarr.creation and zarr.convenience

### DIFF
--- a/src/zarr/convenience.py
+++ b/src/zarr/convenience.py
@@ -1,3 +1,12 @@
+"""
+Convenience helpers.
+
+.. warning::
+
+    This sub-module is deprecated. All functions here are defined
+    in the top level zarr namespace instead.
+"""
+
 import warnings
 
 from zarr.api.synchronous import (
@@ -29,7 +38,8 @@ __all__ = [
 ]
 
 warnings.warn(
-    "zarr.convenience is deprecated, use zarr.api.synchronous",
+    "zarr.convenience is deprecated. "
+    "Import these functions from the top level zarr. namespace instead.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/src/zarr/creation.py
+++ b/src/zarr/creation.py
@@ -1,3 +1,12 @@
+"""
+Helpers for creating arrays.
+
+.. warning::
+
+    This sub-module is deprecated. All functions here are defined
+    in the top level zarr namespace instead.
+"""
+
 import warnings
 
 from zarr.api.synchronous import (

--- a/src/zarr/creation.py
+++ b/src/zarr/creation.py
@@ -31,7 +31,8 @@ __all__ = [
 ]
 
 warnings.warn(
-    "zarr.creation is deprecated, use zarr.api.synchronous",
+    "zarr.creation is deprecated. "
+    "Import these functions from the top level zarr. namespace instead.",
     DeprecationWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
- Add a better deprecation warning (I think these are intended to be used from `zarr.`?)
- Add a warning to the API docs page