### PR TITLE
Enable doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ numpy = ["1.25", "2.1"]
 features = ["gpu"]
 
 [tool.hatch.envs.test.scripts]
-run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=src"
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=src --doctest-glob='*.rst'"
 run-coverage-gpu = "pip install cupy-cuda12x && pytest -m gpu --cov-config=pyproject.toml --cov=pkg --cov=src"
 run = "run-coverage --no-cov"
 run-verbose = "run-coverage --verbose"
@@ -349,7 +349,7 @@ ignore_errors = true
 
 [tool.pytest.ini_options]
 minversion = "7"
-testpaths = ["tests"]
+testpaths = ["tests", "docs"]
 log_cli_level = "INFO"
 xfail_strict = true
 asyncio_mode = "auto"


### PR DESCRIPTION
This should enable doctests to be run as part of the normal test suite. They will almost certainly fail until https://github.com/zarr-developers/zarr-python/pull/2623 is merged, but I'm opening a new PR targeted to `main` to make sure it works without having to alter the GH actions config.

If this works, I'll add it to https://github.com/zarr-developers/zarr-python/pull/2623, so opening as draft because this shouldn't be merged.