### PR TITLE
Move 'about' to end of table of contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,12 +9,12 @@ Zarr-Python
     :hidden:
 
     getting_started
-    about
     user-guide/index
     api/index
     release
     contributing
     roadmap
+    about
 
 **Version**: |version|
 


### PR DESCRIPTION
I think it makes more sense to go

- Getting started
- User guide
- API ref
...

Instead of having the "About" page breaking this order up.