### PR TITLE
Zarr v2 + Zstd: Don't persist the checksum param if false

### DIFF
--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -116,7 +116,13 @@ class ArrayV2Metadata(Metadata):
                 else:
                     return o.descr
             if isinstance(o, numcodecs.abc.Codec):
-                return o.get_config()
+                codec_config = o.get_config()
+
+                # Hotfix for https://github.com/zarr-developers/zarr-python/issues/2647
+                if codec_config["id"] == "zstd" and not codec_config.get("checksum", False):
+                    codec_config.pop("checksum", None)
+
+                return codec_config
             if np.isscalar(o):
                 out: Any
                 if hasattr(o, "dtype") and o.dtype.kind == "M" and hasattr(o, "view"):

--- a/tests/test_metadata/test_v2.py
+++ b/tests/test_metadata/test_v2.py
@@ -9,6 +9,7 @@ import pytest
 import zarr.api.asynchronous
 import zarr.storage
 from zarr.core.buffer import cpu
+from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.group import ConsolidatedMetadata, GroupMetadata
 from zarr.core.metadata import ArrayV2Metadata
 from zarr.core.metadata.v2 import parse_zarr_format
@@ -282,3 +283,18 @@ def test_from_dict_extra_fields() -> None:
         order="C",
     )
     assert result == expected
+
+
+def test_zstd_checksum() -> None:
+    arr = zarr.create_array(
+        {},
+        shape=(10,),
+        chunks=(10,),
+        dtype="int32",
+        compressors={"id": "zstd", "level": 5, "checksum": False},
+        zarr_format=2,
+    )
+    metadata = json.loads(
+        arr.metadata.to_buffer_dict(default_buffer_prototype())[".zarray"].to_bytes()
+    )
+    assert "checksum" not in metadata["compressor"]


### PR DESCRIPTION
Changes the zstd codec to not persist the checksum param, if it is set to False (the default). This is aimed at improving backwards compatibility.

See https://github.com/zarr-developers/zarr-python/issues/2647#issuecomment-2571758778
Fixes #2647