### PR TITLE
Add moto[server] to test deps for FsspecStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ test = [
     "s3fs",
     "pytest-asyncio",
     "pytest-accept",
-    "moto[s3]",
+    "moto[s3,server]",
     "requests",
     "rich",
     "mypy",


### PR DESCRIPTION
The moto server used in [the fsspec tests](https://github.com/zarr-developers/zarr-python/blob/22634ea2dabc0ad9ecfa932e21079fabe94c1f50/tests/test_store/test_fsspec.py#L25) requires Flask, which is not installed by default with moto. This PR adds the necessary optional dependencies to the test environment using the method recommended in https://github.com/getmoto/moto/issues/5468#issuecomment-1260152788. 