### PR TITLE
Fix `Group.array()` with `data` argument

### DIFF
--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -2758,6 +2758,8 @@ class Group(SyncMixin):
             Whether to overwrite an array with the same name in the store, if one exists.
         config : ArrayConfig or ArrayConfigLike, optional
             Runtime configuration for the array.
+        data : array_like
+            The data to fill the array with.
 
         Returns
         -------
@@ -2766,7 +2768,7 @@ class Group(SyncMixin):
         compressors = _parse_deprecated_compressor(compressor, compressors)
         return Array(
             self._sync(
-                self._async_group.create_array(
+                self._async_group.create_dataset(
                     name=name,
                     shape=shape,
                     dtype=dtype,
@@ -2783,6 +2785,7 @@ class Group(SyncMixin):
                     overwrite=overwrite,
                     storage_options=storage_options,
                     config=config,
+                    data=data,
                 )
             )
         )

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -617,8 +617,7 @@ def test_group_create_array(
         array[:] = data
     elif method == "array":
         with pytest.warns(DeprecationWarning):
-            array = group.array(name="array", shape=shape, dtype=dtype)
-            array[:] = data
+            array = group.array(name="array", data=data, shape=shape, dtype=dtype)
     else:
         raise AssertionError
 


### PR DESCRIPTION
Fixes #2667

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
