### PR TITLE
doc: add release announcement banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ main_doc = "index"
 
 # General information about the project.
 project = "zarr"
-copyright = "2024, Zarr Developers"
+copyright = "2025, Zarr Developers"
 author = "Zarr Developers"
 
 version = get_version("zarr")
@@ -181,6 +181,7 @@ html_theme_options = {
     ],
     "collapse_navigation": True,
     "navigation_with_keys": False,
+    "announcement": "Zarr-Python 3 is here! Check out the release announcement <a href='https://zarr.dev/blog/zarr-python-3-release/'>here.</a>",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
Adds a banner to the top of the documentation pointing readers to the 3.0 release announcement. 

Merge after https://github.com/zarr-developers/blog/pull/64