### PR TITLE
Don't put usernames in changelog

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,8 +9,7 @@ New features
 
 Bug fixes
 ~~~~~~~~~
-* Fixes ``order`` argument for Zarr format 2 arrays.
-  By :user:`Norman Rzepka <normanrz>` (:issue:`2679`).
+* Fixes ``order`` argument for Zarr format 2 arrays (:issue:`2679`).
 
 Behaviour changes
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I propose that we don't add usernames to changelog entries, because it's one extra bit of work to do, and as long as we have a link to the issue it's easy from that to see who contributed to the PR.