### PR TITLE
Update set_partial_values to accept Buffer rather than BytesLike

### DIFF
--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from typing import Any, Self, TypeAlias
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 __all__ = ["ByteGetter", "ByteSetter", "Store", "set_or_delete"]
 
@@ -285,9 +284,7 @@ class Store(ABC):
         ...
 
     @abstractmethod
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         """Store values at a given key, starting at byte range_start.
 
         Parameters

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from fsspec.asyn import AsyncFileSystem
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 
 ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
@@ -316,9 +315,7 @@ class FsspecStore(Store):
 
         return [None if isinstance(r, Exception) else prototype.buffer.from_bytes(r) for r in res]
 
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         # docstring inherited
         raise NotImplementedError
 

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -174,7 +174,8 @@ class LocalStore(Store):
         await asyncio.to_thread(_put, path, value, start=None, exclusive=exclusive)
 
     async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, bytes | bytearray | memoryview]]
+        self,
+        key_start_values: Iterable[tuple[str, int, Buffer]],
     ) -> None:
         # docstring inherited
         self._check_writable()

--- a/src/zarr/storage/_logging.py
+++ b/src/zarr/storage/_logging.py
@@ -197,9 +197,7 @@ class LoggingStore(WrapperStore[Store]):
         with self.log(key):
             return await self._store.delete(key=key)
 
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, bytes | bytearray | memoryview]]
-    ) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         # docstring inherited
         keys = ",".join([k[0] for k in key_start_values])
         with self.log(keys):

--- a/src/zarr/storage/_memory.py
+++ b/src/zarr/storage/_memory.py
@@ -38,7 +38,7 @@ class MemoryStore(Store):
 
     supports_writes: bool = True
     supports_deletes: bool = True
-    supports_partial_writes: bool = True
+    supports_partial_writes: bool = False
     supports_listing: bool = True
 
     _store_dict: MutableMapping[str, Buffer]
@@ -134,7 +134,7 @@ class MemoryStore(Store):
         except KeyError:
             logger.debug("Key %s does not exist.", key)
 
-    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, bytes]]) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         # docstring inherited
         raise NotImplementedError
 

--- a/src/zarr/storage/_wrapper.py
+++ b/src/zarr/storage/_wrapper.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
     from zarr.abc.store import ByteRequest
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 from zarr.abc.store import Store
 
@@ -108,9 +107,7 @@ class WrapperStore(Store, Generic[T_Store]):
     def supports_partial_writes(self) -> bool:
         return self._store.supports_partial_writes
 
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         return await self._store.set_partial_values(key_start_values)
 
     @property

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -209,7 +209,7 @@ class ZipStore(Store):
         with self._lock:
             self._set(key, value)
 
-    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, bytes]]) -> None:
+    async def set_partial_values(self, key_start_values: Iterable[tuple[str, int, Buffer]]) -> None:
         raise NotImplementedError
 
     async def set_if_not_exists(self, key: str, value: Buffer) -> None:

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -181,6 +181,23 @@ class StoreTests(Generic[S, B]):
         for k, v in store_dict.items():
             assert (await self.get(store, k)).to_bytes() == v.to_bytes()
 
+    @pytest.mark.parametrize("key", ["zarr.json", "c/0", "foo/c/0.0", "foo/0/0"])
+    async def test_set_partial_values(self, store: S, key: str) -> None:
+        """
+        Ensure that data can be written to the store using the store.set method.
+        """
+        assert not store.read_only
+        # Create empty key
+        await store.set(key, self.buffer_cls.from_bytes(b""))
+        data_buf = self.buffer_cls.from_bytes(b"\x01\x02\x03\x04")
+        if store.supports_partial_writes:
+            await store.set_partial_values([(key, 0, data_buf[:2]), (key, 2, data_buf[2:])])
+            observed = await self.get(store, key)
+            assert_bytes_equal(observed.to_bytes(), data_buf)
+        else:
+            with pytest.raises(NotImplementedError):
+                await store.set_partial_values([(key, 0, data_buf[:2]), (key, 2, data_buf[2:])])
+
     @pytest.mark.parametrize(
         "key_ranges",
         [

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -41,7 +41,7 @@ class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
         assert store.supports_listing
 
     def test_store_supports_partial_writes(self, store: MemoryStore) -> None:
-        assert store.supports_partial_writes
+        assert not store.supports_partial_writes
 
     def test_list_prefix(self, store: MemoryStore) -> None:
         assert True


### PR DESCRIPTION
When working on https://github.com/zarr-developers/zarr-python/issues/2614 in https://github.com/maxrjones/zarr-python/tree/testing-storage, I found that the current implementation of `set_partial_values` for local store cannot work as written because it passes `BytesLike` to `_put` which expects a buffer. None of the other stores implement `set_partial_values`, so it's not possible to look to them for the correct way of implementing this method.

I believe that one of the following needs to happen in order for stores to correctly implement `set_partial_values`:
- Add a `prototype` argument to `set_partial_values` that can be used to go from BytesLike -> Buffer
- Update `set_partial_values` to accept `Buffer` types rather than `BytesLike` types

I chose the second option for this PR because all the other `set` methods seem to accept `Buffer` types. Of course, I welcome corrections if I am not understanding something here and the function signature should work as-is.
