### PR TITLE
Ensure backwards compatibility

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,7 +11,7 @@ Bug fixes
 ~~~~~~~~~
 * Fixes ``order`` argument for Zarr format 2 arrays (:issue:`2679`).
 
-* Fixes consolidated metadata backwards compatibility Zarr format 2 (:issue:`2694`).
+* Fixes a bug that prevented reading Zarr format 2 data with consolidated metadata written using ``zarr-python`` version 2 (:issue:`2694`).
 
 Behaviour changes
 ~~~~~~~~~~~~~~~~~

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,6 +11,8 @@ Bug fixes
 ~~~~~~~~~
 * Fixes ``order`` argument for Zarr format 2 arrays (:issue:`2679`).
 
+* Fixes consolidated metadata backwards compatibility Zarr format 2 (:issue:`2694`).
+
 Behaviour changes
 ~~~~~~~~~~~~~~~~~
 

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -573,8 +573,8 @@ class AsyncGroup:
             v2_consolidated_metadata = json.loads(consolidated_metadata_bytes.to_bytes())
             v2_consolidated_metadata = v2_consolidated_metadata["metadata"]
             # We already read zattrs and zgroup. Should we ignore these?
-            v2_consolidated_metadata.pop(".zattrs")
-            v2_consolidated_metadata.pop(".zgroup")
+            v2_consolidated_metadata.pop(".zattrs", None)
+            v2_consolidated_metadata.pop(".zgroup", None)
 
             consolidated_metadata: defaultdict[str, dict[str, Any]] = defaultdict(dict)
 

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -491,6 +491,9 @@ class TestConsolidated:
     async def test_consolidated_metadata_backwards_compatibility(
         self, v2_consolidated_metadata_empty_dataset
     ):
+        """
+        Test that consolidated metadata handles a missing .zattrs key. This is necessary for backwards compatibility  with zarr-python 2.x. See https://github.com/zarr-developers/zarr-python/issues/2694
+        """
         store = zarr.storage.MemoryStore()
         await zarr.api.asynchronous.open(store=store, zarr_format=2)
         await zarr.api.asynchronous.consolidate_metadata(store)


### PR DESCRIPTION
This is a quick fix for the problem reported in https://github.com/zarr-developers/zarr-python/issues/2694 where an empty consolidated dataset created with `zarr-python 2.x` fails to being read by `zarr-python 3.x` because of the absence of `.zattrs` from the store.

* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] ~New/modified features documented in docs/tutorial.rst~
* [x] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
