### PR TITLE
Fix release notes labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
 needs release notes:
-- all: ['!docs/release.rst']
+- all: ['!docs/release-notes.rst']

--- a/.github/workflows/needs_release_notes.yml
+++ b/.github/workflows/needs_release_notes.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }} && ${{ github.event.pull_request.user.login != 'pre-commit-ci[bot]' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: true


### PR DESCRIPTION
The filename changed (my bad for not updating this when I changed the filename). I also pinned the action to a specific version to avoid it changing under our feet without us checking, dependabot should automatically update this for us.