### PR TITLE
Clean up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,7 @@
 ---
 version: 2
 updates:
-  # Updates for v3 branch (the default branch)
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    groups:
-      actions:
-        patterns:
-          - "*"
+  # Updates for main
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,19 +11,19 @@ updates:
         patterns:
           - "*"
 
-  # Same updates, but for main branch
+  # Updates for support/v2 branch
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "main"
+    target-branch: "support/v2"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       requirements:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "main"
+    target-branch: "support/v2"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
- There are no pip pins on `main` that need updating, so remove that section
- Fix the branch for v2
- Move pip checks for `support/v2` to weekly instead of daily