### PR TITLE
Upgrade ruff to 0.9.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 default_stages: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.1
     hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,8 +326,6 @@ ignore = [
     "Q003",
     "COM812",
     "COM819",
-    "ISC001",
-    "ISC002",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -86,9 +86,9 @@ class _ShardingByteGetter(ByteGetter):
         self, prototype: BufferPrototype, byte_range: ByteRequest | None = None
     ) -> Buffer | None:
         assert byte_range is None, "byte_range is not supported within shards"
-        assert (
-            prototype == default_buffer_prototype()
-        ), f"prototype is not supported within shards currently. diff: {prototype} != {default_buffer_prototype()}"
+        assert prototype == default_buffer_prototype(), (
+            f"prototype is not supported within shards currently. diff: {prototype} != {default_buffer_prototype()}"
+        )
         return self.shard_dict.get(self.chunk_coords)
 
 

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -289,9 +289,9 @@ def is_pure_orthogonal_indexing(selection: Selection, ndim: int) -> TypeGuard[Or
 def get_chunk_shape(chunk_grid: ChunkGrid) -> ChunkCoords:
     from zarr.core.chunk_grids import RegularChunkGrid
 
-    assert isinstance(
-        chunk_grid, RegularChunkGrid
-    ), "Only regular chunk grid is supported, currently."
+    assert isinstance(chunk_grid, RegularChunkGrid), (
+        "Only regular chunk grid is supported, currently."
+    )
     return chunk_grid.chunk_shape
 
 

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -373,9 +373,9 @@ class ArrayV3Metadata(Metadata):
     def get_chunk_spec(
         self, _chunk_coords: ChunkCoords, array_config: ArrayConfig, prototype: BufferPrototype
     ) -> ArraySpec:
-        assert isinstance(
-            self.chunk_grid, RegularChunkGrid
-        ), "Currently, only regular chunk grid is supported"
+        assert isinstance(self.chunk_grid, RegularChunkGrid), (
+            "Currently, only regular chunk grid is supported"
+        )
         return ArraySpec(
             shape=self.chunk_grid.chunk_shape,
             dtype=self.dtype,

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -4,11 +4,11 @@ from numpy.testing import assert_array_equal
 
 pytest.importorskip("hypothesis")
 
-import hypothesis.extra.numpy as npst  # noqa: E402
-import hypothesis.strategies as st  # noqa: E402
-from hypothesis import given  # noqa: E402
+import hypothesis.extra.numpy as npst
+import hypothesis.strategies as st
+from hypothesis import given
 
-from zarr.testing.strategies import arrays, basic_indices, numpy_arrays, zarr_formats  # noqa: E402
+from zarr.testing.strategies import arrays, basic_indices, numpy_arrays, zarr_formats
 
 
 @given(data=st.data(), zarr_format=zarr_formats)


### PR DESCRIPTION
* Fix `RUF100` new warnings (`E402` unused).
* Enable `ISC001`/`ISC002` since the [documentation](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) now states that they are compatible with the ruff formatter if used together:
  > When using Ruff as a formatter, we recommend avoiding the following lint rules:
  > [...]
  > [`multi-line-implicit-string-concatenation`](https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/) (`ISC002`) if used without `ISC001` and `flake8-implicit-str-concat.allow-multiline = false`

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
