### PR TITLE
Clean up warning filters in tests

### DIFF
--- a/changes/2714.misc.rst
+++ b/changes/2714.misc.rst
@@ -1,0 +1,1 @@
+Make warning filters in the tests more specific, so warnings emitted by tests added in the future are more likely to be caught instead of ignored.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,12 +403,11 @@ filterwarnings = [
     "ignore:Creating a zarr.buffer.gpu.Buffer with an array that does not support the __cuda_array_interface__.*:UserWarning",
     "ignore:Automatic shard shape inference is experimental and may change without notice.*:UserWarning",
     "ignore:The codec .* is currently not part in the Zarr format 3 specification.*:UserWarning",
-    "ignore:The dtype .* is currently not part in the Zarr format 3 specification.*:UserWarning",
     "ignore:Use zarr.create_array instead.:DeprecationWarning",
     "ignore:Duplicate name.*:UserWarning",
     "ignore:The `compressor` argument is deprecated. Use `compressors` instead.:UserWarning",
     "ignore:Numcodecs codecs are not in the Zarr version 3 specification and may not be supported by other zarr implementations.:UserWarning",
-
+    "ignore:Unclosed client session <aiohttp.client.ClientSessionResourceWarning.*:ResourceWarning"
 ]
 markers = [
     "gpu: mark a test as requiring CuPy and GPU",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,7 @@ filterwarnings = [
     "ignore:Creating a zarr.buffer.gpu.Buffer with an array that does not support the __cuda_array_interface__.*:UserWarning",
     "ignore:Automatic shard shape inference is experimental and may change without notice.*:UserWarning",
     "ignore:The codec .* is currently not part in the Zarr format 3 specification.*:UserWarning",
+    "ignore:The dtype .* is currently not part in the Zarr format 3 specification.*:UserWarning",
     "ignore:Use zarr.create_array instead.:DeprecationWarning",
     "ignore:Duplicate name.*:UserWarning",
     "ignore:The `compressor` argument is deprecated. Use `compressors` instead.:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,7 +408,7 @@ filterwarnings = [
     "ignore:Duplicate name.*:UserWarning",
     "ignore:The `compressor` argument is deprecated. Use `compressors` instead.:UserWarning",
     "ignore:Numcodecs codecs are not in the Zarr version 3 specification and may not be supported by other zarr implementations.:UserWarning",
-    "ignore:Unclosed client session <aiohttp.client.ClientSessionResourceWarning.*:ResourceWarning"
+    "ignore:Unclosed client session <aiohttp.client.ClientSession.*:ResourceWarning"
 ]
 markers = [
     "gpu: mark a test as requiring CuPy and GPU",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,12 +397,9 @@ addopts = [
     "--durations=10", "-ra", "--strict-config", "--strict-markers",
 ]
 filterwarnings = [
-    "error:::zarr.*",
-    "ignore:PY_SSIZE_T_CLEAN will be required.*:DeprecationWarning",
-    "ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning",
-    "ignore:Creating a zarr.buffer.gpu.*:UserWarning",
-    "ignore:Duplicate name:UserWarning",  # from ZipFile
-    "ignore:.*is currently not part in the Zarr format 3 specification.*:UserWarning",
+    "error",
+    # TODO: explicitly filter or catch the warnings below where we expect them to be emitted in the tests
+    "ignore:Consolidated metadata is currently not part in the Zarr format 3 specification.*:UserWarning",
 ]
 markers = [
     "gpu: mark a test as requiring CuPy and GPU",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -402,7 +402,13 @@ filterwarnings = [
     "ignore:Consolidated metadata is currently not part in the Zarr format 3 specification.*:UserWarning",
     "ignore:Creating a zarr.buffer.gpu.Buffer with an array that does not support the __cuda_array_interface__.*:UserWarning",
     "ignore:Automatic shard shape inference is experimental and may change without notice.*:UserWarning",
-    "ignore:The codec .* is currently not part in the Zarr format 3 specification.*:UserWarning"
+    "ignore:The codec .* is currently not part in the Zarr format 3 specification.*:UserWarning",
+    "ignore:The dtype .* is currently not part in the Zarr format 3 specification.*:UserWarning",
+    "ignore:Use zarr.create_array instead.:DeprecationWarning",
+    "ignore:Duplicate name.*:UserWarning",
+    "ignore:The `compressor` argument is deprecated. Use `compressors` instead.:UserWarning",
+    "ignore:Numcodecs codecs are not in the Zarr version 3 specification and may not be supported by other zarr implementations.:UserWarning",
+
 ]
 markers = [
     "gpu: mark a test as requiring CuPy and GPU",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,6 +400,9 @@ filterwarnings = [
     "error",
     # TODO: explicitly filter or catch the warnings below where we expect them to be emitted in the tests
     "ignore:Consolidated metadata is currently not part in the Zarr format 3 specification.*:UserWarning",
+    "ignore:Creating a zarr.buffer.gpu.Buffer with an array that does not support the __cuda_array_interface__.*:UserWarning",
+    "ignore:Automatic shard shape inference is experimental and may change without notice.*:UserWarning",
+    "ignore:The codec .* is currently not part in the Zarr format 3 specification.*:UserWarning"
 ]
 markers = [
     "gpu: mark a test as requiring CuPy and GPU",

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1417,9 +1417,8 @@ def test_multiprocessing(store: Store, method: Literal["fork", "spawn", "forkser
     data = np.arange(100)
     arr = zarr.create_array(store=store, data=data)
     ctx = mp.get_context(method)
-    pool = ctx.Pool()
-
-    results = pool.starmap(_index_array, [(arr, slice(len(data)))])
+    with ctx.Pool() as pool:
+        results = pool.starmap(_index_array, [(arr, slice(len(data)))])
     assert all(np.array_equal(r, data) for r in results)
 
 

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -25,8 +25,9 @@ pytestmark = [
     pytest.mark.filterwarnings(
         re.escape("ignore:datetime.datetime.utcnow() is deprecated:DeprecationWarning")
     ),
-    # TODO: fix these resource warnings
-    pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
+    # TODO: fix these warnings
+    pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning"),
+    pytest.mark.filterwarnings("ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited:RuntimeWarning")
 ]
 
 fsspec = pytest.importorskip("fsspec")

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -27,7 +27,9 @@ pytestmark = [
     ),
     # TODO: fix these warnings
     pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning"),
-    pytest.mark.filterwarnings("ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited:RuntimeWarning")
+    pytest.mark.filterwarnings(
+        "ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited:RuntimeWarning"
+    ),
 ]
 
 fsspec = pytest.importorskip("fsspec")

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
 pytestmark = [
     pytest.mark.filterwarnings(
         re.escape("ignore:datetime.datetime.utcnow() is deprecated:DeprecationWarning")
-    )
+    ),
+    # TODO: fix these resource warnings
+    pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
 ]
 
 fsspec = pytest.importorskip("fsspec")

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -19,6 +20,12 @@ if TYPE_CHECKING:
 
     import botocore.client
 
+# Warning filter due to https://github.com/boto/boto3/issues/3889
+pytestmark = [
+    pytest.mark.filterwarnings(
+        re.escape("ignore:datetime.datetime.utcnow() is deprecated:DeprecationWarning")
+    )
+]
 
 fsspec = pytest.importorskip("fsspec")
 s3fs = pytest.importorskip("s3fs")

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -15,6 +16,10 @@ if TYPE_CHECKING:
     from zarr.core.common import ZarrFormat
 
 
+# TODO: work out where this warning is coming from and fix it
+@pytest.mark.filterwarnings(
+    re.escape("ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited")
+)
 class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
     store_cls = MemoryStore
     buffer_cls = cpu.Buffer

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -78,6 +78,8 @@ class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
         np.testing.assert_array_equal(a[3:], 0)
 
 
+# TODO: fix this warning
+@pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
 @gpu_test
 class TestGpuMemoryStore(StoreTests[GpuMemoryStore, gpu.Buffer]):
     store_cls = GpuMemoryStore

--- a/tests/test_store/test_stateful.py
+++ b/tests/test_store/test_stateful.py
@@ -16,6 +16,7 @@ pytestmark = [
 ]
 
 
+
 def test_zarr_hierarchy(sync_store: Store):
     def mk_test_instance_sync() -> ZarrHierarchyStateMachine:
         return ZarrHierarchyStateMachine(sync_store)

--- a/tests/test_store/test_stateful.py
+++ b/tests/test_store/test_stateful.py
@@ -8,13 +8,11 @@ from zarr.abc.store import Store
 from zarr.storage import LocalStore, ZipStore
 from zarr.testing.stateful import ZarrHierarchyStateMachine, ZarrStoreStateMachine
 
-
 pytestmark = [
     pytest.mark.slow_hypothesis,
     # TODO: work out where this warning is coming from and fix
     pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning"),
 ]
-
 
 
 def test_zarr_hierarchy(sync_store: Store):

--- a/tests/test_store/test_stateful.py
+++ b/tests/test_store/test_stateful.py
@@ -8,7 +8,12 @@ from zarr.abc.store import Store
 from zarr.storage import LocalStore, ZipStore
 from zarr.testing.stateful import ZarrHierarchyStateMachine, ZarrStoreStateMachine
 
-pytestmark = pytest.mark.slow_hypothesis
+
+pytestmark = [
+    pytest.mark.slow_hypothesis,
+    # TODO: work out where this warning is coming from and fix
+    pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning"),
+]
 
 
 def test_zarr_hierarchy(sync_store: Store):

--- a/tests/test_store/test_wrapper.py
+++ b/tests/test_store/test_wrapper.py
@@ -97,6 +97,7 @@ async def test_wrapped_set(store: Store, capsys: pytest.CaptureFixture[str]) -> 
     assert await store_wrapped.get(key, buffer_prototype) == value
 
 
+@pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
 @pytest.mark.parametrize("store", ["local", "memory", "zip"], indirect=True)
 async def test_wrapped_get(store: Store, capsys: pytest.CaptureFixture[str]) -> None:
     # define a class that prints when it sets

--- a/tests/test_store/test_wrapper.py
+++ b/tests/test_store/test_wrapper.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from zarr.core.buffer.core import BufferPrototype
 
 
+# TODO: fix this warning
+@pytest.mark.filterwarnings(
+    "ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited:RuntimeWarning"
+)
 class TestWrapperStore(StoreTests[WrapperStore, Buffer]):
     store_cls = WrapperStore
     buffer_cls = Buffer

--- a/tests/test_store/test_wrapper.py
+++ b/tests/test_store/test_wrapper.py
@@ -72,6 +72,10 @@ class TestWrapperStore(StoreTests[WrapperStore, Buffer]):
             store._is_open = True
 
 
+# TODO: work out where warning is coming from and fix
+@pytest.mark.filterwarnings(
+    "ignore:coroutine 'ClientCreatorContext.__aexit__' was never awaited:RuntimeWarning"
+)
 @pytest.mark.parametrize("store", ["local", "memory", "zip"], indirect=True)
 async def test_wrapped_set(store: Store, capsys: pytest.CaptureFixture[str]) -> None:
     # define a class that prints when it sets

--- a/tests/test_store/test_zip.py
+++ b/tests/test_store/test_zip.py
@@ -74,6 +74,8 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
     def test_store_supports_listing(self, store: ZipStore) -> None:
         assert store.supports_listing
 
+    # TODO: fix this warning
+    @pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
     def test_api_integration(self, store: ZipStore) -> None:
         root = zarr.open_group(store=store, mode="a")
 

--- a/tests/test_store/test_zip.py
+++ b/tests/test_store/test_zip.py
@@ -19,6 +19,14 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+# TODO: work out where this is coming from and fix
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:coroutine method 'aclose' of 'ZipStore.list' was never awaited:RuntimeWarning"
+    )
+]
+
+
 class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
     store_cls = ZipStore
     buffer_cls = cpu.Buffer

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -90,6 +90,7 @@ def test_sync_raises_if_loop_is_closed() -> None:
     foo.assert_not_awaited()
 
 
+@pytest.mark.filterwarnings("ignore:Unclosed client session:ResourceWarning")
 @pytest.mark.filterwarnings("ignore:coroutine.*was never awaited")
 def test_sync_raises_if_calling_sync_from_within_a_running_loop(
     sync_loop: asyncio.AbstractEventLoop | None,


### PR DESCRIPTION
I'm hoping to clean up the warning filters in this PR, starting with making them all error, and then either fix the warnings that come up or add them back to the filters. Opening because I noticed some deprecation warnings in our tests that should probably either be explicitly caught or the code fixed.

Fixes https://github.com/zarr-developers/zarr-python/issues/2968