### PR TITLE
Fix minimum fsspec test verseion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,11 +228,12 @@ See Spec 0000 for details and drop schedule: https://scientific-python.org/specs
 """
 python = "3.11"
 dependencies = [
+    'zarr[remote]',
     'packaging==22.*',
     'numpy==1.25.*',
     'numcodecs==0.14.*',  # 0.14 needed for zarr3 codecs
-    'fsspec==2022.10.0',
-    's3fs==2022.10.0',
+    'fsspec==2023.10.0',
+    's3fs==2023.10.0',
     'universal_pathlib==0.0.22',
     'typing_extensions==4.9.*',
     'donfig==0.8.*',


### PR DESCRIPTION
This fixes the minimum fsspec version we test on to actually match the minimum fsspec version in the dependencies. I also put in `zarr[remote]` as a test dep, which should prevent this happening in the future.