### PR TITLE
Add hatch command for html coverage report

### DIFF
--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -193,7 +193,7 @@ Both unit tests and docstring doctests are included when computing coverage. Run
 will automatically run the test suite with coverage and produce a XML coverage report.
 This should be 100% before code can be accepted into the main code base.
 
-You can also generate a HTML rendered of the coverage report by running::
+You can also generate an HTML coverage report by running::
 
      $ hatch env run --env test.py3.12-2.1-optional run-coverage-html
 

--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -98,7 +98,7 @@ you can do something like the following::
 To verify that your development environment is working, you can run the unit tests
 for one of the test environments, e.g.::
 
-    $ hatch env run --env test.py3.12-2.1-optional run
+    $ hatch env run --env test.py3.12-2.1-optional run-pytest
 
 Creating a branch
 ~~~~~~~~~~~~~~~~~
@@ -140,7 +140,7 @@ Zarr includes a suite of unit tests. The simplest way to run the unit tests
 is to activate your development environment
 (see `creating a development environment`_ above) and invoke::
 
-    $ hatch env run --env test.py3.12-2.1-optional run
+    $ hatch env run --env test.py3.12-2.1-optional run-pytest
 
 All tests are automatically run via GitHub Actions for every pull
 request and must pass before code can be accepted. Test coverage is

--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -190,8 +190,12 @@ Both unit tests and docstring doctests are included when computing coverage. Run
 
     $ hatch env run --env test.py3.12-2.1-optional run-coverage
 
-will automatically run the test suite with coverage and produce a coverage report.
+will automatically run the test suite with coverage and produce a XML coverage report.
 This should be 100% before code can be accepted into the main code base.
+
+You can also generate a HTML rendered of the coverage report by running::
+
+     $ hatch env run --env test.py3.12-2.1-optional run-coverage-html
 
 When submitting a pull request, coverage will also be collected across all supported
 Python versions via the Codecov service, and will be reported back within the pull

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,9 @@ features = ["gpu"]
 [tool.hatch.envs.test.scripts]
 run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
 run-coverage-gpu = "pip install cupy-cuda12x && pytest -m gpu --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
+run-coverage-html = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report html --cov=src"
 run = "run-coverage --no-cov"
+run-pytest = "run"
 run-verbose = "run-coverage --verbose"
 run-mypy = "mypy src"
 run-hypothesis = "pytest --hypothesis-profile ci tests/test_properties.py tests/test_store/test_stateful*"


### PR DESCRIPTION
I found the html coverage report simpler to use for monitoring progress in https://github.com/zarr-developers/zarr-python/pull/2693 and am wondering if you would consider a hatch command for this, such as the one suggested in the PR.

I also propose adding a `run-pytest` alias for `run` because I heard that using `hatch run --env <env> run` to run the tests was a bit confusing to new contributors at the Pangeo hackday.