### PR TITLE
Fix label action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-- needs release notes:
+needs release notes:
   - all:
     - changed-files:
       - any-glob-to-any-file: 'changes/*.rst'


### PR DESCRIPTION
This seems to have gone wrong in https://github.com/zarr-developers/zarr-python/pull/2736, so trying to fix here.

Because the job is defined using `pull_request_target`, it's run from the GH actions config on the `main` branch, so this will need merging to fix the job.