### PR TITLE
Update labeler config for major version increment

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,3 @@
-- needs release notes:
-  - all:
-    - changed-files:
-      - any-glob-to-any-file: 'changes/*.rst'
+needs release notes:
+- changed-files:
+  - any-glob-to-any-file: 'changes/*.rst'

--- a/.github/workflows/needs_release_notes.yml
+++ b/.github/workflows/needs_release_notes.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on:
-  - pull_request_target
+  pull_request
 
 jobs:
   labeler:
@@ -11,7 +11,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Run Pull Request Labeler
+      uses: actions/labeler@v5.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: true

--- a/.github/workflows/needs_release_notes.yml
+++ b/.github/workflows/needs_release_notes.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   labeler:


### PR DESCRIPTION
This PR simply prepares the repo to upgrade the major version of the labeler workflow (and fix all the workflow errors people are encountering). See docs here: https://github.com/actions/labeler?tab=readme-ov-file#updating-major-version-of-the-labeler

1. Once verified (PRIOR TO MERGING) `pull_request` on line 4 of `needs_release_notes.yml` will need to be reverted to `pull_request_target`. This *must* happen to avoid permissions issues! Cf. https://github.com/actions/labeler?tab=readme-ov-file#recommended-permissions
2. At this point things will fail again (the changes below won't exist so far as the github action is concerned). Ignore the failure. Merge.

This addresses the issue mentioned in #2744 and the unfortunate bug hanging up #2533 (among others)