### PR TITLE
Fix "needs release notes" labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
 needs release notes:
   - all:
     - changed-files:
-      - any-glob-to-any-file: 'changes/*.rst'
+      - any-glob-to-any-file: '!changes/*.rst'


### PR DESCRIPTION
This fixes the labeler to work correctly - it currently is the wrong way round:

- https://github.com/zarr-developers/zarr-python/pull/2693, which shouldn't have the label (but does)
- https://github.com/zarr-developers/zarr-python/pull/2758, which should have the label (but doesn't)