### PR TITLE
Fix pickling of ZipStore

### DIFF
--- a/changes/2762.bugfix.rst
+++ b/changes/2762.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ZipStore to make sure the correct attributes are saved when instances are pickled.
+This fixes a previous bug that prevent using ZipStore with a ProcessPoolExecutor.

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -107,11 +107,14 @@ class ZipStore(Store):
     async def _open(self) -> None:
         self._sync_open()
 
-    def __getstate__(self) -> tuple[Path, ZipStoreAccessModeLiteral, int, bool]:
-        return self.path, self._zmode, self.compression, self.allowZip64
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__
+        for attr in ["_zf", "_lock"]:
+            state.pop(attr, None)
+        return state
 
-    def __setstate__(self, state: Any) -> None:
-        self.path, self._zmode, self.compression, self.allowZip64 = state
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__ = state
         self._is_open = False
         self._sync_open()
 

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -76,8 +76,9 @@ class StoreTests(Generic[S, B]):
         assert store == store2
 
     def test_serializable_store(self, store: S) -> None:
-        foo = pickle.dumps(store)
-        assert pickle.loads(foo) == store
+        new_store: S = pickle.loads(pickle.dumps(store))
+        assert new_store == store
+        assert new_store.read_only == store.read_only
 
     def test_store_read_only(self, store: S) -> None:
         assert not store.read_only


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/2752. The issue was not all attributes were being pickeld for `ZipStore`. This changes the pickling to pickle everything by default, but exclude certain attributes, which I think is a bit safer to guard against other attributes changing in the future?