### PR TITLE
Upload coverage after GPU tests

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -64,3 +64,9 @@ jobs:
     - name: Run Tests
       run: |
         hatch env run --env gputest.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} run-coverage
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true # optional (default = false)


### PR DESCRIPTION
I noticed that the GPU tests aren't uploading coverage to codecov - hopefully this should improve our test coverage a bit!