### PR TITLE
Use removeprefix rather than replace to avoid separator deletion

### DIFF
--- a/changes/2778.bugfix.rst
+++ b/changes/2778.bugfix.rst
@@ -1,0 +1,1 @@
+Use removeprefix rather than replace when removing filename prefixes in `FsspecStore.list`

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -341,7 +341,7 @@ class FsspecStore(Store):
     async def list(self) -> AsyncIterator[str]:
         # docstring inherited
         allfiles = await self.fs._find(self.path, detail=False, withdirs=False)
-        for onefile in (a.replace(self.path + "/", "") for a in allfiles):
+        for onefile in (a.removeprefix(self.path + "/") for a in allfiles):
             yield onefile
 
     async def list_dir(self, prefix: str) -> AsyncIterator[str]:


### PR DESCRIPTION
The point of replace here is just to remove the prefix instance but it has the unintended consequence of deleting separators when path is the empty string. This uses `removeprefix` explicitly and avoids that potential pitfall

Fixes #2777 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
