### PR TITLE
Support automatic removal of `needs release notes`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
 needs release notes:
   - all:
     - changed-files:
-      - any-glob-to-any-file: '!changes/*.rst'
+      - all-glob-to-all-file: '!changes/*.rst'

--- a/changes/2781.bugfix.rst
+++ b/changes/2781.bugfix.rst
@@ -1,0 +1,1 @@
+Enable automatic removal of `needs release notes` with labeler action


### PR DESCRIPTION
This PR updates the Pull Request Labeler configuration to use all/all matching criteria instead of the previous any/any setup for the `needs release notes` label. This change makes it so that the label is automatically removed when a `changes/*.rst` file is added/modified in the PR.

Fixes: #2779 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
