### PR TITLE
Always skip reads when completely overwriting chunks

### DIFF
--- a/changes/2784.feature.rst
+++ b/changes/2784.feature.rst
@@ -1,0 +1,1 @@
+Avoid reading chunks during writes where possible. :issue:`757`

--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -357,7 +357,7 @@ class CodecPipeline:
     @abstractmethod
     async def read(
         self,
-        batch_info: Iterable[tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple]],
+        batch_info: Iterable[tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple, bool]],
         out: NDBuffer,
         drop_axes: tuple[int, ...] = (),
     ) -> None:
@@ -379,7 +379,7 @@ class CodecPipeline:
     @abstractmethod
     async def write(
         self,
-        batch_info: Iterable[tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]],
+        batch_info: Iterable[tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple, bool]],
         value: NDBuffer,
         drop_axes: tuple[int, ...] = (),
     ) -> None:

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -455,8 +455,9 @@ class ShardingCodec(
                     chunk_spec,
                     chunk_selection,
                     out_selection,
+                    is_complete_shard,
                 )
-                for chunk_coords, chunk_selection, out_selection in indexer
+                for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
             out,
         )
@@ -486,7 +487,7 @@ class ShardingCodec(
         )
 
         indexed_chunks = list(indexer)
-        all_chunk_coords = {chunk_coords for chunk_coords, _, _ in indexed_chunks}
+        all_chunk_coords = {chunk_coords for chunk_coords, *_ in indexed_chunks}
 
         # reading bytes of all requested chunks
         shard_dict: ShardMapping = {}
@@ -524,8 +525,9 @@ class ShardingCodec(
                     chunk_spec,
                     chunk_selection,
                     out_selection,
+                    is_complete_shard,
                 )
-                for chunk_coords, chunk_selection, out_selection in indexer
+                for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
             out,
         )
@@ -558,8 +560,9 @@ class ShardingCodec(
                     chunk_spec,
                     chunk_selection,
                     out_selection,
+                    is_complete_shard,
                 )
-                for chunk_coords, chunk_selection, out_selection in indexer
+                for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
             shard_array,
         )
@@ -601,8 +604,9 @@ class ShardingCodec(
                     chunk_spec,
                     chunk_selection,
                     out_selection,
+                    is_complete_shard,
                 )
-                for chunk_coords, chunk_selection, out_selection in indexer
+                for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
             shard_array,
         )

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1290,8 +1290,9 @@ class AsyncArray(Generic[T_ArrayMetadata]):
                         self.metadata.get_chunk_spec(chunk_coords, _config, prototype=prototype),
                         chunk_selection,
                         out_selection,
+                        is_complete_chunk,
                     )
-                    for chunk_coords, chunk_selection, out_selection in indexer
+                    for chunk_coords, chunk_selection, out_selection, is_complete_chunk in indexer
                 ],
                 out_buffer,
                 drop_axes=indexer.drop_axes,
@@ -1417,8 +1418,9 @@ class AsyncArray(Generic[T_ArrayMetadata]):
                     self.metadata.get_chunk_spec(chunk_coords, _config, prototype),
                     chunk_selection,
                     out_selection,
+                    is_complete_chunk,
                 )
-                for chunk_coords, chunk_selection, out_selection in indexer
+                for chunk_coords, chunk_selection, out_selection, is_complete_chunk in indexer
             ],
             value_buffer,
             drop_axes=indexer.drop_axes,

--- a/src/zarr/core/codec_pipeline.py
+++ b/src/zarr/core/codec_pipeline.py
@@ -35,22 +35,6 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-def normalize_slices(
-    idxr: tuple[int | slice, ...], shape: tuple[int, ...]
-) -> tuple[int | slice, ...]:
-    # replace slice objects with stop==None with size
-    out = []
-    for i, size in zip(idxr, shape, strict=False):
-        if not isinstance(i, slice):
-            out.append(i)
-            continue
-        if i.step not in [1, None] or i.start not in [0, None]:
-            out.append(i)
-            continue
-        out.append(slice(i.start, i.stop if i.stop is not None else size, i.step))
-    return tuple(out)
-
-
 def _unzip2(iterable: Iterable[tuple[T, U]]) -> tuple[list[T], list[U]]:
     out0: list[T] = []
     out1: list[U] = []
@@ -295,10 +279,7 @@ class BatchedCodecPipeline(CodecPipeline):
                 chunk_array_batch, batch_info, strict=False
             ):
                 if chunk_array is not None:
-                    normalized_selection = normalize_slices(
-                        chunk_selection, out[out_selection].shape
-                    )
-                    tmp = chunk_array[normalized_selection]
+                    tmp = chunk_array[chunk_selection]
                     if drop_axes != ():
                         tmp = tmp.squeeze(axis=drop_axes)
                     out[out_selection] = tmp
@@ -341,9 +322,7 @@ class BatchedCodecPipeline(CodecPipeline):
                     for idx in range(chunk_spec.ndim)
                 )
                 chunk_value = chunk_value[item]
-
-        normalized_selection = normalize_slices(chunk_selection, chunk_value.shape)
-        chunk_array[normalized_selection] = chunk_value
+        chunk_array[chunk_selection] = chunk_value
         return chunk_array
 
     async def write_batch(

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -403,24 +403,16 @@ class SliceDimIndexer:
                 dim_chunk_sel_start = self.start - dim_offset
                 dim_out_offset = 0
 
-            # Use None to indicate this selection ends at the chunk edge
-            # This is useful for is_total_slice at boundary chunks,
             if self.stop > dim_limit:
                 # selection ends after current chunk
-                dim_chunk_sel_stop = None  # dim_chunk_len
+                dim_chunk_sel_stop = dim_chunk_len
 
             else:
                 # selection ends within current chunk
-                if dim_chunk_ix == (self.nchunks - 1):
-                    # all of the last chunk is included
-                    dim_chunk_sel_stop = None
-                else:
-                    dim_chunk_sel_stop = self.stop - dim_offset
+                dim_chunk_sel_stop = self.stop - dim_offset
 
             dim_chunk_sel = slice(dim_chunk_sel_start, dim_chunk_sel_stop, self.step)
-            dim_chunk_nitems = ceildiv(
-                ((dim_chunk_sel_stop or dim_chunk_len) - dim_chunk_sel_start), self.step
-            )
+            dim_chunk_nitems = ceildiv((dim_chunk_sel_stop - dim_chunk_sel_start), self.step)
 
             # If there are no elements on the selection within this chunk, then skip
             if dim_chunk_nitems == 0:
@@ -1386,17 +1378,7 @@ def is_total_slice(item: Selection, shape: ChunkCoords) -> bool:
                 isinstance(dim_sel, slice)
                 and (
                     (dim_sel == slice(None))
-                    or (
-                        dim_sel.stop is not None
-                        and (dim_sel.stop - dim_sel.start == dim_len)
-                        and (dim_sel.step in [1, None])
-                    )
-                    # starts exactly at a chunk
-                    or (
-                        (dim_sel.start % dim_len == 0)
-                        and dim_sel.stop is None
-                        and (dim_sel.step in [1, None])
-                    )
+                    or ((dim_sel.stop - dim_sel.start == dim_len) and (dim_sel.step in [1, None]))
                 )
             )
             for dim_sel, dim_len in zip(item, shape, strict=False)

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -421,7 +421,9 @@ class SliceDimIndexer:
 
             dim_out_sel = slice(dim_out_offset, dim_out_offset + dim_chunk_nitems)
 
-            is_complete_chunk = dim_chunk_sel_start == 0 and (self.stop >= dim_limit)
+            is_complete_chunk = (
+                dim_chunk_sel_start == 0 and (self.stop >= dim_limit) and self.step in [1, None]
+            )
             yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel, is_complete_chunk)
 
 

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -321,12 +321,12 @@ class ChunkDimProjection(NamedTuple):
         Selection of items from chunk array.
     dim_out_sel
         Selection of items in target (output) array.
-
     """
 
     dim_chunk_ix: int
     dim_chunk_sel: Selector
     dim_out_sel: Selector | None
+    is_complete_chunk: bool
 
 
 @dataclass(frozen=True)
@@ -346,7 +346,8 @@ class IntDimIndexer:
         dim_offset = dim_chunk_ix * self.dim_chunk_len
         dim_chunk_sel = self.dim_sel - dim_offset
         dim_out_sel = None
-        yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
+        is_complete_chunk = self.dim_chunk_len == 1
+        yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel, is_complete_chunk)
 
 
 @dataclass(frozen=True)
@@ -420,7 +421,8 @@ class SliceDimIndexer:
 
             dim_out_sel = slice(dim_out_offset, dim_out_offset + dim_chunk_nitems)
 
-            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
+            is_complete_chunk = dim_chunk_sel_start == 0 and (self.stop >= dim_limit)
+            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel, is_complete_chunk)
 
 
 def check_selection_length(selection: SelectionNormalized, shape: ChunkCoords) -> None:
@@ -493,12 +495,14 @@ class ChunkProjection(NamedTuple):
         Selection of items from chunk array.
     out_selection
         Selection of items in target (output) array.
-
+    is_complete_chunk:
+        True if a complete chunk is indexed
     """
 
     chunk_coords: ChunkCoords
     chunk_selection: tuple[Selector, ...] | npt.NDArray[np.intp]
     out_selection: tuple[Selector, ...] | npt.NDArray[np.intp] | slice
+    is_complete_chunk: bool
 
 
 def is_slice(s: Any) -> TypeGuard[slice]:
@@ -574,8 +578,8 @@ class BasicIndexer(Indexer):
             out_selection = tuple(
                 p.dim_out_sel for p in dim_projections if p.dim_out_sel is not None
             )
-
-            yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
+            is_complete_chunk = all(p.is_complete_chunk for p in dim_projections)
+            yield ChunkProjection(chunk_coords, chunk_selection, out_selection, is_complete_chunk)
 
 
 @dataclass(frozen=True)
@@ -643,8 +647,9 @@ class BoolArrayDimIndexer:
                 start = self.chunk_nitems_cumsum[dim_chunk_ix - 1]
             stop = self.chunk_nitems_cumsum[dim_chunk_ix]
             dim_out_sel = slice(start, stop)
+            is_complete_chunk = False  # TODO
 
-            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
+            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel, is_complete_chunk)
 
 
 class Order(Enum):
@@ -783,8 +788,8 @@ class IntArrayDimIndexer:
             # find region in chunk
             dim_offset = dim_chunk_ix * self.dim_chunk_len
             dim_chunk_sel = self.dim_sel[start:stop] - dim_offset
-
-            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel)
+            is_complete_chunk = False  # TODO
+            yield ChunkDimProjection(dim_chunk_ix, dim_chunk_sel, dim_out_sel, is_complete_chunk)
 
 
 def slice_to_range(s: slice, length: int) -> range:
@@ -921,7 +926,8 @@ class OrthogonalIndexer(Indexer):
                 if not is_basic_selection(out_selection):
                     out_selection = ix_(out_selection, self.shape)
 
-            yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
+            is_complete_chunk = all(p.is_complete_chunk for p in dim_projections)
+            yield ChunkProjection(chunk_coords, chunk_selection, out_selection, is_complete_chunk)
 
 
 @dataclass(frozen=True)
@@ -1030,8 +1036,8 @@ class BlockIndexer(Indexer):
             out_selection = tuple(
                 p.dim_out_sel for p in dim_projections if p.dim_out_sel is not None
             )
-
-            yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
+            is_complete_chunk = all(p.is_complete_chunk for p in dim_projections)
+            yield ChunkProjection(chunk_coords, chunk_selection, out_selection, is_complete_chunk)
 
 
 @dataclass(frozen=True)
@@ -1198,7 +1204,8 @@ class CoordinateIndexer(Indexer):
                 for (dim_sel, dim_chunk_offset) in zip(self.selection, chunk_offsets, strict=True)
             )
 
-            yield ChunkProjection(chunk_coords, chunk_selection, out_selection)
+            is_complete_chunk = False  # TODO
+            yield ChunkProjection(chunk_coords, chunk_selection, out_selection, is_complete_chunk)
 
 
 @dataclass(frozen=True)
@@ -1359,32 +1366,6 @@ def morton_order_iter(chunk_shape: ChunkCoords) -> Iterator[ChunkCoords]:
 
 def c_order_iter(chunks_per_shard: ChunkCoords) -> Iterator[ChunkCoords]:
     return itertools.product(*(range(x) for x in chunks_per_shard))
-
-
-def is_total_slice(item: Selection, shape: ChunkCoords) -> bool:
-    """Determine whether `item` specifies a complete slice of array with the
-    given `shape`. Used to optimize __setitem__ operations on the Chunk
-    class."""
-
-    # N.B., assume shape is normalized
-    if item == slice(None):
-        return True
-    if isinstance(item, slice):
-        item = (item,)
-    if isinstance(item, tuple):
-        return all(
-            (isinstance(dim_sel, int) and dim_len == 1)
-            or (
-                isinstance(dim_sel, slice)
-                and (
-                    (dim_sel == slice(None))
-                    or ((dim_sel.stop - dim_sel.start == dim_len) and (dim_sel.step in [1, None]))
-                )
-            )
-            for dim_sel, dim_len in zip(item, shape, strict=False)
-        )
-    else:
-        raise TypeError(f"expected slice or tuple of slices, found {item!r}")
 
 
 def get_indexer(

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -403,16 +403,24 @@ class SliceDimIndexer:
                 dim_chunk_sel_start = self.start - dim_offset
                 dim_out_offset = 0
 
+            # Use None to indicate this selection ends at the chunk edge
+            # This is useful for is_total_slice at boundary chunks,
             if self.stop > dim_limit:
                 # selection ends after current chunk
-                dim_chunk_sel_stop = dim_chunk_len
+                dim_chunk_sel_stop = None  # dim_chunk_len
 
             else:
                 # selection ends within current chunk
-                dim_chunk_sel_stop = self.stop - dim_offset
+                if dim_chunk_ix == (self.nchunks - 1):
+                    # all of the last chunk is included
+                    dim_chunk_sel_stop = None
+                else:
+                    dim_chunk_sel_stop = self.stop - dim_offset
 
             dim_chunk_sel = slice(dim_chunk_sel_start, dim_chunk_sel_stop, self.step)
-            dim_chunk_nitems = ceildiv((dim_chunk_sel_stop - dim_chunk_sel_start), self.step)
+            dim_chunk_nitems = ceildiv(
+                ((dim_chunk_sel_stop or dim_chunk_len) - dim_chunk_sel_start), self.step
+            )
 
             # If there are no elements on the selection within this chunk, then skip
             if dim_chunk_nitems == 0:
@@ -1378,7 +1386,17 @@ def is_total_slice(item: Selection, shape: ChunkCoords) -> bool:
                 isinstance(dim_sel, slice)
                 and (
                     (dim_sel == slice(None))
-                    or ((dim_sel.stop - dim_sel.start == dim_len) and (dim_sel.step in [1, None]))
+                    or (
+                        dim_sel.stop is not None
+                        and (dim_sel.stop - dim_sel.start == dim_len)
+                        and (dim_sel.step in [1, None])
+                    )
+                    # starts exactly at a chunk
+                    or (
+                        (dim_sel.start % dim_len == 0)
+                        and dim_sel.stop is None
+                        and (dim_sel.step in [1, None])
+                    )
                 )
             )
             for dim_sel, dim_len in zip(item, shape, strict=False)

--- a/src/zarr/storage/_logging.py
+++ b/src/zarr/storage/_logging.py
@@ -88,7 +88,7 @@ class LoggingStore(WrapperStore[T_Store]):
         op = f"{type(self._store).__name__}.{method}"
         if hint:
             op = f"{op}({hint})"
-        self.logger.info("Calling %s", op)
+        self.logger.info(" Calling %s", op)
         start_time = time.time()
         try:
             self.counter[method] += 1

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -205,14 +205,20 @@ def orthogonal_indices(
             npst.integer_array_indices(
                 shape=(size,), result_shape=npst.array_shapes(min_side=1, max_side=size, max_dims=1)
             )
-            # | npst.basic_indices(shape=(size,), allow_ellipsis=False)
+            | basic_indices(shape=(size,), allow_ellipsis=False).map(
+                lambda x: (x,) if not isinstance(x, tuple) else x
+            )
         )
+        if isinstance(idxr, int):
+            idxr = np.array([idxr])
         zindexer.append(idxr)
-        if isinstance(idxr, np.ndarray):
-            newshape = [1] * ndim
-            newshape[axis] = idxr.size
-            idxr = idxr.reshape(newshape)
-            npindexer.append(idxr)
+        if isinstance(idxr, slice):
+            idxr = np.arange(*idxr.indices(size))
+        elif isinstance(idxr, (tuple, int)):
+            idxr = np.array(idxr)
+        newshape = [1] * ndim
+        newshape[axis] = idxr.size
+        npindexer.append(idxr.reshape(newshape))
     return tuple(zindexer), np.broadcast_arrays(*npindexer)
 
 

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -220,6 +220,9 @@ def orthogonal_indices(
         newshape = [1] * ndim
         newshape[axis] = idxr.size
         npindexer.append(idxr.reshape(newshape))
+    from hypothesis import note
+
+    note(val)
     return tuple(zindexer), np.broadcast_arrays(*npindexer)
 
 

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -201,14 +201,15 @@ def orthogonal_indices(
     npindexer = []
     ndim = len(shape)
     for axis, size in enumerate(shape):
-        (idxr,) = draw(
+        val = draw(
             npst.integer_array_indices(
                 shape=(size,), result_shape=npst.array_shapes(min_side=1, max_side=size, max_dims=1)
             )
-            | basic_indices(shape=(size,), allow_ellipsis=False).map(
-                lambda x: (x,) if not isinstance(x, tuple) else x
-            )
+            | basic_indices(min_dims=1, shape=(size,), allow_ellipsis=False)
+            .map(lambda x: (x,) if not isinstance(x, tuple) else x)  # bare ints, slices
+            .filter(lambda x: bool(x))  # skip empty tuple
         )
+        (idxr,) = val
         if isinstance(idxr, int):
             idxr = np.array([idxr])
         zindexer.append(idxr)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -220,10 +220,9 @@ def orthogonal_indices(
         newshape = [1] * ndim
         newshape[axis] = idxr.size
         npindexer.append(idxr.reshape(newshape))
-    from hypothesis import note
 
-    note(val)
-    return tuple(zindexer), np.broadcast_arrays(*npindexer)
+    # casting the output of broadcast_arrays is needed for numpy 1.25
+    return tuple(zindexer), tuple(np.broadcast_arrays(*npindexer))
 
 
 def key_ranges(

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1335,5 +1335,14 @@ async def test_orthogonal_set_total_slice() -> None:
     """Ensure that a whole chunk overwrite does not read chunks"""
     store = MemoryStore()
     array = zarr.create_array(store, shape=(20, 20), chunks=(1, 2), dtype=int, fill_value=-1)
-    with mock.patch("zarr.storage.MemoryStore.get", side_effect=ValueError):
+    with mock.patch("zarr.storage.MemoryStore.get", side_effect=RuntimeError):
         array[0, slice(4, 10)] = np.arange(6)
+
+    array = zarr.create_array(
+        store, shape=(20, 21), chunks=(1, 2), dtype=int, fill_value=-1, overwrite=True
+    )
+    with mock.patch("zarr.storage.MemoryStore.get", side_effect=RuntimeError):
+        array[0, :] = np.arange(21)
+
+    with mock.patch("zarr.storage.MemoryStore.get", side_effect=RuntimeError):
+        array[:] = 1

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -19,7 +19,6 @@ from zarr.core.indexing import (
     OrthogonalSelection,
     Selection,
     _iter_grid,
-    is_total_slice,
     make_slice_selection,
     normalize_integer_selection,
     oindex,
@@ -1954,11 +1953,3 @@ def test_vectorized_indexing_incompatible_shape(store) -> None:
     )
     with pytest.raises(ValueError, match="Attempting to set"):
         arr[np.array([1, 2]), np.array([1, 2])] = np.array([[-1, -2], [-3, -4]])
-
-
-def test_is_total_slice():
-    assert is_total_slice((0, slice(4, 6)), (1, 2))
-    assert is_total_slice((slice(0, 1, None), slice(4, 6)), (1, 2))
-    assert is_total_slice((slice(0, 1, None), slice(4, None)), (1, 2))
-    # slice(5, None) starts in the middle of a chunk
-    assert not is_total_slice((slice(0, 1, None), slice(5, None)), (1, 2))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1959,3 +1959,6 @@ def test_vectorized_indexing_incompatible_shape(store) -> None:
 def test_is_total_slice():
     assert is_total_slice((0, slice(4, 6)), (1, 2))
     assert is_total_slice((slice(0, 1, None), slice(4, 6)), (1, 2))
+    assert is_total_slice((slice(0, 1, None), slice(4, None)), (1, 2))
+    # slice(5, None) starts in the middle of a chunk
+    assert not is_total_slice((slice(0, 1, None), slice(5, None)), (1, 2))

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,7 +6,7 @@ pytest.importorskip("hypothesis")
 
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
-from hypothesis import given, settings
+from hypothesis import given
 
 from zarr.testing.strategies import (
     arrays,
@@ -38,7 +38,6 @@ def test_basic_indexing(data: st.DataObject) -> None:
     assert_array_equal(nparray, zarray[:])
 
 
-@settings(report_multiple_bugs=False)
 @given(data=st.data())
 def test_oindex(data: st.DataObject) -> None:
     # integer_array_indices can't handle 0-size dimensions.

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,9 +6,15 @@ pytest.importorskip("hypothesis")
 
 import hypothesis.extra.numpy as npst
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, settings
 
-from zarr.testing.strategies import arrays, basic_indices, numpy_arrays, zarr_formats
+from zarr.testing.strategies import (
+    arrays,
+    basic_indices,
+    numpy_arrays,
+    orthogonal_indices,
+    zarr_formats,
+)
 
 
 @given(data=st.data(), zarr_format=zarr_formats)
@@ -30,6 +36,18 @@ def test_basic_indexing(data: st.DataObject) -> None:
     zarray[indexer] = new_data
     nparray[indexer] = new_data
     assert_array_equal(nparray, zarray[:])
+
+
+@settings(report_multiple_bugs=False)
+@given(data=st.data())
+def test_oindex(data: st.DataObject) -> None:
+    # integer_array_indices can't handle 0-size dimensions.
+    zarray = data.draw(arrays(shapes=npst.array_shapes(max_dims=4, min_side=1)))
+    nparray = zarray[:]
+
+    zindexer, npindexer = data.draw(orthogonal_indices(shape=nparray.shape))
+    actual = zarray.oindex[zindexer]
+    assert_array_equal(nparray[npindexer], actual)
 
 
 @given(data=st.data())


### PR DESCRIPTION
Teach the *Indexer objects to detect when a selection corresponds to a whole chunk. Propagate that information down to the codec pipeline where reads can be skipped if it makes sense locally.

Closes #757

~I'm opening this for comments about the approach (@d-v-b , @normanrz ) it could definitely use more tests (edit: and some fixes)~

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
