### PR TITLE
Pluralize glob and file in labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
 needs release notes:
   - all:
     - changed-files:
-      - all-glob-to-all-file: '!changes/*.rst'
+      - all-globs-to-all-files: '!changes/*.rst'

--- a/changes/2785.bugfix.rst
+++ b/changes/2785.bugfix.rst
@@ -1,0 +1,1 @@
+Use the proper label config


### PR DESCRIPTION
Well, this is embarrassing. Need to pluralize `glob` and `file` when using `all` as opposed to `any`. Makes sense. Missed it. Going to test things first by changing target to `pull_request` rather than `pull_request_target`

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
