### PR TITLE
fix: implicit fill value initialisation

### DIFF
--- a/changes/2799.bugfix.rst
+++ b/changes/2799.bugfix.rst
@@ -1,0 +1,1 @@
+Enitialise empty chunks to the default fill value during writing and add default fill values for datetime, timedelta, structured, and other (void* fixed size) data types

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -350,7 +350,7 @@ def _default_fill_value(dtype: np.dtype[Any]) -> Any:
     elif dtype.kind in "UO":
         return ""
     elif dtype.kind in "Mm":
-        return dtype.type('nat')
+        return dtype.type("nat")
     elif dtype.kind == "V":
         if dtype.fields is not None:
             default = tuple([_default_fill_value(field[0]) for field in dtype.fields.values()])

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -349,6 +349,14 @@ def _default_fill_value(dtype: np.dtype[Any]) -> Any:
         return b""
     elif dtype.kind in "UO":
         return ""
+    elif dtype.kind in "Mm":
+        return dtype.type('nat')
+    elif dtype.kind == "V":
+        if dtype.fields is not None:
+            default = tuple([_default_fill_value(field[0]) for field in dtype.fields.values()])
+            return np.array([default], dtype=dtype)
+        else:
+            return np.zeros(1, dtype=dtype)
     else:
         return dtype.type(0)
 

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -313,3 +313,22 @@ def test_structured_dtype_roundtrip(fill_value, tmp_path) -> None:
     za[...] = a
     za = zarr.open_array(store=array_path)
     assert (a == za[:]).all()
+
+
+@pytest.mark.parametrize("fill_value", [None, b"x"], ids=["no_fill", "fill"])
+def test_other_dtype_roundtrip(fill_value, tmp_path) -> None:
+    a = np.array([b"a\0\0", b"bb", b"ccc"], dtype="V7")
+    array_path = tmp_path / "data.zarr"
+    za = zarr.create(
+        shape=(3,),
+        store=array_path,
+        chunks=(2,),
+        fill_value=fill_value,
+        zarr_format=2,
+        dtype=a.dtype,
+    )
+    if fill_value is not None:
+        assert (np.array([fill_value] * a.shape[0], dtype=a.dtype) == za[:]).all()
+    za[...] = a
+    za = zarr.open_array(store=array_path)
+    assert (a == za[:]).all()


### PR DESCRIPTION
Fixes omissions in https://github.com/zarr-developers/zarr-python/pull/2274

- initialise empty chunks to the default fill value during writing
- add default fill value for datetime, timedelta, structured, and other (void* fixed size) data types
- add test for "other" data type

Fixes the below:
```python
array = zarr.create_array(
    store=zarr.storage.MemoryStore(),
    dtype=np.uint8,
    shape=(4,),
    chunks=(2,),
    fill_value=None,
    zarr_format=2,
)
array[:3] = [1, 2, 3]
print(array[:]) # [1, 2, 3, undefined]
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
