### PR TITLE
Strengthen pickling test and fix ZipStore __getstate__()

### DIFF
--- a/changes/2807.bugfix.rst
+++ b/changes/2807.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pickling for ZipStore

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -108,7 +108,8 @@ class ZipStore(Store):
         self._sync_open()
 
     def __getstate__(self) -> dict[str, Any]:
-        state = self.__dict__
+        # We need a copy to not modify the state of the original store
+        state = self.__dict__.copy()
         for attr in ["_zf", "_lock"]:
             state.pop(attr, None)
         return state


### PR DESCRIPTION
It's important for stores that manually implement `__getstate__` and `__setstate__` that the store behavior is tested beyond a simply equality check. This is motivated by https://github.com/zarr-developers/zarr-python/pull/1661, where I first added incorrect serialization functionality even though it passed this test. This PR adds a simple set/get check on the serialization test and exposes an issue with ZipStore.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
