### PR TITLE
Multiprocessing support

### DIFF
--- a/src/zarr/core/sync.py
+++ b/src/zarr/core/sync.py
@@ -101,7 +101,9 @@ def reset_resources_after_fork() -> None:
     _executor = None
 
 
-os.register_at_fork(after_in_child=reset_resources_after_fork)
+# this is only available on certain operating systems
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=reset_resources_after_fork)
 
 
 async def _runner(coro: Coroutine[Any, Any, T]) -> T | BaseException:

--- a/src/zarr/core/sync.py
+++ b/src/zarr/core/sync.py
@@ -96,9 +96,13 @@ def reset_resources_after_fork() -> None:
     forked processes will retain invalid references to the parent process's resources.
     """
     global loop, iothread, _executor
-    loop[0] = None
-    iothread[0] = None
-    _executor = None
+    # These lines are excluded from coverage because this function only runs in a child process,
+    # which is not observed by the test coverage instrumentation. Despite the apparent lack of
+    # test coverage, this function should be adequately tested by any test that uses Zarr IO with
+    # multiprocessing.
+    loop[0] = None  # pragma: no cover
+    iothread[0] = None  # pragma: no cover
+    _executor = None  # pragma: no cover
 
 
 # this is only available on certain operating systems

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,8 +1,10 @@
 import dataclasses
 import json
 import math
+import multiprocessing as mp
 import pickle
 import re
+import sys
 from itertools import accumulate
 from typing import TYPE_CHECKING, Any, Literal
 from unittest import mock
@@ -1388,16 +1390,33 @@ def _index_array(arr: Array, index: Any) -> Any:
     return arr[index]
 
 
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param(
+            "fork",
+            marks=pytest.mark.skipif(
+                sys.platform in ("win32", "darwin"), reason="fork not supported on Windows or OSX"
+            ),
+        ),
+        "spawn",
+        pytest.param(
+            "forkserver",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="forkserver not supported on Windows"
+            ),
+        ),
+    ],
+)
 @pytest.mark.parametrize("store", ["local"], indirect=True)
-def test_multiprocessing(store: Store) -> None:
+def test_multiprocessing(store: Store, method: Literal["fork", "spawn"]) -> None:
     """
     Test that arrays can be pickled and indexed in child processes
     """
     data = np.arange(100)
     arr = zarr.create_array(store=store, data=data)
-    from multiprocessing import Pool
+    ctx = mp.get_context(method)
+    pool = ctx.Pool()
 
-    pool = Pool()
-
-    results = pool.starmap(_index_array, [(arr, slice(len(data)))] * 3)
+    results = pool.starmap(_index_array, [(arr, slice(len(data)))])
     assert all(np.array_equal(r, data) for r in results)

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1409,7 +1409,7 @@ def _index_array(arr: Array, index: Any) -> Any:
     ],
 )
 @pytest.mark.parametrize("store", ["local"], indirect=True)
-def test_multiprocessing(store: Store, method: Literal["fork", "spawn"]) -> None:
+def test_multiprocessing(store: Store, method: Literal["fork", "spawn", "forkserver"]) -> None:
     """
     Test that arrays can be pickled and indexed in child processes
     """


### PR DESCRIPTION
I wanted to use this PR to add tests to ensure that basic array operations work in a multiprocessing context. But right now I just have 1 test, and it's failing with an infinite stall. Since this breaks the entire test suite, we should also fix the underlying bug in this PR. Stay tuned!

closes #2812 