### PR TITLE
WIP: Consolidate workflows for GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
             os: 'windows-latest'
           - python-version: '3.11'
             dependency-set: 'min_deps'
-          - python-version: '3.33'
+          - python-version: '3.13'
             dependency-set: 'upstream'
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
             numpy-version: '2.1'
             dependency-set: 'optional'
             os: 'windows-latest'
+          - python-version: '3.11'
+            dependency-set: 'min_deps'
+          - python-version: '3.33'
+            dependency-set: 'upstream'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -68,40 +72,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
-
-  test-upstream-and-min-deps:
-    name: py=${{ matrix.python-version }}-${{ matrix.dependency-set }}
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.11', "3.13"]
-        dependency-set: ["upstream", "min_deps"]
-        exclude:
-          - python-version: "3.13"
-            dependency-set: min_deps
-          - python-version: "3.11"
-            dependency-set: upstream
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install Hatch
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    - name: Set Up Hatch Env
-      run: |
-        hatch env create ${{ matrix.dependency-set }}
-        hatch env run -e ${{ matrix.dependency-set }} list-env
-    - name: Run Tests
-      run: |
-        hatch env run --env ${{ matrix.dependency-set }} run
 
   doctests:
     name: doctests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,6 @@ jobs:
     needs:
       [
         test,
-        test-upstream-and-min-deps,
         doctests
       ]
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,10 @@ jobs:
             os: 'windows-latest'
           - python-version: '3.11'
             dependency-set: 'min_deps'
+            os: 'ubuntu-latest'
           - python-version: '3.13'
             dependency-set: 'upstream'
+            os: 'ubuntu-latest'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -60,15 +62,32 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install hatch
+    - name: Set environment name
+      id : hatch-env-name
+      run : |
+        if [[ ${{ matrix.dependency-set }} = 'upstream' ]]; then
+          HATCH_ENV="upstream"
+        elif [[ ${{ matrix.dependency-set }} = 'min_deps' ]]; then
+          HATCH_ENV="min_deps"
+        else
+          HATCH_ENV="test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }}"
+        fi
+        echo "HATCH_ENV=${HATCH_ENV}" >> "$GITHUB_OUTPUT"
+
     - name: Set Up Hatch Env
+      env:
+          HATCH_ENV: ${{ steps.hatch-env-name.outputs.HATCH_ENV }}
       run: |
-        hatch env create test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }}
-        hatch env run -e test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} list-env
+        hatch env create ${HATCH_ENV}
+        hatch env run -e ${HATCH_ENV} list-env
     - name: Run Tests
+      env:
+          HATCH_ENV: ${{ steps.hatch-env-name.outputs.HATCH_ENV }}
       run: |
-        hatch env run --env test.py${{ matrix.python-version }}-${{ matrix.numpy-version }}-${{ matrix.dependency-set }} run-coverage
+        hatch env run --env ${HATCH_ENV} run-coverage
     - name: Upload coverage
       uses: codecov/codecov-action@v5
+      if: ${{ !env.ACT }} # Skip during local testing
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
@@ -99,7 +118,6 @@ jobs:
 
   test-complete:
     name: Test complete
-
     needs:
       [
         test,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ PIP_PRE = "1"
 run = "pytest --verbose"
 run-mypy = "mypy src"
 run-hypothesis = "pytest --hypothesis-profile ci tests/test_properties.py tests/test_store/test_stateful*"
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
 list-env = "pip list"
 
 [tool.hatch.envs.min_deps]
@@ -257,6 +258,7 @@ dependencies = [
 [tool.hatch.envs.min_deps.scripts]
 run = "pytest --verbose"
 run-hypothesis = "pytest --hypothesis-profile ci tests/test_properties.py tests/test_store/test_stateful*"
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
 list-env = "pip list"
 
 


### PR DESCRIPTION
It might be helpful to run the upstream and min-deps jobs as part of the main 'test' workflow in order to capture caught ImportErrors in the code coverage. Motivated by #2774 where the only missed lines are ImportErrors.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
