### PR TITLE
Run fsspec tests in min_deps env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,11 @@ jobs:
     - name: Run Tests
       run: |
         hatch env run --env ${{ matrix.dependency-set }} run
+    - name: Upload coverage
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true # optional (default = false)
 
   doctests:
     name: doctests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,11 +212,7 @@ dependencies = [
     'typing_extensions @ git+https://github.com/python/typing_extensions',
     'donfig @ git+https://github.com/pytroll/donfig',
     # test deps
-    'hypothesis',
-    'pytest',
-    'pytest-cov',
-    'pytest-asyncio',
-    'moto[s3]',
+    'zarr[test]',
 ]
 
 [tool.hatch.envs.upstream.env-vars]
@@ -228,6 +224,9 @@ PIP_PRE = "1"
 run = "pytest --verbose"
 run-mypy = "mypy src"
 run-hypothesis = "pytest --hypothesis-profile ci tests/test_properties.py tests/test_store/test_stateful*"
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
+run-coverage-gpu = "pip install cupy-cuda12x && pytest -m gpu --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
+run-coverage-html = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report html --cov=src"
 list-env = "pip list"
 
 [tool.hatch.envs.min_deps]
@@ -247,18 +246,16 @@ dependencies = [
     'typing_extensions==4.9.*',
     'donfig==0.8.*',
     # test deps
-    'hypothesis',
-    'pytest',
-    'pytest-cov',
-    'pytest-asyncio',
-    'moto[s3]',
+    'zarr[test]',
 ]
 
 [tool.hatch.envs.min_deps.scripts]
 run = "pytest --verbose"
 run-hypothesis = "pytest --hypothesis-profile ci tests/test_properties.py tests/test_store/test_stateful*"
 list-env = "pip list"
-
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
+run-coverage-gpu = "pip install cupy-cuda12x && pytest -m gpu --cov-config=pyproject.toml --cov=pkg --cov-report xml --cov=src --junitxml=junit.xml -o junit_family=legacy"
+run-coverage-html = "pytest --cov-config=pyproject.toml --cov=pkg --cov-report html --cov=src"
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -110,7 +110,12 @@ class TestFsspecStoreS3(StoreTests[FsspecStore, cpu.Buffer]):
 
     @pytest.fixture
     def store_kwargs(self, request) -> dict[str, str | bool]:
-        fs, path = fsspec.url_to_fs(
+        try:
+            from fsspec import url_to_fs
+        except ImportError:
+            # before fsspec==2024.3.1
+            from fsspec.core import url_to_fs
+        fs, path = url_to_fs(
             f"s3://{test_bucket_name}", endpoint_url=endpoint_url, anon=False, asynchronous=True
         )
         return {"fs": fs, "path": path}
@@ -204,7 +209,12 @@ class TestFsspecStoreS3(StoreTests[FsspecStore, cpu.Buffer]):
             self.store_cls(**store_kwargs)
 
     def test_init_warns_if_fs_asynchronous_is_false(self) -> None:
-        fs, path = fsspec.url_to_fs(
+        try:
+            from fsspec import url_to_fs
+        except ImportError:
+            # before fsspec==2024.3.1
+            from fsspec.core import url_to_fs
+        fs, path = url_to_fs(
             f"s3://{test_bucket_name}", endpoint_url=endpoint_url, anon=False, asynchronous=False
         )
         store_kwargs = {"fs": fs, "path": path}

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -187,6 +187,10 @@ class TestFsspecStoreS3(StoreTests[FsspecStore, cpu.Buffer]):
         )
         assert dict(group.attrs) == {"key": "value-3"}
 
+    @pytest.mark.skipif(
+        parse_version(fsspec.__version__) < parse_version("2024.03.01"),
+        reason="Prior bug in from_upath",
+    )
     def test_from_upath(self) -> None:
         upath = pytest.importorskip("upath")
         path = upath.UPath(


### PR DESCRIPTION
The fsspec tests weren't being run in the min_deps environment because moto[server] wasn't installed. This simplifies the setup for individual test envs to inherit from the general test env. It also uploads another coverage report from the min_deps_and_upstream run.

