### PR TITLE
Deprecate partial read/writes in v2

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,9 +14,19 @@ Release notes
     # re-indented so that it does not show up in the notes.
 
 .. note::
-   Zarr-Python 2.18.* is expected be the final release in the 2.* series. Work on Zarr-Python 3.0 is underway.
-   See `GH1777 <https://github.com/zarr-developers/zarr-python/issues/1777>`_ for more details on the upcoming
-   3.0 release.
+   Zarr-Python 2.* is in support mode now, and no new features will be added.
+
+
+Unreleased
+----------
+
+Deprecations
+~~~~~~~~~~~~
+
+* Deprecated support for ``partial_decompress`` when creating an array.
+  This functionality is no longer supported in ``numcodecs``, and will be removed
+  in ``zarr-python`` 2.19.0.
+  By :user:`David Stansby <dstansby>`
 
 .. _release_2.18.4:
 
@@ -39,9 +49,6 @@ Maintenance
 * Excluded versions 0.14.0 and 0.14.1 of numcodecs, due to a bug in the implementation of
   the Delta filter (see https://github.com/zarr-developers/numcodecs/issues/653 for more information).
   By :user:`David Stansby <dstansby>` (:issue:`2544`).
-
-Deprecations
-~~~~~~~~~~~~
 
 .. _release_2.18.3:
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1,11 +1,10 @@
 import binascii
 import hashlib
-from inspect import stack
 import itertools
 import math
 import operator
 import re
-from functools import partial, reduce
+from functools import reduce
 from typing import Any
 import warnings
 

--- a/zarr/core.py
+++ b/zarr/core.py
@@ -1,11 +1,13 @@
 import binascii
 import hashlib
+from inspect import stack
 import itertools
 import math
 import operator
 import re
-from functools import reduce
+from functools import partial, reduce
 from typing import Any
+import warnings
 
 import numpy as np
 from numcodecs.compat import ensure_bytes
@@ -90,13 +92,6 @@ class Array:
         If True (default), user attributes will be cached for attribute read
         operations. If False, user attributes are reloaded from the store prior
         to all attribute read operations.
-    partial_decompress : bool, optional
-        If True and while the chunk_store is a FSStore and the compression used
-        is Blosc, when getting data from the array chunks will be partially
-        read and decompressed when possible.
-
-        .. versionadded:: 2.7
-
     write_empty_chunks : bool, optional
         If True, all chunks will be stored regardless of their contents. If
         False (default), each chunk is compared to the array's fill value prior
@@ -124,7 +119,7 @@ class Array:
         synchronizer=None,
         cache_metadata=True,
         cache_attrs=True,
-        partial_decompress=False,
+        partial_decompress=None,
         write_empty_chunks=True,
         zarr_version=None,
         meta_array=None,
@@ -154,6 +149,13 @@ class Array:
         self._synchronizer = synchronizer
         self._cache_metadata = cache_metadata
         self._is_view = False
+        if partial_decompress is not None:
+            warnings.warn(
+                "Support for partial decompression is no longer supported in numcodecs. "
+                "Support for partial decompression will be removed in a future version of zarr-python v2.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
         self._partial_decompress = partial_decompress
         self._write_empty_chunks = write_empty_chunks
         if meta_array is not None:

--- a/zarr/creation.py
+++ b/zarr/creation.py
@@ -466,7 +466,7 @@ def open_array(
     object_codec=None,
     chunk_store=None,
     storage_options=None,
-    partial_decompress=False,
+    partial_decompress=None,
     write_empty_chunks=True,
     *,
     zarr_version=None,
@@ -522,10 +522,6 @@ def open_array(
     storage_options : dict
         If using an fsspec URL to create the store, these will be passed to
         the backend implementation. Ignored otherwise.
-    partial_decompress : bool, optional
-        If True and while the chunk_store is a FSStore and the compression used
-        is Blosc, when getting data from the array chunks will be partially
-        read and decompressed when possible.
     write_empty_chunks : bool, optional
         If True (default), all chunks will be stored regardless of their
         contents. If False, each chunk is compared to the array's fill value

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2,6 +2,8 @@ import atexit
 import sys
 import pickle
 import shutil
+import re
+
 from typing import Any, Literal, Optional, Tuple, Union, Sequence
 import unittest
 from itertools import zip_longest
@@ -84,6 +86,11 @@ from zarr.types import DIMENSION_SEPARATOR
 
 # noinspection PyMethodMayBeStatic
 
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:Call to deprecated function .* \_cbuffer\_sizes.*"),
+    pytest.mark.filterwarnings("ignore:Call to deprecated function .* \_cbuffer\_metainfo.*"),
+]
+
 
 class TestArray:
     version = 2
@@ -94,7 +101,7 @@ class TestArray:
     dimension_separator: Optional[DIMENSION_SEPARATOR] = None
     cache_metadata = True
     cache_attrs = True
-    partial_decompress: bool = False
+    partial_decompress: bool | None = None
     write_empty_chunks = True
     read_only = False
     storage_transformers: Tuple[Any, ...] = ()
@@ -2481,6 +2488,9 @@ class TestArrayWithFSStoreFromFilesystem(TestArray):
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+@pytest.mark.filterwarnings(
+    "ignore:.*Support for partial decompression will be removed in a future version.*"
+)
 class TestArrayWithFSStorePartialRead(TestArray):
     compressor = Blosc(blocksize=256)
     partial_decompress = True
@@ -2547,6 +2557,9 @@ class TestArrayWithFSStoreNested(TestArrayWithFSStore):
 
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
+@pytest.mark.filterwarnings(
+    "ignore:.*Support for partial decompression will be removed in a future version.*"
+)
 class TestArrayWithFSStoreNestedPartialRead(TestArrayWithFSStore):
     compressor = Blosc()
     dimension_separator = "/"

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -2,7 +2,6 @@ import atexit
 import sys
 import pickle
 import shutil
-import re
 
 from typing import Any, Literal, Optional, Tuple, Union, Sequence
 import unittest

--- a/zarr/tests/test_core.py
+++ b/zarr/tests/test_core.py
@@ -3032,6 +3032,9 @@ class TestArrayWithFSStoreV3FromFilesystem(TestArrayWithFSStoreV3):
 
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")
+@pytest.mark.filterwarnings(
+    "ignore:.*Support for partial decompression will be removed in a future version.*"
+)
 class TestArrayWithFSStoreV3PartialRead(TestArrayWithFSStoreV3):
     partial_decompress = True
 
@@ -3050,6 +3053,9 @@ class TestArrayWithFSStoreV3PartialRead(TestArrayWithFSStoreV3):
 @pytest.mark.skipif(have_fsspec is False, reason="needs fsspec")
 @pytest.mark.skipif(not v3_api_available, reason="V3 is disabled")
 @pytest.mark.skipif(not v3_sharding_available, reason="sharding is disabled")
+@pytest.mark.filterwarnings(
+    "ignore:.*Support for partial decompression will be removed in a future version.*"
+)
 class TestArrayWithFSStoreV3PartialReadUncompressedSharded(TestArrayWithFSStoreV3):
     partial_decompress = True
     compressor = None


### PR DESCRIPTION
Since this was deprecated in numcodecs (https://github.com/zarr-developers/numcodecs/pull/619), deprecate it here too.

I think it would be good to put this in 2.18.5, then remove the code in 2.19.0 to reduce the maintenance burden on `zarr-python` v2. Any thoughts on that?