### PR TITLE
don't serialize empty tuples for v2 filters, and warn when reading such metadata

### DIFF
--- a/changes/2847.fix.rst
+++ b/changes/2847.fix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where ``ArrayV2Metadata`` could save ``filters`` as an empty array.

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import warnings
 from collections.abc import Iterable
 from enum import Enum
 from functools import cached_property
@@ -178,6 +179,16 @@ class ArrayV2Metadata(Metadata):
         # handle the renames
         expected |= {"dtype", "chunks"}
 
+        # check if `filters` is an empty tuple; if so use None instead and raise a warning
+        if _data["filters"] is not None and len(_data["filters"]) == 0:
+            msg = (
+                "Found an empty list of filters in the array metadata document. "
+                "This is contrary to the Zarr V2 specification, and will cause an error in the future. "
+                "Use None (or Null in a JSON document) instead of an empty list of filters."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=1)
+            _data["filters"] = None
+
         _data = {k: v for k, v in _data.items() if k in expected}
 
         return cls(**_data)
@@ -255,7 +266,11 @@ def parse_filters(data: object) -> tuple[numcodecs.abc.Codec, ...] | None:
             else:
                 msg = f"Invalid filter at index {idx}. Expected a numcodecs.abc.Codec or a dict representation of numcodecs.abc.Codec. Got {type(val)} instead."
                 raise TypeError(msg)
-        return tuple(out)
+        if len(out) == 0:
+            # Per the v2 spec, an empty tuple is not allowed -- use None to express "no filters"
+            return None
+        else:
+            return tuple(out)
     # take a single codec instance and wrap it in a tuple
     if isinstance(data, numcodecs.abc.Codec):
         return (data,)

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -179,7 +179,7 @@ class ArrayV2Metadata(Metadata):
         # handle the renames
         expected |= {"dtype", "chunks"}
 
-        # check if `filters` is an empty tuple; if so use None instead and raise a warning
+        # check if `filters` is an empty sequence; if so use None instead and raise a warning
         if _data["filters"] is not None and len(_data["filters"]) == 0:
             msg = (
                 "Found an empty list of filters in the array metadata document. "

--- a/tests/test_metadata/test_v2.py
+++ b/tests/test_metadata/test_v2.py
@@ -33,7 +33,7 @@ def test_parse_zarr_format_invalid(data: Any) -> None:
 
 
 @pytest.mark.parametrize("attributes", [None, {"foo": "bar"}])
-@pytest.mark.parametrize("filters", [None, (), (numcodecs.GZip(),)])
+@pytest.mark.parametrize("filters", [None, (numcodecs.GZip(),)])
 @pytest.mark.parametrize("compressor", [None, numcodecs.GZip()])
 @pytest.mark.parametrize("fill_value", [None, 0, 1])
 @pytest.mark.parametrize("order", ["C", "F"])
@@ -79,6 +79,24 @@ def test_metadata_to_dict(
         observed.pop("dimension_separator")
 
     assert observed == expected
+
+
+def test_filters_empty_tuple_warns() -> None:
+    metadata_dict = {
+        "zarr_format": 2,
+        "shape": (1,),
+        "chunks": (1,),
+        "dtype": "uint8",
+        "order": "C",
+        "compressor": None,
+        "filters": (),
+        "fill_value": 0,
+    }
+    with pytest.warns(
+        UserWarning, match="Found an empty list of filters in the array metadata document."
+    ):
+        meta = ArrayV2Metadata.from_dict(metadata_dict)
+    assert meta.filters is None
 
 
 class TestConsolidated:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -113,6 +113,13 @@ async def test_roundtrip_array_metadata(
         assert actual == expected
 
 
+@given(store=stores, meta=array_metadata())  # type: ignore[misc]
+def test_array_metadata_meets_spec(store: Store, meta: ArrayV2Metadata | ArrayV3Metadata) -> None:
+    asdict = meta.to_dict()
+    if isinstance(meta, ArrayV2Metadata):
+        assert asdict["filters"] != ()
+
+
 # @st.composite
 # def advanced_indices(draw, *, shape):
 #     basic_idxr = draw(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -115,9 +115,16 @@ async def test_roundtrip_array_metadata(
 
 @given(store=stores, meta=array_metadata())  # type: ignore[misc]
 def test_array_metadata_meets_spec(store: Store, meta: ArrayV2Metadata | ArrayV3Metadata) -> None:
+    # TODO: fill this out
     asdict = meta.to_dict()
     if isinstance(meta, ArrayV2Metadata):
         assert asdict["filters"] != ()
+        assert asdict["filters"] is None or isinstance(asdict["filters"], tuple)
+        assert asdict["zarr_format"] == 2
+    elif isinstance(meta, ArrayV3Metadata):
+        assert asdict["zarr_format"] == 3
+    else:
+        raise NotImplementedError
 
 
 # @st.composite


### PR DESCRIPTION
We were violating the v2 spec by serializing "no filters" as the empty array. We created arrays in the wild with this metadata, so any fix should be backwards compatible.

To fix this bug, this PR changes the filters parsing function so that it no longer returns empty tuples, and instead return `None` when no filters are specified. For backwards compatibility with datasets created with earlier versions of zarr-python 3.x, the `from_dict` method will replace empty lists / tuples with the value `None` and emit a warning. 

After a reasonable amount of time (a few minor releases?) we should remove this special-casing and treat `filters = []` as an error. Happy to chat about the timeline.

closes https://github.com/zarr-developers/zarr-python/issues/2842

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
