### PR TITLE
DOC: Add store import changes to v3 migration guide (fix #2733)

### DIFF
--- a/docs/user-guide/v3_migration.rst
+++ b/docs/user-guide/v3_migration.rst
@@ -124,6 +124,30 @@ The Store class
 The Store API has changed significant in Zarr-Python 3. The most notable changes to the
 Store API are:
 
+Store Import Paths
+~~~~~~~~~~~~~~~~~~
+Several store implementations have moved from the top-level module to ``zarr.storage``:
+
+.. code-block:: diff
+   :caption: Store import changes from v2 to v3
+
+   # Before (v2)
+   - from zarr import MemoryStore, DirectoryStore
+   + from zarr.storage import MemoryStore, LocalStore  # LocalStore replaces DirectoryStore
+
+Common replacements:
+
++-------------------------+------------------------------------+
+| v2 Import               | v3 Import                          |
++=========================+====================================+
+| ``zarr.MemoryStore``    | ``zarr.storage.MemoryStore``       |
++-------------------------+------------------------------------+
+| ``zarr.DirectoryStore`` | ``zarr.storage.LocalStore``        |
++-------------------------+------------------------------------+
+| ``zarr.TempStore``      | Use ``tempfile.TemporaryDirectory``|
+|                         | with ``LocalStore``                |
++-------------------------+------------------------------------+
+
 1. Replaced the ``MutableMapping`` base class in favor of a custom abstract base class
    (:class:`zarr.abc.store.Store`).
 2. Switched to an asynchronous interface for all store methods that result in IO. This

--- a/docs/user-guide/v3_migration.rst
+++ b/docs/user-guide/v3_migration.rst
@@ -125,7 +125,7 @@ The Store API has changed significant in Zarr-Python 3. The most notable changes
 Store API are:
 
 Store Import Paths
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 Several store implementations have moved from the top-level module to ``zarr.storage``:
 
 .. code-block:: diff


### PR DESCRIPTION
My first contribution addressing #2733! This PR adds documentation to clarify store import changes in the v3 migration guide.

### What's Included
- Clear comparison table showing v2 vs v3 imports for MemoryStore/DirectoryStore
- Example using tempfile.TemporaryDirectory for TempStore migration
- Fixed formatting in the migration guide based on build feedback

### Checklist (For Maintainers)
✅ Docs updated in `user-guide/v3_migration.rst`  
✅ No code changes needed (pure documentation)  
✅ Built docs locally to verify formatting  

This helps users like those in imagecodecs#123 who encountered build errors with old imports. While it doesn't fix external projects directly, it:  
1. Shows proper v3 import paths  
2. Explains replacements for deprecated stores  
3. Provides copy-paste examples for common migrations  

I'm happy to make any adjustments needed!  
@OPMTerra  