### PR TITLE
Fix ABSStore w/ latest azure-blob-client on v2

### DIFF
--- a/requirements_dev_optional.txt
+++ b/requirements_dev_optional.txt
@@ -4,10 +4,7 @@ lmdb==1.5.1; sys_platform != 'win32'
 # optional library requirements for Jupyter
 ipytree==0.2.2
 ipywidgets==8.1.5
-# optional library requirements for services
-# don't let pyup change pinning for azure-storage-blob, need to pin to older
-# version to get compatibility with azure storage emulator on appveyor (FIXME)
-azure-storage-blob==12.21.0 # pyup: ignore
+azure-storage-blob==12.24.1
 redis==5.1.1
 types-redis
 types-setuptools

--- a/zarr/_storage/absstore.py
+++ b/zarr/_storage/absstore.py
@@ -231,7 +231,7 @@ class ABSStore(Store):
             elif not fs_path.endswith("/"):
                 fs_path += "/"
             for blob in self.client.walk_blobs(name_starts_with=fs_path, delimiter="/"):
-                blob_client = self.client.get_blob_client(blob)
+                blob_client = self.client.get_blob_client(blob.name)
                 if blob_client.exists():
                     size += blob_client.get_blob_properties().size
             return size


### PR DESCRIPTION
A quick attempt at getting v2 dependency upgrades working again (see https://github.com/zarr-developers/zarr-python/pull/2879).