### PR TITLE
refer to zulip chat as developer chat

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: A new major feature should be discussed in the Zarr specifications repository.
   - name: Discuss something on ZulipChat
     url: https://ossci.zulipchat.com/
-    about: For questions like "How do I do X with Zarr?", you can move to our ZulipChat.
+    about: For questions like "How do I do X with Zarr?", consider posting your question to our developer chat.
   - name: Discuss something on GitHub Discussions
     url: https://github.com/zarr-developers/zarr-python/discussions
     about: For questions like "How do I do X with Zarr?", you can move to GitHub Discussions.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
   </td>
 </tr>
 <tr>
-	<td>Zulip</td>
+	<td>Developer Chat</td>
 	<td>
 		<a href="https://ossci.zulipchat.com/">
 		<img src="https://img.shields.io/badge/zulip-join_chat-brightgreen.svg" />

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Zarr-Python
 **Useful links**:
 `Source Repository <https://github.com/zarr-developers/zarr-python>`_ |
 `Issue Tracker <https://github.com/zarr-developers/zarr-python/issues>`_ |
-`Zulip Chat <https://ossci.zulipchat.com/>`_ |
+`Developer Chat <https://ossci.zulipchat.com/>`_ |
 `Zarr specifications <https://zarr-specs.readthedocs.io>`_
 
 Zarr-Python is a Python library for reading and writing Zarr groups and arrays. Highlights include:


### PR DESCRIPTION
Various places in the docs say something like "here is our zulip [link to zulip chat]". I think it's better to say "here is our developer chat [link to zulip chat]".
Two main reasons for this change:
- People might not know what zulip is. But they will know what developer chat is.
- We might hypothetically switch chat platforms. With these changes, we would only need to update the hyperlink.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
