### PR TITLE
Disable `W` ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,6 @@ extend-select = [
     "TCH",  # flake8-type-checking
     "TRY",  # tryceratops
     "UP",   # pyupgrade
-    "W",    # pycodestyle warnings
 ]
 ignore = [
     "ANN401",


### PR DESCRIPTION
`W` rules are not needed if using a formatter, according to the Scientific Python Library Development Guide:
	https://learn.scientific-python.org/development/guides/style/#ruff

> * `E`, `F`, `W`: These are the standard flake8 checks, classic checks that have stood the test of time. Not required if you use `extend-select` (`W` not needed if you use a formatter)

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
