### PR TITLE
fix: restore attrs del functionality

### DIFF
--- a/changes/2908.bugfix.rst
+++ b/changes/2908.bugfix.rst
@@ -1,0 +1,1 @@
+Restore functionality of `del z.attrs['key']` to actually delete the key.

--- a/src/zarr/core/attributes.py
+++ b/src/zarr/core/attributes.py
@@ -28,7 +28,7 @@ class Attributes(MutableMapping[str, JSON]):
     def __delitem__(self, key: str) -> None:
         new_attrs = dict(self._obj.metadata.attributes)
         del new_attrs[key]
-        self._obj = self._obj.update_attributes(new_attrs)
+        self.put(new_attrs)
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._obj.metadata.attributes)

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -59,3 +59,12 @@ def test_update_no_changes() -> None:
 
     z.update_attributes({})
     assert dict(z.attrs) == {"a": [], "b": 3}
+
+
+def test_del_works() -> None:
+    store = zarr.storage.MemoryStore()
+    z = zarr.create(10, store=store, overwrite=True)
+    assert dict(z.attrs) == {}
+    z.update_attributes({"a": [3, 4], "c": 4})
+    del z.attrs["a"]
+    assert "c" in z.attrs

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -66,6 +66,7 @@ def test_update_no_changes() -> None:
 @pytest.mark.parametrize("group", [True, False])
 def test_del_works(group: bool) -> None:
     store = zarr.storage.MemoryStore()
+    z: zarr.Group | zarr.Array
     if group:
         z = zarr.create_group(store)
     else:
@@ -75,6 +76,7 @@ def test_del_works(group: bool) -> None:
     del z.attrs["a"]
     assert dict(z.attrs) == {"c": 4}
 
+    z2: zarr.Group | zarr.Array
     if group:
         z2 = zarr.open_group(store)
     else:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -67,4 +67,5 @@ def test_del_works() -> None:
     assert dict(z.attrs) == {}
     z.update_attributes({"a": [3, 4], "c": 4})
     del z.attrs["a"]
+    assert "a" not in z.attrs
     assert "c" in z.attrs


### PR DESCRIPTION
Restore the bevahior of `del obj.attrs['some-key']` to the pre #2870 behavior

Fixes: https://github.com/zarr-developers/zarr-python/issues/2903

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
