### PR TITLE
fix(storage): accept pytest tmp_dir as valid store_like paths

### DIFF
--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -346,7 +346,7 @@ def _is_pytest_legacy_path(path: Any) -> bool:
     # https://docs.pytest.org/en/stable/how-to/tmp_path.html#tmp-path
     try:
         from _pytest.compat import LEGACY_PATH
-    except ImportError:
+    except ImportError:  # pragma: no cover
         return False
     return isinstance(path, LEGACY_PATH)
 

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -297,6 +297,8 @@ async def make_store_path(
             store = await MemoryStore.open(read_only=_read_only)
         elif isinstance(store_like, Path):
             store = await LocalStore.open(root=store_like, read_only=_read_only)
+        elif _is_pytest_legacy_path(store_like):
+            store = await LocalStore.open(root=Path(str(store_like)), read_only=_read_only)
         elif isinstance(store_like, str):
             storage_options = storage_options or {}
 
@@ -338,6 +340,15 @@ def _is_fsspec_uri(uri: str) -> bool:
     False
     """
     return "://" in uri or ("::" in uri and "local://" not in uri)
+
+
+def _is_pytest_legacy_path(path: Any) -> bool:
+    # https://docs.pytest.org/en/stable/how-to/tmp_path.html#tmp-path
+    try:
+        from _pytest.compat import LEGACY_PATH
+    except ImportError:
+        return False
+    return isinstance(path, LEGACY_PATH)
 
 
 async def ensure_no_existing_node(store_path: StorePath, zarr_format: ZarrFormat) -> None:

--- a/tests/test_store/test_core.py
+++ b/tests/test_store/test_core.py
@@ -64,18 +64,22 @@ async def test_make_store_path_none(path: str) -> None:
 
 
 @pytest.mark.parametrize("path", [None, "", "bar"])
-@pytest.mark.parametrize("store_type", [str, Path])
+@pytest.mark.parametrize("store_type", [str, Path, LEGACY_PATH])
 @pytest.mark.parametrize("mode", ["r", "w"])
 async def test_make_store_path_local(
     tmpdir: LEGACY_PATH,
-    store_type: type[str] | type[Path] | type[LocalStore],
+    store_type: type[str] | type[Path] | type[LEGACY_PATH],
     path: str,
     mode: AccessModeLiteral,
 ) -> None:
     """
     Test the various ways of invoking make_store_path that create a LocalStore
     """
-    store_like = store_type(str(tmpdir))
+
+    if store_type is LEGACY_PATH:
+        store_like = tmpdir
+    else:
+        store_like = store_type(tmpdir)
     store_path = await make_store_path(store_like, path=path, mode=mode)
     assert isinstance(store_path.store, LocalStore)
     assert Path(store_path.store.root) == Path(tmpdir)


### PR DESCRIPTION
This PR adjusts the logic in `make_store_path` to accept pytest's `tmp_dir` fixture as a valid store_like argument. This worked in Zarr 2 and the fix here brings back the prior behavior.

An alternative approach would have been to cast any unknown argument type to a string but this seemed less safe.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
