### PR TITLE
Fix: respect `config` when opening an existing array

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -324,7 +324,11 @@ async def open(
             zarr_format = _metadata_dict["zarr_format"]
             is_v3_array = zarr_format == 3 and _metadata_dict.get("node_type") == "array"
             if is_v3_array or zarr_format == 2:
-                return AsyncArray(store_path=store_path, metadata=_metadata_dict)
+                return AsyncArray(
+                    store_path=store_path,
+                    metadata=_metadata_dict,
+                    config=kwargs.pop("config", None),
+                )
         except (AssertionError, FileNotFoundError, NodeTypeValidationError):
             pass
         return await open_group(store=store_path, zarr_format=zarr_format, mode=mode, **kwargs)

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -869,6 +869,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         cls,
         store: StoreLike,
         zarr_format: ZarrFormat | None = 3,
+        config: ArrayConfigLike | None = None,
     ) -> AsyncArray[ArrayV3Metadata] | AsyncArray[ArrayV2Metadata]:
         """
         Async method to open an existing Zarr array from a given store.
@@ -879,6 +880,8 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             The store containing the Zarr array.
         zarr_format : ZarrFormat | None, optional
             The Zarr format version (default is 3).
+        config : ArrayConfigLike, optional
+            Runtime configuration for the array.
 
         Returns
         -------
@@ -896,7 +899,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         metadata_dict = await get_array_metadata(store_path, zarr_format=zarr_format)
         # TODO: remove this cast when we have better type hints
         _metadata_dict = cast(ArrayV3MetadataDict, metadata_dict)
-        return cls(store_path=store_path, metadata=_metadata_dict)
+        return cls(store_path=store_path, metadata=_metadata_dict, config=config)
 
     @property
     def store(self) -> Store:

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -746,6 +746,44 @@ def test_resize_2d(store: MemoryStore, zarr_format: ZarrFormat) -> None:
     assert new_shape == z[:].shape
 
 
+@pytest.mark.parametrize("store", ["local"], indirect=True)
+@pytest.mark.parametrize("open", ["open", "open_array"])
+def test_append_config_passed(store: LocalStore, open: str, zarr_format: ZarrFormat) -> None:
+    z = zarr.create_array(
+        store=store,
+        name="test",
+        shape=(2,),
+        dtype=int,
+        fill_value=0,
+        chunks=(1,),
+        config={"write_empty_chunks": True},
+        overwrite=True,
+        zarr_format=zarr_format,
+    )
+    z[:] = 0
+    print(store)
+
+    def assert_correct_files_written(expected: list[str]) -> None:
+        """Helper to compare written files"""
+        if zarr_format == 2:
+            actual = [f.name for f in store.root.rglob("test/*")]
+        else:
+            actual = [f.name for f in store.root.rglob("test/c/*")]
+        actual = [f for f in actual if f not in [".zattrs", ".zarray", "zarr.json"]]
+        assert sorted(expected) == sorted(actual)
+
+    assert_correct_files_written(["0", "1"])
+
+    # parametrized over open and open_array
+    z = getattr(zarr, open)(store, path="test", config={"write_empty_chunks": True}, fill_value=0)
+    z.resize((4,))
+    assert_correct_files_written(["0", "1"])
+    z[2:] = 0
+    assert_correct_files_written(["0", "1", "2", "3"])
+    z[:] = 0
+    assert_correct_files_written(["0", "1", "2", "3"])
+
+
 @pytest.mark.parametrize("store", ["memory"], indirect=True)
 def test_append_1d(store: MemoryStore, zarr_format: ZarrFormat) -> None:
     a = np.arange(105)


### PR DESCRIPTION

Fixes https://github.com/zarr-developers/zarr-python/issues/2931 

Previously there were edge cases with open which would result in the `write_empty_chunks` config was being ignored. This PR has two separate fixes.
1st: for `zarr.open` line 327
2nd: `zarr.open_array` required some config parsing as well as a change to the api of `AsyncArray.open`


* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [NA] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
