### PR TITLE
Avoid memory copy in local store write

### DIFF
--- a/changes/2944.misc.rst
+++ b/changes/2944.misc.rst
@@ -1,0 +1,1 @@
+Avoid an unnecessary memory copy when writing Zarr to a local file

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -51,7 +51,7 @@ def _put(
     if start is not None:
         with path.open("r+b") as f:
             f.seek(start)
-            f.write(value.as_numpy_array())
+            f.write(value.as_numpy_array())  # type: ignore[arg-type]
         return None
     else:
         view = memoryview(value.as_numpy_array())

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -51,6 +51,7 @@ def _put(
     if start is not None:
         with path.open("r+b") as f:
             f.seek(start)
+            # write takes any object supporting the buffer protocol
             f.write(value.as_numpy_array())  # type: ignore[arg-type]
         return None
     else:
@@ -60,6 +61,7 @@ def _put(
         else:
             mode = "wb"
         with path.open(mode=mode) as f:
+            # write takes any object supporting the buffer protocol
             return f.write(view)
 
 

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -51,10 +51,10 @@ def _put(
     if start is not None:
         with path.open("r+b") as f:
             f.seek(start)
-            f.write(value.as_numpy_array().tobytes())
+            f.write(value.as_numpy_array())
         return None
     else:
-        view = memoryview(value.as_numpy_array().tobytes())
+        view = memoryview(value.as_numpy_array())
         if exclusive:
             mode = "xb"
         else:

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -54,7 +54,7 @@ def _put(
             f.write(value.as_numpy_array())  # type: ignore[arg-type]
         return None
     else:
-        view = memoryview(value.as_numpy_array())
+        view = memoryview(value.as_numpy_array())  # type: ignore[arg-type]
         if exclusive:
             mode = "xb"
         else:


### PR DESCRIPTION
This removes an unnecessary memory copy when writing to a local file, bringing the memory usage in line with Zarr Python v2 for this case (see https://github.com/tomwhite/memray-array).

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
