### PR TITLE
Remove `mode` arg usage in `create_array`

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,7 +72,7 @@ Zarr supports data compression and filters. For example, to use Blosc compressio
 
     >>> z = zarr.create_array(
     ...    "data/example-3.zarr",
-    ...    mode="w", shape=(100, 100),
+    ...    shape=(100, 100),
     ...    chunks=(10, 10), dtype="f4",
     ...    compressors=zarr.codecs.BloscCodec(cname="zstd", clevel=3, shuffle=zarr.codecs.BloscShuffle.shuffle)
     ... )
@@ -153,7 +153,7 @@ using external libraries like `s3fs <https://s3fs.readthedocs.io>`_ or
 
     >>> import s3fs # doctest: +SKIP
     >>>
-    >>> z = zarr.create_array("s3://example-bucket/foo", mode="w", shape=(100, 100), chunks=(10, 10), dtype="f4") # doctest: +SKIP
+    >>> z = zarr.create_array("s3://example-bucket/foo", shape=(100, 100), chunks=(10, 10), dtype="f4") # doctest: +SKIP
     >>> z[:, :] = np.random.random((100, 100)) # doctest: +SKIP
 
 A single-file store can also be created using the the :class:`zarr.storage.ZipStore`::
@@ -163,7 +163,6 @@ A single-file store can also be created using the the :class:`zarr.storage.ZipSt
     >>>
     >>> z = zarr.create_array(
     ...     store=store,
-    ...     mode="w",
     ...     shape=(100, 100),
     ...     chunks=(10, 10),
     ...     dtype="f4"


### PR DESCRIPTION
Quickstart tutorial code gave an error upon incorrect usage of mode argument in `zarr.create_array()`. So I tried removing it in this fix. Let me know if same is needed for `zarr.open_array()`.
It was interesting to see that `zarr.storage.ZipStore()` still takes mode argument.