### PR TITLE
Pin numcodecs to < 0.16 to fix v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ docs = [
     'sphinx-copybutton',
     'pydata-sphinx-theme',
     'numpydoc',
-    'numcodecs[msgpack]!=0.14.0,!=0.14.1',
+    'numcodecs[msgpack]!=0.14.0,!=0.14.1,<0.16',
     'pytest-doctestplus',
 ]
 


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/2963 - I think worth getting this in and doing a release straight away, since it unbreaks an installation with just `pip install zarr<3`