### PR TITLE
Improve return types for public API

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -9,7 +9,8 @@ import numpy as np
 import numpy.typing as npt
 from typing_extensions import deprecated
 
-from zarr.core.array import Array, AsyncArray, create_array, get_array_metadata
+from zarr import Array, AsyncArray, AsyncGroup
+from zarr.core.array import create_array, get_array_metadata
 from zarr.core.array_spec import ArrayConfig, ArrayConfigLike, ArrayConfigParams
 from zarr.core.buffer import NDArrayLike
 from zarr.core.common import (
@@ -24,7 +25,6 @@ from zarr.core.common import (
     parse_dtype,
 )
 from zarr.core.group import (
-    AsyncGroup,
     ConsolidatedMetadata,
     GroupMetadata,
     create_hierarchy,

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -6,9 +6,8 @@ from typing_extensions import deprecated
 
 import zarr.api.asynchronous as async_api
 import zarr.core.array
+from zarr import Array, AsyncArray, Group
 from zarr._compat import _deprecate_positional_args
-from zarr.core.array import Array, AsyncArray
-from zarr.core.group import Group
 from zarr.core.sync import sync
 from zarr.core.sync_group import create_hierarchy
 


### PR DESCRIPTION
This updates the return types in the public API to be public objects, where a group or array is returned.

Currently the return typing for the top level namespace (see the [API ref here](https://zarr.readthedocs.io/en/stable/api/zarr/index.html#functions)) has objects from `zarr.core.*`. This PR uses public objects in `zarr.*` instead.