### PR TITLE
More consistent store docstrings

### DIFF
--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -32,7 +32,7 @@ ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
 
 class FsspecStore(Store):
     """
-    A remote Store based on FSSpec
+    Store for remote data based on FSSpec.
 
     Parameters
     ----------

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -67,7 +67,7 @@ def _put(
 
 class LocalStore(Store):
     """
-    Local file system store.
+    Store for the local file system.
 
     Parameters
     ----------

--- a/src/zarr/storage/_logging.py
+++ b/src/zarr/storage/_logging.py
@@ -24,7 +24,7 @@ T_Store = TypeVar("T_Store", bound=Store)
 
 class LoggingStore(WrapperStore[T_Store]):
     """
-    Store wrapper that logs all calls to the wrapped store.
+    Store that logs all calls to another wrapped store.
 
     Parameters
     ----------

--- a/src/zarr/storage/_memory.py
+++ b/src/zarr/storage/_memory.py
@@ -19,7 +19,7 @@ logger = getLogger(__name__)
 
 class MemoryStore(Store):
     """
-    In-memory store.
+    Store for local memory.
 
     Parameters
     ----------
@@ -173,8 +173,10 @@ class MemoryStore(Store):
 
 
 class GpuMemoryStore(MemoryStore):
-    """A GPU only memory store that stores every chunk in GPU memory irrespective
-    of the original location.
+    """
+    Store for GPU memory.
+
+    Stores every chunk in GPU memory irrespective of the original location.
 
     The dictionary of buffers to initialize this memory store with *must* be
     GPU Buffers.

--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -37,7 +37,8 @@ _ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (
 
 
 class ObjectStore(Store):
-    """A Zarr store that uses obstore for fast read/write from AWS, GCP, Azure.
+    """
+    Store that uses obstore for fast read/write from AWS, GCP, Azure.
 
     Parameters
     ----------

--- a/src/zarr/storage/_wrapper.py
+++ b/src/zarr/storage/_wrapper.py
@@ -18,7 +18,8 @@ T_Store = TypeVar("T_Store", bound=Store)
 
 class WrapperStore(Store, Generic[T_Store]):
     """
-    A store class that wraps an existing ``Store`` instance.
+    Store that wraps an existing Store.
+
     By default all of the store methods are delegated to the wrapped store instance, which is
     accessible via the ``._store`` attribute of this class.
 

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -24,7 +24,7 @@ ZipStoreAccessModeLiteral = Literal["r", "w", "a"]
 
 class ZipStore(Store):
     """
-    Storage class using a ZIP file.
+    Store using a ZIP file.
 
     Parameters
     ----------


### PR DESCRIPTION
This makes the 'style' the same for the first sentence in each store. This should give a more consistent and readable [API reference table](https://zarr.readthedocs.io/en/latest/api/zarr/storage/#classes).

If we're not going to mess around with the API listing, then I think this would fix https://github.com/zarr-developers/zarr-python/issues/2905.