### PR TITLE
Improve write performance of shards

### DIFF
--- a/bench/write_shard.py
+++ b/bench/write_shard.py
@@ -1,0 +1,66 @@
+import itertools
+import os.path
+import shutil
+import sys
+import tempfile
+import timeit
+
+import line_profiler
+import numpy as np
+
+import zarr
+import zarr.codecs
+import zarr.codecs.sharding
+
+if __name__ == "__main__":
+    sys.path.insert(0, "..")
+
+    # setup
+    with tempfile.TemporaryDirectory() as path:
+
+        ndim = 3
+        opt = {
+            'shape': [1024]*ndim,
+            'chunks': [128]*ndim,
+            'shards': [512]*ndim,
+            'dtype': np.float64,
+        }
+
+        store = zarr.storage.LocalStore(path)
+        z = zarr.create_array(store, **opt)
+        print(z)
+
+        def cleanup() -> None:
+            for elem in os.listdir(path):
+                elem = os.path.join(path, elem)
+                if not elem.endswith(".json"):
+                    if os.path.isdir(elem):
+                        shutil.rmtree(elem)
+                    else:
+                        os.remove(elem)
+
+        def write() -> None:
+            wchunk = [512]*ndim
+            nwchunks = [n//s for n, s in zip(opt['shape'], wchunk, strict=True)]
+            for shard in itertools.product(*(range(n) for n in nwchunks)):
+                slicer = tuple(
+                    slice(i*n, (i+1)*n)
+                    for i, n in zip(shard, wchunk, strict=True)
+                )
+                d = np.random.rand(*wchunk).astype(opt['dtype'])
+                z[slicer] = d
+
+        print("*" * 79)
+
+        # time
+        vars = {"write": write, "cleanup": cleanup, "z": z, "opt": opt}
+        t = timeit.repeat("write()", "cleanup()", repeat=2, number=1, globals=vars)
+        print(t)
+        print(min(t))
+        print(z)
+
+        # profile
+        # f = zarr.codecs.sharding.ShardingCodec._encode_partial_single
+        # profile = line_profiler.LineProfiler(f)
+        # profile.run("write()")
+        # profile.print_stats()

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -251,7 +251,7 @@ class _ShardBuilder(_ShardReader, ShardMutableMapping):
         if buffer_prototype is None:
             buffer_prototype = default_buffer_prototype()
         obj = cls()
-        obj.buf = buffer_prototype.buffer.create_zero_length()
+        obj.buf = buffer_prototype.buffer.Delayed.create_zero_length()
         obj.index = _ShardIndex.create_empty(chunks_per_shard)
         return obj
 
@@ -585,15 +585,16 @@ class ShardingCodec(
         chunks_per_shard = self._get_chunks_per_shard(shard_spec)
         chunk_spec = self._get_chunk_spec(shard_spec)
 
-        shard_dict = _MergingShardBuilder(
-            await self._load_full_shard_maybe(
-                byte_getter=byte_setter,
-                prototype=chunk_spec.prototype,
-                chunks_per_shard=chunks_per_shard,
-            )
-            or _ShardReader.create_empty(chunks_per_shard),
-            _ShardBuilder.create_empty(chunks_per_shard),
+        shard_read = await self._load_full_shard_maybe(
+            byte_getter=byte_setter,
+            prototype=chunk_spec.prototype,
+            chunks_per_shard=chunks_per_shard,
         )
+        shard_build = _ShardBuilder.create_empty(chunks_per_shard)
+        if shard_read:
+            shard_dict = _MergingShardBuilder(shard_read, shard_build)
+        else:
+            shard_dict = shard_build
 
         indexer = list(
             get_indexer(

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -196,6 +196,24 @@ class DelayedBuffer(core.DelayedBuffer, Buffer):
         core.DelayedBuffer.__init__(self, array)
         self._data_list = list(map(np.asanyarray, self._data_list))
 
+    @classmethod
+    def create_zero_length(cls) -> Self:
+        return cls(np.array([], dtype="b"))
+
+    @classmethod
+    def from_buffer(cls, buffer: core.Buffer) -> Self:
+        if isinstance(buffer, cls):
+            return cls(buffer._data_list)
+        else:
+            return cls(buffer._data)
+
+    @classmethod
+    def from_bytes(cls, bytes_like: BytesLike) -> Self:
+        return cls(np.asarray(bytes_like, dtype="b"))
+
+    def as_numpy_array(self) -> npt.NDArray[Any]:
+        return np.asanyarray(self._data)
+
 
 Buffer.Delayed = DelayedBuffer
 

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -185,43 +185,16 @@ class NDBuffer(core.NDBuffer):
         self._data.__setitem__(key, value)
 
 
-class DelayedBuffer(Buffer):
+class DelayedBuffer(core.DelayedBuffer, Buffer):
     """
     A Buffer that is the virtual concatenation of other buffers.
     """
+    _BufferImpl = Buffer
+    _concatenate = np.concatenate
 
     def __init__(self, array: NDArrayLike | list[NDArrayLike] | None) -> None:
-        if array is None:
-            self._data_list = []
-        elif isinstance(array, list):
-            self._data_list = list(array)
-        else:
-            self._data_list = [array]
-        for array in self._data_list:
-            if array.ndim != 1:
-                raise ValueError("array: only 1-dim allowed")
-            if array.dtype != np.dtype("b"):
-                raise ValueError("array: only byte dtype allowed")
-
-    @property
-    def _data(self) -> npt.NDArray[Any]:
-        return np.concatenate(self._data_list)
-
-    @classmethod
-    def from_buffer(cls, buffer: core.Buffer) -> Self:
-        if isinstance(buffer, cls):
-            return cls(buffer._data_list)
-        else:
-            return cls(buffer._data)
-
-    def __add__(self, other: core.Buffer) -> Self:
-        if isinstance(other, self.__class__):
-            return self.__class__(self._data_list + other._data_list)
-        else:
-            return self.__class__(self._data_list + [other._data])
-
-    def __len__(self) -> int:
-        return sum(map(len, self._data_list))
+        core.DelayedBuffer.__init__(self, array)
+        self._data_list = list(map(np.asanyarray, self._data_list))
 
 
 Buffer.Delayed = DelayedBuffer

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -218,6 +218,49 @@ class NDBuffer(core.NDBuffer):
         self._data.__setitem__(key, value)
 
 
+class DelayedBuffer(Buffer):
+    """
+    A Buffer that is the virtual concatenation of other buffers.
+    """
+
+    def __init__(self, array: NDArrayLike | list[NDArrayLike] | None) -> None:
+        if array is None:
+            self._data_list = []
+        elif isinstance(array, list):
+            self._data_list = list(array)
+        else:
+            self._data_list = [array]
+        for array in self._data_list:
+            if array.ndim != 1:
+                raise ValueError("array: only 1-dim allowed")
+            if array.dtype != np.dtype("b"):
+                raise ValueError("array: only byte dtype allowed")
+        self._data_list = list(map(cp.asarray, self._data_list))
+
+    @property
+    def _data(self) -> npt.NDArray[Any]:
+        return cp.concatenate(self._data_list)
+
+    @classmethod
+    def from_buffer(cls, buffer: core.Buffer) -> Self:
+        if isinstance(buffer, cls):
+            return cls(buffer._data_list)
+        else:
+            return cls(buffer._data)
+
+    def __add__(self, other: core.Buffer) -> Self:
+        if isinstance(other, self.__class__):
+            return self.__class__(self._data_list + other._data_list)
+        else:
+            return self.__class__(self._data_list + [other._data])
+
+    def __len__(self) -> int:
+        return sum(map(len, self._data_list))
+
+
+Buffer.Delayed = DelayedBuffer
+
+
 buffer_prototype = BufferPrototype(buffer=Buffer, nd_buffer=NDBuffer)
 
 register_buffer(Buffer)

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -218,44 +218,16 @@ class NDBuffer(core.NDBuffer):
         self._data.__setitem__(key, value)
 
 
-class DelayedBuffer(Buffer):
+class DelayedBuffer(core.DelayedBuffer, Buffer):
     """
     A Buffer that is the virtual concatenation of other buffers.
     """
+    _BufferImpl = Buffer
+    _concatenate = getattr(cp, 'concatenate', None)
 
     def __init__(self, array: NDArrayLike | list[NDArrayLike] | None) -> None:
-        if array is None:
-            self._data_list = []
-        elif isinstance(array, list):
-            self._data_list = list(array)
-        else:
-            self._data_list = [array]
-        for array in self._data_list:
-            if array.ndim != 1:
-                raise ValueError("array: only 1-dim allowed")
-            if array.dtype != np.dtype("b"):
-                raise ValueError("array: only byte dtype allowed")
+        core.DelayedBuffer.__init__(self, array)
         self._data_list = list(map(cp.asarray, self._data_list))
-
-    @property
-    def _data(self) -> npt.NDArray[Any]:
-        return cp.concatenate(self._data_list)
-
-    @classmethod
-    def from_buffer(cls, buffer: core.Buffer) -> Self:
-        if isinstance(buffer, cls):
-            return cls(buffer._data_list)
-        else:
-            return cls(buffer._data)
-
-    def __add__(self, other: core.Buffer) -> Self:
-        if isinstance(other, self.__class__):
-            return self.__class__(self._data_list + other._data_list)
-        else:
-            return self.__class__(self._data_list + [other._data])
-
-    def __len__(self) -> int:
-        return sum(map(len, self._data_list))
 
 
 Buffer.Delayed = DelayedBuffer

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -229,6 +229,24 @@ class DelayedBuffer(core.DelayedBuffer, Buffer):
         core.DelayedBuffer.__init__(self, array)
         self._data_list = list(map(cp.asarray, self._data_list))
 
+    @classmethod
+    def create_zero_length(cls) -> Self:
+        return cls(np.array([], dtype="b"))
+
+    @classmethod
+    def from_buffer(cls, buffer: core.Buffer) -> Self:
+        if isinstance(buffer, cls):
+            return cls(buffer._data_list)
+        else:
+            return cls(buffer._data)
+
+    @classmethod
+    def from_bytes(cls, bytes_like: BytesLike) -> Self:
+        return cls(np.asarray(bytes_like, dtype="b"))
+
+    def as_numpy_array(self) -> npt.NDArray[Any]:
+        return np.asanyarray(self._data)
+
 
 Buffer.Delayed = DelayedBuffer
 


### PR DESCRIPTION
The poor write performance of sharded zarrs in the zarr-python implementation is currently a major limiting factor to its adoption by our group. We found that writing shard-by-shard in an empty sharded array is one magnitude slower than writing in unsharded zarrs. This is surprising, as writing full shards should only be marginally slower than writing unsharded chunks.

While [this 2023 discussion](https://github.com/zarr-developers/zarr-python/discussions/1338) suggests that the latency is caused by the re-generation of the index table, this does not seem to be the case in the latest implementation, which saves all chunks in memory and (properly) waits for all chunks to be available before generating the index table (see [`_encode_partial_single`](https://github.com/zarr-developers/zarr-python/blob/018f61d93207112f68eba06ea8c2560a489767f6/src/zarr/codecs/sharding.py#L576)).

Instead I found that a major cause of slowdown comes from the implementation of the `Buffer` class, which calls `np.concatenate` every time bytes are added to the buffer. As a proof of concept, I have implemented an alternative `DelayedBuffer` class that keeps individual byte chunks in a list, and only concatenates them when needed. On a simple benchmark that uses `512**3` shards and `128**3` chunks and a local store, it reduces the time to write one shard from ~10 sec to ~1 sec, which is on par with the time taken to write the same `512**3` array in an unsharded zarr (~0.9 sec).

I am keeping this as a draft for now as it is a hacky proof-of-concept implementation, but I am happy to clean it up if this is found to be a good solution (with guidance on how to implement the delayed buffer in a way that is compatible with the buffer prototype logic, which I don't fully understand). All tests pass except one that checks whether a store receives a `TestBuffer` (as it instead receives a `DelayedBuffer).

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
