### PR TITLE
Ignore stale children when reconsolidating metadata

### DIFF
--- a/changes/2921.bugfix.rst
+++ b/changes/2921.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore stale child metadata when reconsolidating metadata.

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -193,7 +193,10 @@ async def consolidate_metadata(
     group = await AsyncGroup.open(store_path, zarr_format=zarr_format, use_consolidated=False)
     group.store_path.store._check_writable()
 
-    members_metadata = {k: v.metadata async for k, v in group.members(max_depth=None)}
+    members_metadata = {
+        k: v.metadata
+        async for k, v in group.members(max_depth=None, use_consolidated_for_children=False)
+    }
     # While consolidating, we want to be explicit about when child groups
     # are empty by inserting an empty dict for consolidated_metadata.metadata
     for k, v in members_metadata.items():

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -573,3 +573,47 @@ class TestConsolidated:
             assert len([x async for x in good.members()]) == 2
             assert good.metadata.consolidated_metadata
             assert sorted(good.metadata.consolidated_metadata.metadata) == ["a", "b"]
+
+    async def test_stale_child_metadata_ignored(self, memory_store: zarr.storage.MemoryStore):
+        # https://github.com/zarr-developers/zarr-python/issues/2921
+        # When consolidating metadata, we should ignore any (possibly stale) metadata
+        # from previous consolidations, *including at child nodes*.
+        root = await zarr.api.asynchronous.group(store=memory_store, zarr_format=3)
+        await root.create_group("foo")
+        await zarr.api.asynchronous.consolidate_metadata(memory_store, path="foo")
+        await root.create_group("foo/bar/spam")
+
+        await zarr.api.asynchronous.consolidate_metadata(memory_store)
+
+        reopened = await zarr.api.asynchronous.open_consolidated(store=memory_store, zarr_format=3)
+        result = [x[0] async for x in reopened.members(max_depth=None)]
+        expected = ["foo", "foo/bar", "foo/bar/spam"]
+        assert result == expected
+
+    async def test_use_consolidated_for_children_members(
+        self, memory_store: zarr.storage.MemoryStore
+    ):
+        # A test that has *unconsolidated* metadata at the root group, but discovers
+        # a child group with consolidated metadata.
+
+        root = await zarr.api.asynchronous.create_group(store=memory_store)
+        await root.create_group("a/b")
+        # Consolidate metadata at "a/b"
+        await zarr.api.asynchronous.consolidate_metadata(memory_store, path="a/b")
+
+        # Add a new group a/b/c, that's not present in the CM at "a/b"
+        await root.create_group("a/b/c")
+
+        # Now according to the consolidated metadata, "a" has children ["b"]
+        # but according to the unconsolidated metadata, "a" has children ["b", "c"]
+        group = await zarr.api.asynchronous.open_group(store=memory_store, path="a")
+        with pytest.warns(UserWarning, match="Object at 'c' not found"):
+            result = sorted([x[0] async for x in group.members(max_depth=None)])
+        expected = ["b"]
+        assert result == expected
+
+        result = sorted(
+            [x[0] async for x in group.members(max_depth=None, use_consolidated_for_children=False)]
+        )
+        expected = ["b", "b/c"]
+        assert result == expected


### PR DESCRIPTION
This fixes a bug when recreating consolidated metadata, when one of the child groups picked up had (stale) consolidated metadata.

In `consolidate_metadata`, we already ignore the `group.metadata.consolidated_metadata` for the root group. The fix is to *also* ignore the consolidated metadata for any child nodes loaded by `.members()`.

For now, I've made this a new public parameter in `.members()`. It might be worth keeping it private (by making a `_members_private` method that takes this parameter). I don't immediately see any other use case for this parameter.

Closes #2921 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
