### PR TITLE
fix: wrap the fsspec fs in an AsyncWrapper also if it is called with asynchronouos=False

### DIFF
--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -94,7 +94,7 @@ class FsspecStore(Store):
         self.path = path
         self.allowed_exceptions = allowed_exceptions
 
-        if not self.fs.async_impl:
+        if not self.fs.async_impl or not self.fs.asynchronous:
             raise TypeError("Filesystem needs to support async operations.")
         if not self.fs.asynchronous:
             warnings.warn(


### PR DESCRIPTION
If a zarr is open from an fsspec URL, like `simplecache::https://some.url.org` it failed because the underlying fsspec filesystem (simplecache) is an `AsyncFileSystem` but it is not instantiated with `asynchronouos=True`. This led to errors.

This PR wraps the `fs` in an `AsyncFileSystemWrapper` to ensure that it is asynchronouos.

TODO:
* ~~[ ] Add unit tests and/or doctests in docstrings~~
* ~~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~~
* ~~[ ] New/modified features documented in `docs/user-guide/*.rst`~~
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
