### PR TITLE
Fix nan encoding in consolidated metadata

### DIFF
--- a/changes/2996.bugfix.rst
+++ b/changes/2996.bugfix.rst
@@ -1,0 +1,4 @@
+Fixes `ConsolidatedMetadata` serialization of `nan`, `inf`, and `-inf` to be
+consistent with the behavior of `ArrayMetadata`.
+
+

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -334,7 +334,7 @@ class GroupMetadata(Metadata):
         if self.zarr_format == 3:
             return {
                 ZARR_JSON: prototype.buffer.from_bytes(
-                    json.dumps(self.to_dict(), cls=V3JsonEncoder).encode()
+                    json.dumps(_replace_special_floats(self.to_dict()), cls=V3JsonEncoder).encode()
                 )
             }
         else:

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -49,7 +49,7 @@ from zarr.core.common import (
 )
 from zarr.core.config import config
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
-from zarr.core.metadata.v3 import V3JsonEncoder
+from zarr.core.metadata.v3 import V3JsonEncoder, _replace_special_floats
 from zarr.core.sync import SyncMixin, sync
 from zarr.errors import ContainsArrayError, ContainsGroupError, MetadataValidationError
 from zarr.storage import StoreLike, StorePath
@@ -355,10 +355,10 @@ class GroupMetadata(Metadata):
                 assert isinstance(consolidated_metadata, dict)
                 for k, v in consolidated_metadata.items():
                     attrs = v.pop("attributes", None)
-                    d[f"{k}/{ZATTRS_JSON}"] = attrs
+                    d[f"{k}/{ZATTRS_JSON}"] = _replace_special_floats(attrs)
                     if "shape" in v:
                         # it's an array
-                        d[f"{k}/{ZARRAY_JSON}"] = v
+                        d[f"{k}/{ZARRAY_JSON}"] = _replace_special_floats(v)
                     else:
                         d[f"{k}/{ZGROUP_JSON}"] = {
                             "zarr_format": self.zarr_format,

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -575,7 +575,6 @@ class TestConsolidated:
             assert sorted(good.metadata.consolidated_metadata.metadata) == ["a", "b"]
 
 
-@pytest.mark.parametrize("zarr_format", [2, 3])
 @pytest.mark.parametrize("fill_value", [np.nan, np.inf, -np.inf])
 async def test_consolidated_metadata_encodes_special_chars(
     memory_store: Store, zarr_format: ZarrFormat, fill_value: float


### PR DESCRIPTION
Fixes #2990 by reusing the special character replacement before encoding the same as the v3 metadata does 

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
