### PR TITLE
updated migration documention to say that '.' syntax is no longer all…

### DIFF
--- a/changes/2991.doc.rst
+++ b/changes/2991.doc.rst
@@ -1,0 +1,1 @@
+Updated the 3.0 migration guide to include the removal of "." sytax for getting group members.

--- a/changes/2991.doc.rst
+++ b/changes/2991.doc.rst
@@ -1,1 +1,1 @@
-Updated the 3.0 migration guide to include the removal of "." sytax for getting group members.
+Updated the 3.0 migration guide to include the removal of "." syntax for getting group members.

--- a/docs/user-guide/v3_migration.rst
+++ b/docs/user-guide/v3_migration.rst
@@ -117,6 +117,8 @@ The Group class
 
    - Use :func:`zarr.Group.create_array` in place of :func:`zarr.Group.create_dataset`
    - Use :func:`zarr.Group.require_array` in place of :func:`zarr.Group.require_dataset`
+3. Disallow "." syntax for getting group members. To get a member of a group named ``foo``,
+   use ``group["foo"]`` in place of ``group.foo``.
 
 The Store class
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
…owed for variables in groups

In #2991, @d-v-b said that "." syntax is gone for group members in v3.0. This is my suggested update to the 3.0 migration documentation.
