### PR TITLE
[v2] Remove `print` statement from structured dtype metadata parsing

### DIFF
--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -294,7 +294,6 @@ def parse_metadata(data: ArrayV2Metadata) -> ArrayV2Metadata:
 
 def _parse_structured_fill_value(fill_value: Any, dtype: np.dtype[Any]) -> Any:
     """Handle structured dtype/fill value pairs"""
-    print("FILL VALUE", fill_value, "DT", dtype)
     try:
         if isinstance(fill_value, list):
             return np.array([tuple(fill_value)], dtype=dtype)[0]


### PR DESCRIPTION
In #2802 a `print` statement was added to V2 metadata parsing for structured arrays. This is most likely a debugging statement. Removing this because it prints every time we open a group or array with structured arrays.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
