### PR TITLE
restore v2-like exceptions

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -28,13 +28,16 @@ from zarr.core.group import (
     ConsolidatedMetadata,
     GroupMetadata,
     create_hierarchy,
-    get_node,
 )
 from zarr.core.metadata import ArrayMetadataDict, ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.metadata.v2 import _default_compressor, _default_filters
-from zarr.errors import ArrayNotFoundError, GroupNotFoundError, NodeNotFoundError, NodeTypeValidationError
+from zarr.errors import (
+    ArrayNotFoundError,
+    GroupNotFoundError,
+    NodeNotFoundError,
+    NodeTypeValidationError,
+)
 from zarr.storage._common import make_store_path
-import contextlib
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -317,37 +320,32 @@ async def open(
     zarr_format = _handle_zarr_version_or_format(zarr_version=zarr_version, zarr_format=zarr_format)
 
     store_path = await make_store_path(store, mode=mode, path=path, storage_options=storage_options)
-    extant_node: AsyncArray[Any] | AsyncGroup | None = None
-    if mode in ('r', 'r+', 'a', 'w-'):
-        # we need to check for an existing node.
-        if zarr_format is None:
-            try:
-                extant_node = await get_node(store_path.store, store_path.path, zarr_format=3)
-            except NodeNotFoundError:
-                with contextlib.suppress(NodeNotFoundError):
-                    extant_node = await get_node(store_path.store, store_path.path, zarr_format=2)
-        else:
-            with contextlib.suppress(NodeNotFoundError):
-                extant_node = await get_node(store_path.store, store_path.path, zarr_format=zarr_format)
-
-    if mode in ('r', 'r+') and extant_node is None:
-        if zarr_format is None:
+    # TODO: the mode check below seems wrong!
+    if "shape" not in kwargs and mode in {"a", "r", "r+", "w"}:
+        try:
+            metadata_dict = await get_array_metadata(store_path, zarr_format=zarr_format)
+            # TODO: remove this cast when we fix typing for array metadata dicts
+            _metadata_dict = cast(ArrayMetadataDict, metadata_dict)
+            # for v2, the above would already have raised an exception if not an array
+            zarr_format = _metadata_dict["zarr_format"]
+            is_v3_array = zarr_format == 3 and _metadata_dict.get("node_type") == "array"
+            if is_v3_array or zarr_format == 2:
+                return AsyncArray(store_path=store_path, metadata=_metadata_dict)
+        except (AssertionError, ArrayNotFoundError, NodeTypeValidationError):
+            pass
+        try:
+            return await open_group(store=store_path, zarr_format=zarr_format, mode=mode, **kwargs)
+        except GroupNotFoundError as e:
             msg = (
-                "No Zarr V2 or V3 metadata documents were found in store "
-                f"{store_path.store!r} at path {store_path.path!r}."
-                )
-        else:
-            msg = (
-                f"No Zarr V{zarr_format} metadata documents were found in store "
-                f"{store_path.store!r} at path {store_path.path!r}."
-                )
-        raise NodeNotFoundError(msg)
-
+                "'Neither array nor group metadata were found in '"
+                f"store {store_path.store} at path {store_path.path!r}"
+            )
+            raise NodeNotFoundError(msg) from e
+    if "shape" in kwargs:
+        return await open_array(store=store_path, zarr_format=zarr_format, mode=mode, **kwargs)
     else:
-        if "shape" in kwargs:
-            return await open_array(store=store_path, mode=mode, zarr_format=zarr_format, **kwargs)
-        else:
-            return await open_group(store=store_path, mode=mode, zarr_format=zarr_format, **kwargs)
+        return await open_group(store=store_path, zarr_format=zarr_format, mode=mode, **kwargs)
+
 
 async def open_consolidated(
     *args: Any, use_consolidated: Literal[True] = True, **kwargs: Any

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -108,7 +108,7 @@ from zarr.core.metadata.v2 import (
 )
 from zarr.core.metadata.v3 import DataType, parse_node_type_array
 from zarr.core.sync import sync
-from zarr.errors import ArrayNotFoundError, MetadataValidationError
+from zarr.errors import ArrayNotFoundError
 from zarr.registry import (
     _parse_array_array_codec,
     _parse_array_bytes_codec,
@@ -171,8 +171,8 @@ async def get_array_metadata(
         )
         if zarray_bytes is None:
             msg = (
-            "A Zarr V2 array metadata document was not found in store "
-            f"{store_path.store!r} at path {store_path.path!r}."
+                "A Zarr V2 array metadata document was not found in store "
+                f"{store_path.store!r} at path {store_path.path!r}."
             )
             raise ArrayNotFoundError(msg)
     elif zarr_format == 3:
@@ -210,7 +210,7 @@ async def get_array_metadata(
         else:
             zarr_format = 2
     else:
-        msg = f"Invalid value for zarr_format. Expected one of 2, 3 or None. Got {zarr_format}."  # type: ignore[unreachable]
+        msg = f"Invalid value for zarr_format. Expected one of 2, 3, or None. Got {zarr_format}."  # type: ignore[unreachable]
         raise ValueError(msg)
 
     metadata_dict: dict[str, JSON]

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -55,13 +55,15 @@ SPECIAL_FLOATS_ENCODED = {
 def parse_zarr_format(data: object) -> Literal[3]:
     if data == 3:
         return 3
-    raise MetadataValidationError("zarr_format", 3, data)
+    msg = f"Invalid value for zarr_format. Expected 3. Got {data!r}."
+    raise MetadataValidationError(msg)
 
 
 def parse_node_type_array(data: object) -> Literal["array"]:
     if data == "array":
         return "array"
-    raise NodeTypeValidationError("node_type", "array", data)
+    msg = f"Invalid value for node_type. Expected 'array'. Got {data!r}."
+    raise NodeTypeValidationError(msg)
 
 
 def parse_codecs(data: object) -> tuple[Codec, ...]:

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing_extensions import deprecated
 
 __all__ = [
     "BaseZarrError",
@@ -12,42 +12,42 @@ __all__ = [
 
 class BaseZarrError(ValueError):
     """
-    Base error which all zarr errors are sub-classed from.
+    Base class for Zarr errors.
     """
-
-    _msg = ""
-
-    def __init__(self, *args: Any) -> None:
-        super().__init__(self._msg.format(*args))
 
 
 class ContainsGroupError(BaseZarrError):
     """Raised when a group already exists at a certain path."""
 
-    _msg = "A group exists in store {!r} at path {!r}."
-
 
 class ContainsArrayError(BaseZarrError):
     """Raised when an array already exists at a certain path."""
 
-    _msg = "An array exists in store {!r} at path {!r}."
+
+class ArrayNotFoundError(BaseZarrError):
+    """Raised when an array does not exist at a certain path."""
+
+
+class GroupNotFoundError(BaseZarrError):
+    """Raised when a group does not exist at a certain path."""
+
+
+@deprecated("Use NodeNotFoundError instead.", category=None)
+class PathNotFoundError(BaseZarrError):
+    # Backwards compatibility with v2. Superseded by NodeNotFoundError.
+    ...
+
+
+class NodeNotFoundError(PathNotFoundError):
+    """Raised when an array or group does not exist at a certain path."""
 
 
 class ContainsArrayAndGroupError(BaseZarrError):
-    """Raised when both array and group metadata are found at the same path."""
-
-    _msg = (
-        "Array and group metadata documents (.zarray and .zgroup) were both found in store "
-        "{!r} at path {!r}. "
-        "Only one of these files may be present in a given directory / prefix. "
-        "Remove the .zarray file, or the .zgroup file, or both."
-    )
+    """Raised when both array and group metadata are found at the same path. Zarr V2 only."""
 
 
 class MetadataValidationError(BaseZarrError):
-    """Raised when the Zarr metadata is invalid in some way"""
-
-    _msg = "Invalid value for '{}'. Expected '{}'. Got '{}'."
+    """Raised when a Zarr metadata document is invalid"""
 
 
 class NodeTypeValidationError(MetadataValidationError):
@@ -56,4 +56,10 @@ class NodeTypeValidationError(MetadataValidationError):
 
     This can be raised when the value is invalid or unexpected given the context,
     for example an 'array' node when we expected a 'group'.
+    """
+
+
+class ReadOnlyError(PermissionError, BaseZarrError):
+    """
+    Exception for when a mutation is attempted on an immutable resource.
     """

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -80,7 +80,7 @@ def test_parse_node_type_valid() -> None:
 def test_parse_node_type_invalid(node_type: Any) -> None:
     with pytest.raises(
         MetadataValidationError,
-        match=f"Invalid value for 'node_type'. Expected 'array or group'. Got '{node_type}'.",
+        match=f"Invalid value for node_type. Expected 'array' or 'group'. Got {node_type!r}.",
     ):
         parse_node_type(node_type)
 
@@ -88,7 +88,7 @@ def test_parse_node_type_invalid(node_type: Any) -> None:
 @pytest.mark.parametrize("data", [None, "group"])
 def test_parse_node_type_array_invalid(data: Any) -> None:
     with pytest.raises(
-        ValueError, match=f"Invalid value for 'node_type'. Expected 'array'. Got '{data}'."
+        ValueError, match=f"Invalid value for node_type. Expected 'array'. Got {data!r}."
     ):
         parse_node_type_array(data)
 


### PR DESCRIPTION
This PR brings the following changes:

### new (old) exceptions
`zarr.errors` gets new exceptions `ArrayNotFoundError`, `GroupNotFoundError`, `PathNotFoundError`, `NodeNotFoundError` (for when neither an array nor a group were found, in a context where either one was a valid result). The first three existed in zarr-python 2, so this PR is restoring compatibility. The new `NodeNotFoundError` is an instance of the zarr-python 2 exception `PathNotFoundError`. This subclass relationship exists for zarr-python 2 compatibility -- users coming from zarr-python 2 can use `try..., except PathNotFoundError` and catch the `NodeNotFoundError`. `PathNotFoundError` is deprecated but does not emit a warning on use. We should decide when to remove it. 

`PathNotFoundError` is deprecated because the name of that exception is inconsistent with `ArrayNotFoundError` and `GroupNotFoundError`, which take the form `<thing at a path>NotFoundError`. `PathNotFoundError` is raised when a path fails to resolve to a node, i.e. an array or group, even if something is at that path. Because the name is bad (IMO), we should remove this exception entirely in the future. Until then, `NodeNotFoundError` inherits from `PathNotFoundError`, and we should use `NodeNotFoundError` in the codebase.

We were using `FileNotFoundError` and `KeyError` to model "failure to find an array or group at a path." In this PR, we consistently use `ArrayNotFoundError` when failing to find an array, `GroupNotFoundError` when failing to find a group, and `NodeNotFoundError` when failing to find either an array or group, in a context where either would have been OK (e.g., `zarr.open()` or `group['nodea_name']`).

### relaxed exception formatting
In this PR, exceptions defined in `zarr.errors` take a single string in their constructor. This is a change from `main`, where the exceptions take a tuple of values that will be inserted into an f-string defined in the exception class.

That is, in `main`, `raise FooError('a', 'b')` will emit `FooError: predefined message with two args, 'a' and 'b'`, but in this PR, you would need to invoke `raise FooError("predefined message with two args, 'a', 'b'")` to get the same message. 

The acute reason for this change is to allow the same exception to contain a contextualized message. In the case of missing arrays or groups, it's useful to tell the user in e.g. an `ArrayNotFoundError` which zarr format the code was looking for, which means failing to find a v2 array or a v3 array (or either, if zarr_format was unspecified) each requires a slightly different message.

A more general reason for this change is that (IMO) pre-defining an exception message in the exception class is not good design. The exception text is read by humans, so it should convey whatever is most helpful in the context of that exception, and this might vary in different contexts. The exception message does not need to be highly structured for this purpose (it will not be read by machines), and if we _do_ for some reason want our exceptions to be highly structured, then we can write separate functions that generate a pre-formatted exception message, and use this function before calling the exception. A cost of this approach is that it's a little more work to write exception messages, but the gain in expressiveness is worth it IMO.