### PR TITLE
Pin minimum s3fs (to fix tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
 remote_tests = [
     'zarr[remote]',
     "botocore",
-    "s3fs",
+    "s3fs>=2023.10.0",
     "moto[s3,server]",
     "requests",
 ]
@@ -104,7 +104,7 @@ docs = [
     # Optional dependencies to run examples
     'numcodecs[msgpack]',
     'rich',
-    's3fs',
+    's3fs>=2023.10.0',
     'astroid<4'
 ]
 


### PR DESCRIPTION
This is an attempt to debug recent test failures, which I think might be caused by a very old version of s3fs being installed. I have no idea why that's happening though, so maybe adding a pin here will help debug?

Update: this fixes the tests, so I think it's fine (and good) to merge. Since this only updates dev dependencies, I don't think it needs a release note.