### PR TITLE
Fix readtehdocs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ docs = [
     'sphinx-issues',
     'sphinx-copybutton',
     'sphinx-reredirects',
+    # See https://github.com/sphinx-doc/sphinx/issues/13533;
+    # pin can be removed once that issue is fixed.
+    'snowballstemmer<3',
     'pydata-sphinx-theme',
     'numpydoc',
     # Changelog generation


### PR DESCRIPTION
Playing whack-a-mole with broken dependencies again; see https://github.com/sphinx-doc/sphinx/issues/13533.