### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
 default_stages: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.9
+    rev: v0.11.9
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
@@ -40,7 +40,7 @@ repos:
           - hypothesis
           - s3fs
   - repo: https://github.com/scientific-python/cookie
-    rev: 2025.01.22
+    rev: 2025.05.02
     hooks:
       - id: sp-repo-review
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,7 @@ extend-select = [
     "RUF",
     "SIM",  # flake8-simplify
     "SLOT", # flake8-slots
-    "TCH",  # flake8-type-checking
+    "TC",  # flake8-type-checking
     "TRY",  # tryceratops
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,7 @@ ignore = [
     "Q003",
     "COM812",
     "COM819",
+    "TC006",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
Replaces https://github.com/zarr-developers/zarr-python/pull/2966. I'm not a fan of making all type hints strings instead of actual types, so I added an exclusion to TC006. An example of changes that would happen if we enabled TC006 can be found at https://github.com/zarr-developers/zarr-python/pull/2966 if folks are interested.

Also replaces https://github.com/zarr-developers/zarr-python/pull/3032, because it seemed sensible to do that here too.