### PR TITLE
Fix overwrite modes

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -88,7 +88,7 @@ __all__ = [
 
 _READ_MODES: tuple[AccessModeLiteral, ...] = ("r", "r+", "a")
 _CREATE_MODES: tuple[AccessModeLiteral, ...] = ("a", "w", "w-")
-_OVERWRITE_MODES: tuple[AccessModeLiteral, ...] = ("a", "r+", "w")
+_OVERWRITE_MODES: tuple[AccessModeLiteral, ...] = ("w",)
 
 
 def _infer_overwrite(mode: AccessModeLiteral) -> bool:
@@ -817,7 +817,6 @@ async def open_group(
         warnings.warn("chunk_store is not yet implemented", RuntimeWarning, stacklevel=2)
 
     store_path = await make_store_path(store, mode=mode, storage_options=storage_options, path=path)
-
     if attributes is None:
         attributes = {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,6 @@ from zarr.api.synchronous import (
     create_group,
     group,
     load,
-    open,
     open_group,
     save,
     save_array,
@@ -40,6 +39,9 @@ from zarr.errors import MetadataValidationError
 from zarr.storage import MemoryStore
 from zarr.storage._utils import normalize_path
 from zarr.testing.utils import gpu_test
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_create(memory_store: Store) -> None:
@@ -135,28 +137,28 @@ async def test_open_array(memory_store: MemoryStore, zarr_format: ZarrFormat) ->
     store = memory_store
 
     # open array, create if doesn't exist
-    z = open(store=store, shape=100, zarr_format=zarr_format)
+    z = zarr.api.synchronous.open(store=store, shape=100, zarr_format=zarr_format)
     assert isinstance(z, Array)
     assert z.shape == (100,)
 
     # open array, overwrite
     # store._store_dict = {}
     store = MemoryStore()
-    z = open(store=store, shape=200, zarr_format=zarr_format)
+    z = zarr.api.synchronous.open(store=store, shape=200, zarr_format=zarr_format)
     assert isinstance(z, Array)
     assert z.shape == (200,)
 
     # open array, read-only
     store_cls = type(store)
     ro_store = await store_cls.open(store_dict=store._store_dict, read_only=True)
-    z = open(store=ro_store, mode="r")
+    z = zarr.api.synchronous.open(store=ro_store, mode="r")
     assert isinstance(z, Array)
     assert z.shape == (200,)
     assert z.read_only
 
     # path not found
     with pytest.raises(FileNotFoundError):
-        open(store="doesnotexist", mode="r", zarr_format=zarr_format)
+        zarr.api.synchronous.open(store="doesnotexist", mode="r", zarr_format=zarr_format)
 
 
 @pytest.mark.parametrize("store", ["memory", "local", "zip"], indirect=True)
@@ -233,12 +235,12 @@ def test_save(store: Store, n_args: int, n_kwargs: int) -> None:
             save(store)
     elif n_args == 1 and n_kwargs == 0:
         save(store, *args)
-        array = open(store)
+        array = zarr.api.synchronous.open(store)
         assert isinstance(array, Array)
         assert_array_equal(array[:], data)
     else:
         save(store, *args, **kwargs)  # type: ignore [arg-type]
-        group = open(store)
+        group = zarr.api.synchronous.open(store)
         assert isinstance(group, Group)
         for array in group.array_values():
             assert_array_equal(array[:], data)
@@ -1077,7 +1079,7 @@ def test_tree() -> None:
 def test_open_positional_args_deprecated() -> None:
     store = MemoryStore()
     with pytest.warns(FutureWarning, match="pass"):
-        open(store, "w", shape=(1,))
+        zarr.api.synchronous.open(store, "w", shape=(1,))
 
 
 def test_save_array_positional_args_deprecated() -> None:
@@ -1236,3 +1238,13 @@ def test_v2_with_v3_compressor() -> None:
         zarr.create(
             store={}, shape=(1), dtype="uint8", zarr_format=2, compressor=zarr.codecs.BloscCodec()
         )
+
+
+def test_create_no_delete_file(tmp_path: Path) -> None:
+    with open(tmp_path / "file.txt", "w") as f:
+        f.write("abc")
+
+    with pytest.raises(NotImplementedError, match="loading groups not yet supported"):
+        zarr.load("./tmp")
+    # Even though above fails, it shouldn't delete existing file
+    assert (tmp_path / "file.txt").exists()


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/3061. @jhamman, you last modified these lines in https://github.com/zarr-developers/zarr-python/pull/2442, is there a reason why "a" and "r+" was in ovewrite modes? It seems to me like they definitely shouldn't be there.