### PR TITLE
Don't compress data in hypothesis store testing

### DIFF
--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -17,6 +17,7 @@ from hypothesis.strategies import DataObject
 import zarr
 from zarr import Array
 from zarr.abc.store import Store
+from zarr.codecs.bytes import BytesCodec
 from zarr.core.buffer import Buffer, BufferPrototype, cpu, default_buffer_prototype
 from zarr.core.sync import SyncMixin
 from zarr.storage import LocalStore, MemoryStore
@@ -108,7 +109,14 @@ class ZarrHierarchyStateMachine(SyncMixin, RuleBasedStateMachine):
         assume(self.can_add(path))
         note(f"Adding array:  path='{path}'  shape={array.shape}  chunks={chunks}")
         for store in [self.store, self.model]:
-            zarr.array(array, chunks=chunks, path=path, store=store, fill_value=fill_value)
+            zarr.array(
+                array,
+                chunks=chunks,
+                path=path,
+                store=store,
+                fill_value=fill_value,
+                codecs=[BytesCodec()],
+            )
         self.all_arrays.add(path)
 
     # @precondition(lambda self: bool(self.all_groups))

--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -115,6 +115,7 @@ class ZarrHierarchyStateMachine(SyncMixin, RuleBasedStateMachine):
                 path=path,
                 store=store,
                 fill_value=fill_value,
+                # Chose bytes codec to avoid wasting time compressing the data being written
                 codecs=[BytesCodec()],
             )
         self.all_arrays.add(path)


### PR DESCRIPTION
Since the store tests are insensitive to how data is encoded, use the simplest codecs to avoid compressing the data all the time these tests are run.

Should help a bit with https://github.com/zarr-developers/zarr-python/issues/3010.