### PR TITLE
Add a GroupNotFoundError

### DIFF
--- a/changes/3066.bugfix.rst
+++ b/changes/3066.bugfix.rst
@@ -1,2 +1,0 @@
-`~zarr.errors.BaseZarrError` now inherits from `Exception` instead of `ValueError`.
-This fix also affects all other exceptions in `zarr.errors`.

--- a/changes/3066.bugfix.rst
+++ b/changes/3066.bugfix.rst
@@ -1,0 +1,2 @@
+`~zarr.errors.BaseZarrError` now inherits from `Exception` instead of `ValueError`.
+This fix also affects all other exceptions in `zarr.errors`.

--- a/changes/3066.feature.rst
+++ b/changes/3066.feature.rst
@@ -1,0 +1,1 @@
+Added `~zarr.errors.GroupNotFoundError`, which is raised when attempting to open a group that does not exist.

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -39,7 +39,7 @@ from zarr.core.group import (
 )
 from zarr.core.metadata import ArrayMetadataDict, ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.metadata.v2 import _default_compressor, _default_filters
-from zarr.errors import NodeTypeValidationError
+from zarr.errors import GroupNotFoundError, NodeTypeValidationError
 from zarr.storage._common import make_store_path
 
 if TYPE_CHECKING:
@@ -836,7 +836,7 @@ async def open_group(
             overwrite=overwrite,
             attributes=attributes,
         )
-    raise FileNotFoundError(f"Unable to find group: {store_path}")
+    raise GroupNotFoundError(store, store_path.path)
 
 
 async def create(

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 
-class BaseZarrError(Exception):
+class BaseZarrError(ValueError):
     """
     Base error which all zarr errors are sub-classed from.
     """

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 
-class BaseZarrError(ValueError):
+class BaseZarrError(Exception):
     """
     Base error which all zarr errors are sub-classed from.
     """
@@ -19,6 +19,14 @@ class BaseZarrError(ValueError):
 
     def __init__(self, *args: Any) -> None:
         super().__init__(self._msg.format(*args))
+
+
+class GroupNotFoundError(BaseZarrError, FileNotFoundError):
+    """
+    Raised when a group isn't found at a certain path.
+    """
+
+    _msg = "No group found in store {!r} at path {!r}"
 
 
 class ContainsGroupError(BaseZarrError):

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -20,7 +20,7 @@ from zarr.core.metadata.v3 import (
     parse_fill_value,
     parse_zarr_format,
 )
-from zarr.errors import MetadataValidationError
+from zarr.errors import MetadataValidationError, NodeTypeValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -62,7 +62,8 @@ dtypes = (*bool_dtypes, *int_dtypes, *float_dtypes, *complex_dtypes, *vlen_dtype
 @pytest.mark.parametrize("data", [None, 1, 2, 4, 5, "3"])
 def test_parse_zarr_format_invalid(data: Any) -> None:
     with pytest.raises(
-        ValueError, match=f"Invalid value for 'zarr_format'. Expected '3'. Got '{data}'."
+        MetadataValidationError,
+        match=f"Invalid value for 'zarr_format'. Expected '3'. Got '{data}'.",
     ):
         parse_zarr_format(data)
 
@@ -88,7 +89,8 @@ def test_parse_node_type_invalid(node_type: Any) -> None:
 @pytest.mark.parametrize("data", [None, "group"])
 def test_parse_node_type_array_invalid(data: Any) -> None:
     with pytest.raises(
-        ValueError, match=f"Invalid value for 'node_type'. Expected 'array'. Got '{data}'."
+        NodeTypeValidationError,
+        match=f"Invalid value for 'node_type'. Expected 'array'. Got '{data}'.",
     ):
         parse_node_type_array(data)
 


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/2298.

Note I also updated the base zarr exception to no longer inherit from ValueError, because in general errors we raise are not always ValueErrors. I'll add a separate release note for this change.