### PR TITLE
(feat): use `np.zeros` for buffer creation with `fill_value=0`

### DIFF
--- a/changes/3082.feature.rst
+++ b/changes/3082.feature.rst
@@ -1,0 +1,1 @@
+Use :py:func:`numpy.zeros` instead of :py:func:`np.full` for a performance speedup when creating a `zarr.core.buffer.NDBuffer` with `fill_value=0`.

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -154,7 +154,8 @@ class NDBuffer(core.NDBuffer):
         order: Literal["C", "F"] = "C",
         fill_value: Any | None = None,
     ) -> Self:
-        if fill_value is None or fill_value == 0:
+        # np.zeros is much faster than np.full, and therefore using it when possible is better.
+        if fill_value is None or (isinstance(fill_value, int) and fill_value == 0):
             return cls(np.zeros(shape=tuple(shape), dtype=dtype, order=order))
         else:
             return cls(np.full(shape=tuple(shape), fill_value=fill_value, dtype=dtype, order=order))

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -154,7 +154,7 @@ class NDBuffer(core.NDBuffer):
         order: Literal["C", "F"] = "C",
         fill_value: Any | None = None,
     ) -> Self:
-        if fill_value is None:
+        if fill_value is None or fill_value == 0:
             return cls(np.zeros(shape=tuple(shape), dtype=dtype, order=order))
         else:
             return cls(np.full(shape=tuple(shape), fill_value=fill_value, dtype=dtype, order=order))


### PR DESCRIPTION
I was profiling code and noticed a non-trivial amount of time spent on `np.full` with a `fill_value=0` so I did a little digging and at least on my machine:

```python
In [1]: import numpy as np

In [2]: %timeit np.full((10_000, 10_000), dtype=np.float32, fill_value=0, order="C")
33.2 ms ± 784 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit np.zeros((10_000, 10_000), dtype=np.float32, order="C")
1.04 μs ± 1.48 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

For example: 

https://github.com/zarr-developers/zarr-python/blob/481550a2b98d1bf51d731653208c26b5bcfce454/src/zarr/core/array.py#L1285-L1290

and

https://github.com/zarr-developers/zarr-python/blob/481550a2b98d1bf51d731653208c26b5bcfce454/src/zarr/codecs/sharding.py#L441-L443

are both points where this happens

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
