### PR TITLE
Add async oindex method to AsyncArray

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1370,7 +1370,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         if prototype is None:
             prototype = default_buffer_prototype()
         indexer = OrthogonalIndexer(selection, self.shape, self.metadata.chunk_grid)
-        return await self._async_array._get_selection(
+        return await self._get_selection(
             indexer=indexer, out=out, fields=fields, prototype=prototype
         )
 

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -79,6 +79,7 @@ from zarr.core.indexing import (
     MaskIndexer,
     MaskSelection,
     OIndex,
+    AsyncOIndex,
     OrthogonalIndexer,
     OrthogonalSelection,
     Selection,
@@ -1358,6 +1359,21 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         )
         return await self._get_selection(indexer, prototype=prototype)
 
+    async def get_orthogonal_selection(
+        self,
+        selection: OrthogonalSelection,
+        *,
+        out: NDBuffer | None = None,
+        fields: Fields | None = None,
+        prototype: BufferPrototype | None = None,
+    ) -> NDArrayLike:
+        if prototype is None:
+            prototype = default_buffer_prototype()
+        indexer = OrthogonalIndexer(selection, self.shape, self.metadata.chunk_grid)
+        return await self._async_array._get_selection(
+            indexer=indexer, out=out, fields=fields, prototype=prototype
+        )
+
     async def _save_metadata(self, metadata: ArrayMetadata, ensure_parents: bool = False) -> None:
         """
         Asynchronously save the array metadata.
@@ -1487,6 +1503,12 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             chunk_grid=self.metadata.chunk_grid,
         )
         return await self._set_selection(indexer, value, prototype=prototype)
+
+    @property
+    def oindex(self) -> AsyncOIndex:
+        """Shortcut for orthogonal (outer) indexing, see :func:`get_orthogonal_selection` and
+        :func:`set_orthogonal_selection` for documentation and examples."""
+        return AsyncOIndex(self)
 
     async def resize(self, new_shape: ShapeLike, delete_outside_chunks: bool = True) -> None:
         """


### PR DESCRIPTION
`Array` has an `.oindex` method (and `.vindex`), but `AsyncArray` has no equivalent. This PR adds one.

I want it for https://github.com/pydata/xarray/pull/10327#discussion_r2103674520

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
