### PR TITLE
issues: add pep-723 to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,19 @@ body:
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: Minimal, reproducible code sample, a copy-pastable example if possible.
+      description: Minimal, reproducible code sample. Must list dependencies per [PEP-723](https://peps.python.org/pep-0723/#example). When put in a file named `issue.py` calling `uv run issue.py` should show the issue.
+      placeholder: |
+        ```python
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "zarr==YOUR VERSION HERE",
+        # ]
+        # ///
+
+        import zarr
+        # your reproducer code
+        ```
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Adds `pep-723` compliant metadata to the placeholder for the reproducer in the bug report

You can see how it will render by making a new issue here: https://github.com/ianhi/git-expt/issues

![image](https://github.com/user-attachments/assets/c17878aa-7ec9-48b5-9a83-65ca5c98a2aa)

