### PR TITLE
use our fork of s3fs for upstream testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,11 @@ dependencies = [
     'numpy',  # from scientific-python-nightly-wheels
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
     'fsspec @ git+https://github.com/fsspec/filesystem_spec',
-    's3fs @ git+https://github.com/fsspec/s3fs',
+    # we use a fork of s3fs because fsspec/s3fs declares an exact version of fsspec,
+    # which cannot be satisfied when we use the git version of fsspec.
+    # our fork relaxes the upper bound on the fsspec dependency.
+    # see https://github.com/fsspec/s3fs/pull/966
+    's3fs @ git+https://github.com/zarr-developers/s3fs',
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'typing_extensions @ git+https://github.com/python/typing_extensions',
     'donfig @ git+https://github.com/pytroll/donfig',


### PR DESCRIPTION
`s3fs` depends on an exact version of [`fsspec` (`2025.5.1`)](https://github.com/fsspec/s3fs/blob/2f3c76d9c36025c7daefa766a8f81c79fc4010e7/requirements.txt#L2). The unreleased version of `fsspec`, i.e. what you get when you install fsspec from a git dependency declaration like `fsspec @ git+https://github.com/fsspec/filesystem_spec`, is generally ahead of that version, and thus the two are, by declaration, incompatible. This apparent incompatibility has prevented [recent upstream tests](https://github.com/zarr-developers/zarr-python/actions/runs/15218451870/job/42826570416?pr=3087) from succeeding. 

As a short-term fix, I [forked s3fs](https://github.com/zarr-developers/s3fs) and relaxed the upper bound of its fsspec dependency. This PR changes the upstream tests s3fs dependency to use our fork.

this was discussed over at s3fs [here](https://github.com/fsspec/s3fs/pull/966)