### PR TITLE
remove insertion of vlen-string codec for v2 metadata creation

### DIFF
--- a/changes/3100.bugfix.rst
+++ b/changes/3100.bugfix.rst
@@ -1,3 +1,3 @@
-Zarr V2: allow fixed-length string arrays to be created without automatically inserting a
+For Zarr format 2, allow fixed-length string arrays to be created without automatically inserting a
 ``Vlen-UT8`` codec in the array of filters. Fixed-length string arrays do not need this codec. This
 change fixes regressions against Zarr Python 2.18.

--- a/changes/3100.bugfix.rst
+++ b/changes/3100.bugfix.rst
@@ -1,3 +1,3 @@
 For Zarr format 2, allow fixed-length string arrays to be created without automatically inserting a
 ``Vlen-UT8`` codec in the array of filters. Fixed-length string arrays do not need this codec. This
-change fixes regressions against Zarr Python 2.18.
+change fixes a regression where fixed-length string arrays created with Zarr Python 3 could not be read with Zarr Python 2.18.

--- a/changes/3100.bugfix.rst
+++ b/changes/3100.bugfix.rst
@@ -1,0 +1,3 @@
+Zarr V2: allow fixed-length string arrays to be created without automatically inserting a
+``Vlen-UT8`` codec in the array of filters. Fixed-length string arrays do not need this codec. This
+change fixes regressions against Zarr Python 2.18.

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -768,14 +768,6 @@ class AsyncArray(Generic[T_ArrayMetadata]):
 
         dtype = parse_dtype(dtype, zarr_format=2)
 
-        # inject VLenUTF8 for str dtype if not already present
-        if np.issubdtype(dtype, np.str_):
-            filters = filters or []
-            from numcodecs.vlen import VLenUTF8
-
-            if not any(isinstance(x, VLenUTF8) or x["id"] == "vlen-utf8" for x in filters):
-                filters = list(filters) + [VLenUTF8()]
-
         return ArrayV2Metadata(
             shape=shape,
             dtype=np.dtype(dtype),

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1245,7 +1245,7 @@ class TestCreateArray:
             zarr.create(store=store, dtype="uint8", shape=(10,), zarr_format=3, **kwargs)
 
     @staticmethod
-    @pytest.mark.parametrize("dtype", ["uint8", "float32", "str"])
+    @pytest.mark.parametrize("dtype", ["uint8", "float32", "str", "U10", "S10", ">M8[10s]"])
     @pytest.mark.parametrize(
         "compressors",
         [


### PR DESCRIPTION
This PR removes the following code block:

https://github.com/zarr-developers/zarr-python/blob/0dd797f8a7eeab05982a1e4115990200d97d9d98/src/zarr/core/array.py#L771-L777

Neither of the two numpy dtypes that can model variable-length strings are subdtypes of `np.str_`:

```python
>>> np.issubdtype(np.dtypes.ObjectDType(), np.str_)         
False
>>> np.issubdtype(np.dtypes.StringDType(), np.str_)         
False
```

so there is no reason to use vlen-string codec here.

This was revealed by [regression testing against 2.18](https://github.com/zarr-developers/zarr-python/pull/3099). Zarr-python 2.18 cannot read certain arrays generated by zarr-python main because we inserting this codec. 