### PR TITLE
Use context manager for temporary directories in store tests

### DIFF
--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -618,6 +618,7 @@ class TestConsolidated:
         expected = ["b", "b/c"]
         assert result == expected
 
+
 @pytest.mark.parametrize("fill_value", [np.nan, np.inf, -np.inf])
 async def test_consolidated_metadata_encodes_special_chars(
     memory_store: Store, zarr_format: ZarrFormat, fill_value: float

--- a/tests/test_store/test_core.py
+++ b/tests/test_store/test_core.py
@@ -18,6 +18,26 @@ from zarr.storage._utils import (
 )
 
 
+@pytest.fixture(
+    params=["none", "temp_dir_str", "temp_dir_path", "store_path", "memory_store", "dict"]
+)
+def store_like(request):
+    if request.param == "none":
+        yield None
+    elif request.param == "temp_dir_str":
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield temp_dir
+    elif request.param == "temp_dir_path":
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield Path(temp_dir)
+    elif request.param == "store_path":
+        yield StorePath(store=MemoryStore(store_dict={}), path="/")
+    elif request.param == "memory_store":
+        yield MemoryStore(store_dict={})
+    elif request.param == "dict":
+        yield {}
+
+
 @pytest.mark.parametrize("path", ["foo", "foo/bar"])
 @pytest.mark.parametrize("write_group", [True, False])
 @pytest.mark.parametrize("zarr_format", [2, 3])
@@ -134,17 +154,6 @@ async def test_make_store_path_fsspec(monkeypatch) -> None:
     assert isinstance(store_path.store, FsspecStore)
 
 
-@pytest.mark.parametrize(
-    "store_like",
-    [
-        None,
-        tempfile.TemporaryDirectory().name,
-        Path(tempfile.TemporaryDirectory().name),
-        StorePath(store=MemoryStore(store_dict={}), path="/"),
-        MemoryStore(store_dict={}),
-        {},
-    ],
-)
 async def test_make_store_path_storage_options_raises(store_like: StoreLike) -> None:
     with pytest.raises(TypeError, match="storage_options"):
         await make_store_path(store_like, storage_options={"foo": "bar"})


### PR DESCRIPTION
This PR creates a pytest fixture so that the temporary directory used in the store tests get cleaned up after use. The motivation is that the current usage of temporary directories was causing the failures seen in https://github.com/zarr-developers/zarr-python/actions/runs/15405315759/job/43346759238?pr=2774. 