### PR TITLE
remove fsspec from upstream tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,6 @@ dependencies = [
     'packaging @ git+https://github.com/pypa/packaging',
     'numpy',  # from scientific-python-nightly-wheels
     'numcodecs @ git+https://github.com/zarr-developers/numcodecs',
-    'fsspec @ git+https://github.com/fsspec/filesystem_spec',
     's3fs @ git+https://github.com/fsspec/s3fs',
     'universal_pathlib @ git+https://github.com/fsspec/universal_pathlib',
     'typing_extensions @ git+https://github.com/python/typing_extensions',


### PR DESCRIPTION
This removes fsspec from our upstream tests. Since s3fs depends on a released version of fsspec, we will test against that version when we pull in s3fs.

resolves #3115 