### PR TITLE
Multiple imports for an import name

### DIFF
--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 
 obstore = pytest.importorskip("obstore")
-import pytest
+
 from hypothesis.stateful import (
     run_state_machine_as_test,
 )


### PR DESCRIPTION
I hope I’m not missing a reason why `pytest` should be imported twice.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
