### PR TITLE
Suppress FileNotFoundError when deleting keys in the obstore adapter

### DIFF
--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -181,7 +181,12 @@ class ObjectStore(Store):
         import obstore as obs
 
         self._check_writable()
-        await obs.delete_async(self.store, key)
+
+        # Some stores such as local filesystems, GCP and Azure raise an error
+        # when deleting a non-existent key, while others such as S3 and in-memory do
+        # not. We suppress the error to make the behavior consistent across all stores
+        with contextlib.suppress(FileNotFoundError):
+            await obs.delete_async(self.store, key)
 
     @property
     def supports_partial_writes(self) -> bool:

--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -75,6 +75,9 @@ class TestObjectStore(StoreTests[ObjectStore, cpu.Buffer]):
         with pytest.raises(TypeError):
             ObjectStore("path/to/store")
 
+    async def test_store_delete_nonexistent_key_does_not_raise(self, store: ObjectStore) -> None:
+        await store.delete("nonexistent_key")
+
 
 @pytest.mark.slow_hypothesis
 def test_zarr_hierarchy():


### PR DESCRIPTION
Suppress `FileNotFoundError` in `delete` operation of the obstore adapter.

Since some underlying stores allow this, while others raise an error, supressing the error results in consistent behaviour across all stores. This also mimics how the same thing is implemented in the `fsspec` adapter.

Fixes #3136 

TODO:
* [X] Add unit tests and/or doctests in docstrings
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
