### PR TITLE
Fix URL to contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-Please see the [project documentation](https://zarr.readthedocs.io/en/stable/contributing.html) for information about contributing to Zarr.
+Please see the [project documentation](https://zarr.readthedocs.io/en/stable/developers/contributing.html) for information about contributing to Zarr.


### PR DESCRIPTION
Just noticed a dead link when creating another PR and was therefore looking for the contributing guide