### PR TITLE
Add GroupNotFound error to API docs

### DIFF
--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -5,6 +5,7 @@ __all__ = [
     "ContainsArrayAndGroupError",
     "ContainsArrayError",
     "ContainsGroupError",
+    "GroupNotFoundError",
     "MetadataValidationError",
     "NodeTypeValidationError",
 ]


### PR DESCRIPTION
This was an omission in the original (unreleased) PR.