### PR TITLE
Apply ruff/flake8-comprehensions preview rule C409

### DIFF
--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1642,12 +1642,10 @@ async def test_create_hierarchy_existing_nodes(
     elif impl == "async":
         with pytest.raises(err_cls, match=re.escape(msg)):
             tuple(
-                [
-                    x
-                    async for x in create_hierarchy(
-                        store=store, nodes={"node": new_metadata}, overwrite=False
-                    )
-                ]
+                x
+                async for x in create_hierarchy(
+                    store=store, nodes={"node": new_metadata}, overwrite=False
+                )
             )
     else:
         raise ValueError(f"Invalid impl: {impl}")


### PR DESCRIPTION
C409 Unnecessary list comprehension passed to `tuple()` (rewrite as a generator)

[unnecessary-literal-within-tuple-call (C409)](https://docs.astral.sh/ruff/rules/unnecessary-literal-within-tuple-call/#unnecessary-literal-within-tuple-call-c409)

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
