### PR TITLE
Only warn if opening writeable store with mode='r'

### DIFF
--- a/changes/3068.bugfix.rst
+++ b/changes/3068.bugfix.rst
@@ -1,1 +1,3 @@
-Trying to open an array with ``mode='r'`` when the store is not read-only now raises an error.
+Opening an array or group with ``mode='r'`` when the store is not read-only now raises a warning.
+If you do this the group or array will still be writeable.
+We intend to fix this behaviour in a future zarr-python release.

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias
 
@@ -87,7 +88,11 @@ class StorePath:
         if store.read_only and mode != "r":
             raise ValueError(f"Store is read-only but mode is '{mode}'")
         if not store.read_only and mode == "r":
-            raise ValueError(f"Store is not read-only but mode is '{mode}'")
+            warnings.warn(
+                f"Store is not read-only but mode is '{mode}'. You will still be able to write to arrays and groups within this store.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         match mode:
             case "w-":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1318,7 +1318,7 @@ def test_no_overwrite_open(tmp_path: Path, open_func: Callable, mode: str) -> No
     existing_fpath = add_empty_file(tmp_path)
 
     assert existing_fpath.exists()
-    with contextlib.suppress(FileExistsError, FileNotFoundError, ValueError):
+    with contextlib.suppress(FileExistsError, FileNotFoundError, UserWarning):
         open_func(store=store, mode=mode)
     if mode == "w":
         assert not existing_fpath.exists()

--- a/tests/test_store/test_core.py
+++ b/tests/test_store/test_core.py
@@ -263,8 +263,8 @@ def test_relativize_path_invalid() -> None:
         _relativize_path(path="a/b/c", prefix="b")
 
 
-def test_invalid_open_mode() -> None:
+def test_different_open_mode() -> None:
     store = MemoryStore()
     zarr.create((100,), store=store, zarr_format=2, path="a")
-    with pytest.raises(ValueError, match="Store is not read-only but mode is 'r'"):
+    with pytest.warns(UserWarning, match="Store is not read-only but mode is 'r'"):
         zarr.open_array(store=store, path="a", zarr_format=2, mode="r")


### PR DESCRIPTION
See much discussion in https://github.com/zarr-developers/zarr-python/pull/3068 - instead of erroring, this just warns now. ping @maxrjones 