### PR TITLE
Disable codecov PR annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,12 @@ coverage:
     patch:
       default:
         target: auto
+        after_n_builds: 10  # Wait for all 10 reports before updating the status
     project:
       default:
         target: auto
         threshold: 0.1
+        after_n_builds: 2   # Wait for all 10 reports before updating the status
 comment: false
 github_checks:
     annotations: false


### PR DESCRIPTION
This PR disables the GitHub annotations for codecov (e.g., screenshot below) for two reasons:
- the current annotations are routinely wrong. Multiple recent PRs have lines annotated as not covered when you can see on the [codecov portal](https://app.codecov.io/gh/zarr-developers/zarr-python/commit/76a04977e541308e0973b464e522dacc9264bf69) that they are covered.
- [the annotations are being deprecated by CodeCov due to API limitations](https://docs.codecov.com/docs/github-checks)


![image](https://github.com/user-attachments/assets/35b23a27-d463-419b-bba0-8309a6d6d796)

I also have seen multiple people (including myself) confused by the failing codecov status while some of the reports have yet to be uploaded. Specifically, the hypothesis tests take a while and are required to meet the codecov targets. I changed the configuration to wait until 10 (all) reports are available before changing the configuration.