### PR TITLE
Add human readable size for No. bytes stored to `info_complete`

### DIFF
--- a/docs/user-guide/arrays.rst
+++ b/docs/user-guide/arrays.rst
@@ -211,7 +211,7 @@ prints additional diagnostics, e.g.::
    Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
    Compressors        : (BloscCodec(typesize=4, cname=<BloscCname.zstd: 'zstd'>, clevel=3, shuffle=<BloscShuffle.bitshuffle: 'bitshuffle'>, blocksize=0),)
    No. bytes          : 400000000 (381.5M)
-   No. bytes stored   : 3558573
+   No. bytes stored   : 3558573 (3.4M)
    Storage ratio      : 112.4
    Chunks Initialized : 100
 
@@ -285,7 +285,7 @@ Here is an example using a delta filter with the Blosc compressor::
    >>> compressors = zarr.codecs.BloscCodec(cname='zstd', clevel=1, shuffle=zarr.codecs.BloscShuffle.shuffle)
    >>> data = np.arange(100000000, dtype='int32').reshape(10000, 10000)
    >>> z = zarr.create_array(store='data/example-9.zarr', shape=data.shape, dtype=data.dtype, chunks=(1000, 1000), filters=filters, compressors=compressors)
-   >>> z.info
+   >>> z.info_complete()
    Type               : Array
    Zarr format        : 3
    Data type          : Int32(endianness='little')
@@ -299,6 +299,9 @@ Here is an example using a delta filter with the Blosc compressor::
    Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
    Compressors        : (BloscCodec(typesize=4, cname=<BloscCname.zstd: 'zstd'>, clevel=1, shuffle=<BloscShuffle.shuffle: 'shuffle'>, blocksize=0),)
    No. bytes          : 400000000 (381.5M)
+   No. bytes stored   : 826
+   Storage ratio      : 484261.5
+   Chunks Initialized : 0
 
 For more information about available filter codecs, see the `Numcodecs
 <https://numcodecs.readthedocs.io/>`_ documentation.
@@ -615,7 +618,7 @@ Sharded arrays can be created by providing the ``shards`` parameter to :func:`za
   Serializer         : BytesCodec(endian=None)
   Compressors        : (ZstdCodec(level=0, checksum=False),)
   No. bytes          : 100000000 (95.4M)
-  No. bytes stored   : 3981473
+  No. bytes stored   : 3981473 (3.8M)
   Storage ratio      : 25.1
   Shards Initialized : 100
 

--- a/docs/user-guide/groups.rst
+++ b/docs/user-guide/groups.rst
@@ -139,7 +139,7 @@ property. E.g.::
    Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
    Compressors        : (ZstdCodec(level=0, checksum=False),)
    No. bytes          : 8000000 (7.6M)
-   No. bytes stored   : 1614
+   No. bytes stored   : 1614 (1.6K)
    Storage ratio      : 4956.6
    Chunks Initialized : 10
    >>> baz.info

--- a/docs/user-guide/performance.rst
+++ b/docs/user-guide/performance.rst
@@ -133,7 +133,7 @@ ratios, depending on the correlation structure within the data. E.g.::
    Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
    Compressors        : (ZstdCodec(level=0, checksum=False),)
    No. bytes          : 400000000 (381.5M)
-   No. bytes stored   : 342588911
+   No. bytes stored   : 342588911 (326.7M)
    Storage ratio      : 1.2
    Chunks Initialized : 100
    >>> with zarr.config.set({'array.order': 'F'}):
@@ -153,7 +153,7 @@ ratios, depending on the correlation structure within the data. E.g.::
    Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
    Compressors        : (ZstdCodec(level=0, checksum=False),)
    No. bytes          : 400000000 (381.5M)
-   No. bytes stored   : 342588911
+   No. bytes stored   : 342588911 (326.7M)
    Storage ratio      : 1.2
    Chunks Initialized : 100
 

--- a/src/zarr/core/_info.py
+++ b/src/zarr/core/_info.py
@@ -133,7 +133,7 @@ class ArrayInfo:
 
         if self._count_bytes_stored is not None:
             template += "\nNo. bytes stored   : {_count_bytes_stored}"
-            kwargs["_count_stored"] = byte_info(self._count_bytes_stored)
+            kwargs["_count_bytes_stored"] = byte_info(self._count_bytes_stored)
 
         if (
             self._count_bytes is not None

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -79,7 +79,7 @@ def test_array_info(zarr_format: ZarrFormat) -> None:
 
 
 @pytest.mark.parametrize("zarr_format", ZARR_FORMATS)
-@pytest.mark.parametrize("bytes_things", [(1_000_000, "976.6K", 500_000, "500000", "2.0", 5)])
+@pytest.mark.parametrize("bytes_things", [(1_000_000, "976.6K", 500_000, "488.3K", "2.0", 5)])
 def test_array_info_complete(
     zarr_format: ZarrFormat, bytes_things: tuple[int, str, int, str, str, int]
 ) -> None:
@@ -120,7 +120,7 @@ def test_array_info_complete(
         Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
         Compressors        : ()
         No. bytes          : {count_bytes} ({count_bytes_formatted})
-        No. bytes stored   : {count_bytes_stored_formatted}
+        No. bytes stored   : {count_bytes_stored} ({count_bytes_stored_formatted})
         Storage ratio      : {storage_ratio_formatted}
         Chunks Initialized : 5""")
 


### PR DESCRIPTION
Example:

```python
>>> z.info_complete()
Type               : Array
Zarr format        : 3
Data type          : Int32(endianness='little')
Fill value         : 0
Shape              : (10000, 10000)
Chunk shape        : (1000, 1000)
Order              : C
Read-only          : False
Store type         : LocalStore
Filters            : ()
Serializer         : BytesCodec(endian=<Endian.little: 'little'>)
Compressors        : (BloscCodec(typesize=4, cname=<BloscCname.zstd: 'zstd'>, clevel=3, shuffle=<BloscShuffle.bitshuffle: 'bitshuffle'>, blocksize=0),)
No. bytes          : 400000000 (381.5M)
No. bytes stored   : 3558573 (3.4M)
Storage ratio      : 112.4
Chunks Initialized : 100
```


Note: I think this was the intention, looks like just a dict key misalignment.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
