### PR TITLE
fix: restore fill_value=None for zarr_format=2

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -774,15 +774,13 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         chunks: ChunkCoords,
         order: MemoryOrder,
         dimension_separator: Literal[".", "/"] | None = None,
-        fill_value: float | None = None,
+        fill_value: Any | None = None,
         filters: Iterable[dict[str, JSON] | numcodecs.abc.Codec] | None = None,
         compressor: CompressorLikev2 = None,
         attributes: dict[str, JSON] | None = None,
     ) -> ArrayV2Metadata:
         if dimension_separator is None:
             dimension_separator = "."
-        if fill_value is None:
-            fill_value = dtype.default_scalar()  # type: ignore[assignment]
         return ArrayV2Metadata(
             shape=shape,
             dtype=dtype,
@@ -806,7 +804,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         order: MemoryOrder,
         config: ArrayConfig,
         dimension_separator: Literal[".", "/"] | None = None,
-        fill_value: float | None = None,
+        fill_value: Any | None = None,
         filters: Iterable[dict[str, JSON] | numcodecs.abc.Codec] | None = None,
         compressor: CompressorLike = "auto",
         attributes: dict[str, JSON] | None = None,


### PR DESCRIPTION
Should fix #3197

Without this it is not possible to write "null" to the zarr format 2 fill value. 

@d-v-b 


TODO:
* [ ] Add unit tests and/or doctests in docstrings

* [NA] New/modified features documented in `docs/user-guide/*.rst`
* [NA] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
