### PR TITLE
"Backport PR #3193 on branch 3.0.10 (Remove breaking check about auto_mkdir for FSSpecStore)"

### DIFF
--- a/changes/3193.bugfix.rst
+++ b/changes/3193.bugfix.rst
@@ -1,0 +1,2 @@
+Removed an unnecessary check from ``_fsspec._make_async`` that would raise an exception when
+creating a read-only store backed by a local file system with ``auto_mkdir`` set  to ``False``.

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -56,19 +56,15 @@ def _make_async(fs: AbstractFileSystem) -> AsyncFileSystem:
         fs_dict["asynchronous"] = True
         return fsspec.AbstractFileSystem.from_json(json.dumps(fs_dict))
 
-    # Wrap sync filesystems with the async wrapper
-    if type(fs) is fsspec.implementations.local.LocalFileSystem and not fs.auto_mkdir:
-        raise ValueError(
-            f"LocalFilesystem {fs} was created with auto_mkdir=False but Zarr requires the filesystem to automatically create directories"
-        )
     if fsspec_version < parse_version("2024.12.0"):
         raise ImportError(
             f"The filesystem '{fs}' is synchronous, and the required "
             "AsyncFileSystemWrapper is not available. Upgrade fsspec to version "
             "2024.12.0 or later to enable this functionality."
         )
+    from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 
-    return fsspec.implementations.asyn_wrapper.AsyncFileSystemWrapper(fs, asynchronous=True)
+    return AsyncFileSystemWrapper(fs, asynchronous=True)
 
 
 class FsspecStore(Store):


### PR DESCRIPTION
* Remove breaking check from _make_async

* Update expected error

* Change import structure to protect against AttributeError

* changelog

* add test to ensure that we can create a read-only copy of the store with auto_mkdir=False

* only test if the async wrapper is available

---------


(cherry picked from commit 5a24487f09d499c91ce25f24af910c2ede055b5a)

[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
