### PR TITLE
Preventing Deadlocks When Reading Metadata Concurrently via `asyncio.gather`

### DIFF
--- a/changes/3207.bugfix.rst
+++ b/changes/3207.bugfix.rst
@@ -2,17 +2,14 @@
   opening Zarr v3 arrays on synchronous fsspec filesystems, by implementing a
   fallback to sequential reads for non-concurrency-safe filesystems, ensuring
   robust metadata retrieval without sacrificing performance for safe
-  filesystems. Furthermore ``Store.get_many`` was modified to retrieve objects
+  filesystems. Furthermore ``Store._get_many`` was modified to retrieve objects
   concurrently from storage. The previous implementation was sequential,
-  awaiting each ``self.get(*req)`` before proceeding, contrary to the docstring.
-- Introduced ``Store.get_many_ordered`` and ``StorePath.get_many_ordered`` to
-  retrieve multiple metadata files in a single call, optimizing the retrieval
-  process and reducing overhead. ``StorePath.get_many_ordered`` is used in
-  ``get_array_metadata``. ``Store._get_many_ordered`` is used in
-  ``_read_metadata_v2``.
-- Modified ``FsspecStore._get_many`` and ``FsspecStore._get_many_ordered``
-  to conditionally use ``asyncio.gather`` based on the concurrency safety
-  of the underlying file system, enhancing compatibility with
-  synchronous file systems by avoiding deadlocks when accessing metadata
-  concurrently. Adding tests ``LockableFileSystem`` to test with
-  async/sync behavior.
+  awaiting each ``self.get(*req)`` before proceeding, contrary to the
+  docstring.
+- Introduced ``StorePath.get_many``, mimicing the behaviour of `StorePath.get`.
+- Use ``Store._get_many`` and ``StorePath.get_many`` in ``get_array_metadata``.
+- Implemented ``FsspecStore._get_many`` to conditionally use ``asyncio.gather``
+  based on the concurrency safety of the underlying file system, enhancing
+  compatibility with synchronous file systems by avoiding deadlocks when
+  accessing metadata concurrently. Adding tests ``LockableFileSystem`` to test
+  with async/sync behavior.

--- a/changes/3207.bugfix.rst
+++ b/changes/3207.bugfix.rst
@@ -1,0 +1,18 @@
+- This pull request resolves the issue of deadlocks and indefinite hangs when
+  opening Zarr v3 arrays on synchronous fsspec filesystems, by implementing a
+  fallback to sequential reads for non-concurrency-safe filesystems, ensuring
+  robust metadata retrieval without sacrificing performance for safe
+  filesystems. Furthermore ``Store.get_many`` was modified to retrieve objects
+  concurrently from storage. The previous implementation was sequential,
+  awaiting each ``self.get(*req)`` before proceeding, contrary to the docstring.
+- Introduced ``Store.get_many_ordered`` and ``StorePath.get_many_ordered`` to
+  retrieve multiple metadata files in a single call, optimizing the retrieval
+  process and reducing overhead. ``StorePath.get_many_ordered`` is used in
+  ``get_array_metadata``. ``Store._get_many_ordered`` is used in
+  ``_read_metadata_v2``.
+- Modified ``FsspecStore._get_many`` and ``FsspecStore._get_many_ordered``
+  to conditionally use ``asyncio.gather`` based on the concurrency safety
+  of the underlying file system, enhancing compatibility with
+  synchronous file systems by avoiding deadlocks when accessing metadata
+  concurrently. Adding tests ``LockableFileSystem`` to test with
+  async/sync behavior.

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import gather
+from asyncio import as_completed, gather
 from dataclasses import dataclass
 from itertools import starmap
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
@@ -414,8 +414,27 @@ class Store(ABC):
         that objects will be retrieved in the order in which they were requested, so this method
         yields tuple[str, Buffer | None] instead of just Buffer | None
         """
-        for req in requests:
-            yield (req[0], await self.get(*req))
+
+        async def _get_with_name(
+            key: str, prototype: BufferPrototype, byte_range: ByteRequest | None
+        ) -> tuple[str, Buffer | None]:
+            value = await self.get(key, prototype, byte_range)
+            return key, value
+
+        tasks = [_get_with_name(*req) for req in requests]
+        for completed in as_completed(tasks):
+            task = await completed
+            yield task
+
+    async def _get_many_ordered(
+        self, requests: Iterable[tuple[str, BufferPrototype, ByteRequest | None]]
+    ) -> tuple[Buffer | None, ...]:
+        """
+        Retrieve a collection of objects from storage in the order they were requested.
+        """
+        tasks = [self.get(*req) for req in requests]
+
+        return tuple(await gather(*tasks))
 
     async def getsize(self, key: str) -> int:
         """

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -426,16 +426,6 @@ class Store(ABC):
             task = await completed
             yield task
 
-    async def _get_many_ordered(
-        self, requests: Iterable[tuple[str, BufferPrototype, ByteRequest | None]]
-    ) -> tuple[Buffer | None, ...]:
-        """
-        Retrieve a collection of objects from storage in the order they were requested.
-        """
-        tasks = [self.get(*req) for req in requests]
-
-        return tuple(await gather(*tasks))
-
     async def getsize(self, key: str) -> int:
         """
         Return the size, in bytes, of a value in a Store.

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -211,9 +211,10 @@ async def get_array_metadata(
     store_path: StorePath, zarr_format: ZarrFormat | None = 3
 ) -> dict[str, JSON]:
     if zarr_format == 2:
-        zarray_bytes, zattrs_bytes = await gather(
-            (store_path / ZARRAY_JSON).get(prototype=cpu_buffer_prototype),
-            (store_path / ZATTRS_JSON).get(prototype=cpu_buffer_prototype),
+        zarray_bytes, zattrs_bytes = await store_path.get_many_ordered(
+            ZARRAY_JSON,
+            ZATTRS_JSON,
+            prototype=cpu_buffer_prototype,
         )
         if zarray_bytes is None:
             raise FileNotFoundError(store_path)
@@ -222,10 +223,11 @@ async def get_array_metadata(
         if zarr_json_bytes is None:
             raise FileNotFoundError(store_path)
     elif zarr_format is None:
-        zarr_json_bytes, zarray_bytes, zattrs_bytes = await gather(
-            (store_path / ZARR_JSON).get(prototype=cpu_buffer_prototype),
-            (store_path / ZARRAY_JSON).get(prototype=cpu_buffer_prototype),
-            (store_path / ZATTRS_JSON).get(prototype=cpu_buffer_prototype),
+        zarr_json_bytes, zarray_bytes, zattrs_bytes = await store_path.get_many_ordered(
+            ZARR_JSON,
+            ZARRAY_JSON,
+            ZATTRS_JSON,
+            prototype=cpu_buffer_prototype,
         )
         if zarr_json_bytes is not None and zarray_bytes is not None:
             # warn and favor v3
@@ -1445,7 +1447,6 @@ class AsyncArray(Generic[T_ArrayMetadata]):
                         ).items()
                     ]
                 )
-
         await gather(*awaitables)
 
     async def _set_selection(

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -513,19 +513,23 @@ class AsyncGroup:
             consolidated_key = use_consolidated
 
         if zarr_format == 2:
-            paths = [store_path / ZGROUP_JSON, store_path / ZATTRS_JSON]
+            requests = [
+                (key, default_buffer_prototype(), None) for key in [ZGROUP_JSON, ZATTRS_JSON]
+            ]
             if use_consolidated or use_consolidated is None:
-                paths.append(store_path / consolidated_key)
+                requests.append((consolidated_key, default_buffer_prototype(), None))
 
-            zgroup_bytes, zattrs_bytes, *rest = await asyncio.gather(
-                *[path.get() for path in paths]
+            retrieved_buffers = {key: value async for key, value in store_path.get_many(requests)}
+            zgroup_bytes, zattrs_bytes = (
+                retrieved_buffers[ZGROUP_JSON],
+                retrieved_buffers[ZATTRS_JSON],
             )
+
             if zgroup_bytes is None:
                 raise FileNotFoundError(store_path)
 
             if use_consolidated or use_consolidated is None:
-                maybe_consolidated_metadata_bytes = rest[0]
-
+                maybe_consolidated_metadata_bytes = retrieved_buffers[consolidated_key]
             else:
                 maybe_consolidated_metadata_bytes = None
 
@@ -534,17 +538,18 @@ class AsyncGroup:
             if zarr_json_bytes is None:
                 raise FileNotFoundError(store_path)
         elif zarr_format is None:
+            requests = [
+                (key, default_buffer_prototype(), None)
+                for key in [ZARR_JSON, ZGROUP_JSON, ZATTRS_JSON, consolidated_key]
+            ]
+            retrieved_buffers = {key: value async for key, value in store_path.get_many(requests)}
             (
                 zarr_json_bytes,
                 zgroup_bytes,
                 zattrs_bytes,
                 maybe_consolidated_metadata_bytes,
-            ) = await store_path.get_many_ordered(
-                ZARR_JSON,
-                ZGROUP_JSON,
-                ZATTRS_JSON,
-                consolidated_key,
-            )
+            ) = tuple(retrieved_buffers.get(req[0]) for req in requests)
+
             if zarr_json_bytes is not None and zgroup_bytes is not None:
                 # warn and favor v3
                 msg = f"Both zarr.json (Zarr format 3) and .zgroup (Zarr format 2) metadata objects exist at {store_path}. Zarr format 3 will be used."
@@ -3476,12 +3481,14 @@ async def _read_metadata_v2(store: Store, path: str) -> ArrayV2Metadata | GroupM
     """
     # TODO: consider first fetching array metadata, and only fetching group metadata when we don't
     # find an array
-    zarray_bytes, zgroup_bytes, zattrs_bytes = await store._get_many_ordered(
-        [
-            (_join_paths([path, ZARRAY_JSON]), default_buffer_prototype(), None),
-            (_join_paths([path, ZGROUP_JSON]), default_buffer_prototype(), None),
-            (_join_paths([path, ZATTRS_JSON]), default_buffer_prototype(), None),
-        ]
+    requests = [
+        (_join_paths([path, ZARRAY_JSON]), default_buffer_prototype(), None),
+        (_join_paths([path, ZGROUP_JSON]), default_buffer_prototype(), None),
+        (_join_paths([path, ZATTRS_JSON]), default_buffer_prototype(), None),
+    ]
+    retrieved_buffers = {key: value async for key, value in store._get_many(requests)}
+    zarray_bytes, zgroup_bytes, zattrs_bytes = tuple(
+        retrieved_buffers.get(req[0]) for req in requests
     )
 
     if zattrs_bytes is None:

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -331,24 +331,12 @@ class FsspecStore(Store):
         self, requests: Iterable[tuple[str, BufferPrototype, ByteRequest | None]]
     ) -> AsyncGenerator[tuple[str, Buffer | None], None]:
         if getattr(self.fs, "asynchronous", True):
-            async for key, value in super()._get_many(requests):
-                yield (key, value)
+            async for result in super()._get_many(requests):
+                yield result
         else:
             for key, prototype, byte_range in requests:
                 value = await self.get(key, prototype, byte_range)
                 yield (key, value)
-    
-    async def _get_many_ordered(
-        self, requests: Iterable[tuple[str, BufferPrototype, ByteRequest | None]]
-    ) -> tuple[Buffer | None, ...]:
-        if getattr(self.fs, "asynchronous", True):
-            return await super()._get_many_ordered(requests)
-        else:
-            results = []
-            for key, prototype, byte_range in requests:
-                value = await self.get(key, prototype, byte_range)
-                results.append(value)
-            return tuple(results)
 
     async def set(
         self,

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -265,30 +265,6 @@ class StoreTests(Generic[S, B]):
         expected_kvs = sorted(((k, b) for k, b in zip(keys, values, strict=False)))
         assert observed_kvs == expected_kvs
 
-    async def test_get_many_ordered(self, store: S) -> None:
-        """
-        Ensure that multiple keys can be retrieved at once with the _get_many method,
-        preserving the order of keys.
-        """
-        keys = tuple(map(str, range(10)))
-        values = tuple(f"{k}".encode() for k in keys)
-
-        for k, v in zip(keys, values, strict=False):
-            await self.set(store, k, self.buffer_cls.from_bytes(v))
-
-        observed_buffers = await store._get_many_ordered(
-            tuple(
-                zip(
-                    keys,
-                    (default_buffer_prototype(),) * len(keys),
-                    (None,) * len(keys),
-                    strict=False,
-                )
-            )
-        )
-        observed_bytes = tuple(b.to_bytes() for b in observed_buffers if b is not None)
-        assert observed_bytes == values, f"Expected {values}, got {observed_bytes}"
-
     @pytest.mark.parametrize("key", ["c/0", "foo/c/0.0", "foo/0/0"])
     @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
     async def test_getsize(self, store: S, key: str, data: bytes) -> None:

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -265,6 +265,30 @@ class StoreTests(Generic[S, B]):
         expected_kvs = sorted(((k, b) for k, b in zip(keys, values, strict=False)))
         assert observed_kvs == expected_kvs
 
+    async def test_get_many_ordered(self, store: S) -> None:
+        """
+        Ensure that multiple keys can be retrieved at once with the _get_many method,
+        preserving the order of keys.
+        """
+        keys = tuple(map(str, range(10)))
+        values = tuple(f"{k}".encode() for k in keys)
+
+        for k, v in zip(keys, values, strict=False):
+            await self.set(store, k, self.buffer_cls.from_bytes(v))
+
+        observed_buffers = await store._get_many_ordered(
+            tuple(
+                zip(
+                    keys,
+                    (default_buffer_prototype(),) * len(keys),
+                    (None,) * len(keys),
+                    strict=False,
+                )
+            )
+        )
+        observed_bytes = tuple(b.to_bytes() for b in observed_buffers if b is not None)
+        assert observed_bytes == values, f"Expected {values}, got {observed_bytes}"
+
     @pytest.mark.parametrize("key", ["c/0", "foo/c/0.0", "foo/0/0"])
     @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
     async def test_getsize(self, store: S, key: str, data: bytes) -> None:

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -532,25 +532,10 @@ class TestLockableFSSPECFileSystem:
         results = []
         async for k, v in self.store_sync._get_many(requests):
             results.append((k, v.to_bytes() if v else None))
-        # Results should already be in the same order as requests
+        # In the synchronous case, results should be in the same order as requests
 
         assert results == true_results
 
-    async def test_get_many_ordered_synchronous_fs(self):
-        requests, true_results = self.get_requests_and_true_results()
-
-        results = await self.store_sync._get_many_ordered(requests)
-        results = [value.to_bytes() if value else None for value in results]
-
-        assert results == [value[1] for value in true_results]
-
-    async def test_get_many_ordered_asynchronous_fs(self):
-        requests, true_results = self.get_requests_and_true_results()
-
-        results = await self.store_async._get_many_ordered(requests)
-        results = [value.to_bytes() if value else None for value in results]
-
-        assert results == [value[1] for value in true_results]
 
     async def test_asynchronous_locked_fs_raises(self):
         store = LockableFileSystem(asynchronous=True, lock=True).get_store(path="root")
@@ -559,6 +544,3 @@ class TestLockableFSSPECFileSystem:
         with pytest.raises(RuntimeError, match="Concurrent requests!"):
             async for _, _ in store._get_many(requests):
                 pass
-
-        with pytest.raises(RuntimeError, match="Concurrent requests!"):
-            await store._get_many_ordered(requests)


### PR DESCRIPTION
As described in #3196, I encountered issues opening Zarr v3 arrays stored over SFTP using `fsspec`. Specifically, python would freeze opening zarr arrays.

#### Root Cause

The issue stems from the use of `asyncio.gather` in `zarr.core.array.get_array_metadata`, which attempts to read multiple metadata files (e.g., `.zarray`, `.zattrs`, `zarr.json`) concurrently. This works well for truly asynchronous filesystems, but breaks when using systems like `SFTPFileSystem`, which does not seem to be concurrency-safe in async contexts (potentially relying on blocking I/O internally or managing connection states using global locks) leading to deadlocks or indefinite hangs when `asyncio.gather` is used to perform multiple reads simultaneously.

#### Solution

To address this, I’ve implemented a fallback to **sequential reads** for filesystems that are not concurrency-safe. The logic is as follows: For non asynchronous file systems, the user sets `store.fs.asynchronous=False`. The helper function `is_concurrency_safe(store_path: StorePath) -> bool`, checks this `getattr(fs, "asynchronous", True)`. If True `asyncio.gather` is used, else we fall back to sequential `await`. This Preserves the performance benefit of concurrent reads for safe filesystems (e.g., local disk, S3, GCS), while preventing deadlocks and improved robustness when using backends like SFTP.

These changes may not address all scenarios not asynchronous file systems could cause issues, as there are several other instances of `asyncio.gather` in `zarr.core.array` and `zarr.core.group`. However, I opted to focus on this specific problem first, as enabling the opening of arrays and groups is likely the highest priority, and I wanted to discuss this approach before making too many changes.

I look forward to hearing your thoughts and seeing this issue resolved!

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
