### PR TITLE
Fix race condition in from_array for arrays with shards

### DIFF
--- a/changes/3169.bugfix.rst
+++ b/changes/3169.bugfix.rst
@@ -1,0 +1,1 @@
+Fix race condition when passing array data in ``create_array(data=..)`` for an array that has a set shard size.

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1644,6 +1644,30 @@ async def test_from_array(
     assert result.chunks == new_chunks
 
 
+@pytest.mark.parametrize("store", ["memory"], indirect=True)
+@pytest.mark.parametrize("chunks", [(10, 10)])
+@pytest.mark.parametrize("shards", [(60, 60)])
+async def test_from_array_shards(
+    store: Store,
+    zarr_format: ZarrFormat,
+    chunks: tuple[int, ...],
+    shards: tuple[int, ...],
+) -> None:
+    # Regression test for https://github.com/zarr-developers/zarr-python/issues/3169
+    source_data = np.arange(3600).reshape((60, 60))
+
+    zarr.create_array(
+        store=store,
+        data=source_data,
+        chunks=chunks,
+        shards=shards,
+    )
+
+    array = zarr.open_array(store=store)
+
+    assert np.array_equal(array[:], source_data)
+
+
 @pytest.mark.parametrize("store", ["local"], indirect=True)
 @pytest.mark.parametrize("chunks", ["keep", "auto"])
 @pytest.mark.parametrize("write_data", [True, False])


### PR DESCRIPTION
Fixes #3169.

When passing data via `create_array(data = ...)`, the data is inserted by `from_array` after getting split by chunks. In current main, when using shards, `from_array` ends up splitting the data by sub-chunks (due to `AsyncArray.chunks` returning `Metadata.chunks` which returns the size of the chunks inside shards instead of the size of the "physical" chunk files), which ends up creating a race condition when the writes to multiple sub-chunk end up writing to the same physical chunk file.
This PR changes `from_array` to instead split the data by shard in case there are shards.

(Probably, there needs to be a lock somewhere in AsyncArray or ShardCodec which prevents multiple writes to the same shard (or, just physical chunk in general) to execute at the same time)

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
