### PR TITLE
Remove redundant release note

### DIFF
--- a/changes/3151.bugfix.rst
+++ b/changes/3151.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed an issue preventing correct parsing of NumPy ``int32`` dtypes when constructed via
-``np.dtype('i')``.


### PR DESCRIPTION
I think this was a fix to code introduced for the first time in 3.1.0 anyway, so this release note isn't needed for users?

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
