### PR TITLE
Fix type of v2 compressors

### DIFF
--- a/changes/3232.bugfix.rst
+++ b/changes/3232.bugfix.rst
@@ -1,0 +1,3 @@
+Fix the type of ``ArrayV2Metadata.codec`` to constrain it to ``numcodecs.abc.Codec | None``.
+Previously the type was more permissive, allowing objects that can be parsed into Codecs (e.g., the codec name).
+The constructor of ``ArrayV2Metadata`` still allows the permissive input when creating new objects.

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -68,7 +68,7 @@ class ArrayV2Metadata(Metadata):
     order: MemoryOrder = "C"
     filters: tuple[numcodecs.abc.Codec, ...] | None = None
     dimension_separator: Literal[".", "/"] = "."
-    compressor: CompressorLikev2
+    compressor: numcodecs.abc.Codec | None
     attributes: dict[str, JSON] = field(default_factory=dict)
     zarr_format: Literal[2] = field(init=False, default=2)
 


### PR DESCRIPTION
Because `__init__` parses a `CompressorLikev2` input, I *think* the actual attribute type should simply be a `Codec` or None.