### PR TITLE
fix obstore type hints

### DIFF
--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -16,7 +16,7 @@ from zarr.abc.store import (
 from zarr.core.config import config
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Coroutine, Iterable
+    from collections.abc import AsyncGenerator, Coroutine, Iterable, Sequence
     from typing import Any
 
     from obstore import ListResult, ListStream, ObjectMeta, OffsetRange, SuffixRange
@@ -216,14 +216,14 @@ class ObjectStore(Store):
         # docstring inherited
         import obstore as obs
 
-        objects: ListStream[list[ObjectMeta]] = obs.list(self.store)
+        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store)  # type: ignore[type-var, assignment]
         return _transform_list(objects)
 
     def list_prefix(self, prefix: str) -> AsyncGenerator[str, None]:
         # docstring inherited
         import obstore as obs
 
-        objects: ListStream[list[ObjectMeta]] = obs.list(self.store, prefix=prefix)
+        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store, prefix=prefix)  # type: ignore[assignment, type-var]
         return _transform_list(objects)
 
     def list_dir(self, prefix: str) -> AsyncGenerator[str, None]:
@@ -231,11 +231,11 @@ class ObjectStore(Store):
         import obstore as obs
 
         coroutine = obs.list_with_delimiter_async(self.store, prefix=prefix)
-        return _transform_list_dir(coroutine, prefix)
+        return _transform_list_dir(coroutine, prefix)  # type: ignore[arg-type]
 
 
 async def _transform_list(
-    list_stream: ListStream[list[ObjectMeta]],
+    list_stream: ListStream[Sequence[ObjectMeta]],  # type: ignore[type-var]
 ) -> AsyncGenerator[str, None]:
     """
     Transform the result of list into an async generator of paths.
@@ -246,7 +246,8 @@ async def _transform_list(
 
 
 async def _transform_list_dir(
-    list_result_coroutine: Coroutine[Any, Any, ListResult[list[ObjectMeta]]], prefix: str
+    list_result_coroutine: Coroutine[Any, Any, ListResult[Sequence[ObjectMeta]]],  # type: ignore[type-var]
+    prefix: str,
 ) -> AsyncGenerator[str, None]:
     """
     Transform the result of list_with_delimiter into an async generator of paths.

--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -216,14 +216,14 @@ class ObjectStore(Store):
         # docstring inherited
         import obstore as obs
 
-        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store)  # type: ignore[type-var, assignment]
+        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store)
         return _transform_list(objects)
 
     def list_prefix(self, prefix: str) -> AsyncGenerator[str, None]:
         # docstring inherited
         import obstore as obs
 
-        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store, prefix=prefix)  # type: ignore[assignment, type-var]
+        objects: ListStream[Sequence[ObjectMeta]] = obs.list(self.store, prefix=prefix)
         return _transform_list(objects)
 
     def list_dir(self, prefix: str) -> AsyncGenerator[str, None]:
@@ -231,11 +231,11 @@ class ObjectStore(Store):
         import obstore as obs
 
         coroutine = obs.list_with_delimiter_async(self.store, prefix=prefix)
-        return _transform_list_dir(coroutine, prefix)  # type: ignore[arg-type]
+        return _transform_list_dir(coroutine, prefix)
 
 
 async def _transform_list(
-    list_stream: ListStream[Sequence[ObjectMeta]],  # type: ignore[type-var]
+    list_stream: ListStream[Sequence[ObjectMeta]],
 ) -> AsyncGenerator[str, None]:
     """
     Transform the result of list into an async generator of paths.
@@ -246,7 +246,7 @@ async def _transform_list(
 
 
 async def _transform_list_dir(
-    list_result_coroutine: Coroutine[Any, Any, ListResult[Sequence[ObjectMeta]]],  # type: ignore[type-var]
+    list_result_coroutine: Coroutine[Any, Any, ListResult[Sequence[ObjectMeta]]],
     prefix: str,
 ) -> AsyncGenerator[str, None]:
     """


### PR DESCRIPTION
mypy was flagging problems with some of the obstore type annotations. I don't know what change precipitated these new errors, but this PR silences them by adding type: ignore statements. Obviously fixing the type annotations would be even better, but several obvious things that I attempted did not work, so I think we need an obstore expert for a real fix (@kylebarron)

until then, this PR keeps our CI clean

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
