### PR TITLE
don't test self-deletion in stateful tests

### DIFF
--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -343,6 +343,8 @@ class ZarrHierarchyStateMachine(SyncMixin, RuleBasedStateMachine):
     @precondition(lambda self: len(self.all_groups) >= 2)  # fixme don't delete root
     @rule(data=st.data())
     def delete_group_using_del(self, data: DataObject) -> None:
+        # ensure that we don't include the root group in the list of member names that we try
+        # to delete
         member_names = tuple(filter(lambda v: "/" in v, sorted(self.all_groups)))
         group_path = data.draw(st.sampled_from(member_names), label="Group deletion target")
         prefix, group_name = split_prefix_name(group_path)

--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -343,8 +343,8 @@ class ZarrHierarchyStateMachine(SyncMixin, RuleBasedStateMachine):
     @precondition(lambda self: len(self.all_groups) >= 2)  # fixme don't delete root
     @rule(data=st.data())
     def delete_group_using_del(self, data: DataObject) -> None:
-        members = tuple(filter(lambda v: "/" in v, sorted(self.all_groups)))
-        group_path = data.draw(st.sampled_from(members), label="Group deletion target")
+        member_names = tuple(filter(lambda v: "/" in v, sorted(self.all_groups)))
+        group_path = data.draw(st.sampled_from(member_names), label="Group deletion target")
         prefix, group_name = split_prefix_name(group_path)
         note(f"Deleting group '{group_path=!r}', {prefix=!r}, {group_name=!r} using delete")
         members = zarr.open_group(store=self.model, path=group_path).members(max_depth=None)

--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -343,9 +343,8 @@ class ZarrHierarchyStateMachine(SyncMixin, RuleBasedStateMachine):
     @precondition(lambda self: len(self.all_groups) >= 2)  # fixme don't delete root
     @rule(data=st.data())
     def delete_group_using_del(self, data: DataObject) -> None:
-        group_path = data.draw(
-            st.sampled_from(sorted(self.all_groups)), label="Group deletion target"
-        )
+        members = tuple(filter(lambda v: "/" in v, sorted(self.all_groups)))
+        group_path = data.draw(st.sampled_from(members), label="Group deletion target")
         prefix, group_name = split_prefix_name(group_path)
         note(f"Deleting group '{group_path=!r}', {prefix=!r}, {group_name=!r} using delete")
         members = zarr.open_group(store=self.model, path=group_path).members(max_depth=None)


### PR DESCRIPTION
This PR prevents the stateful group tests from deleting the root group

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
