### PR TITLE
Set correct chunk shape when using shards

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -4321,9 +4321,7 @@ async def init_array(
                 chunk_grid=RegularChunkGrid(chunk_shape=shard_shape_parsed),
             )
             codecs_out = (sharding_codec,)
-            chunks_out = shard_shape_parsed
         else:
-            chunks_out = chunk_shape_parsed
             codecs_out = sub_codecs
 
         if config is None:
@@ -4335,7 +4333,7 @@ async def init_array(
             shape=shape_parsed,
             dtype=zdtype,
             fill_value=fill_value,
-            chunk_shape=chunks_out,
+            chunk_shape=chunk_shape_parsed,
             chunk_key_encoding=chunk_key_encoding_parsed,
             codecs=codecs_out,
             dimension_names=dimension_names,


### PR DESCRIPTION
This makes sure the chunk shape is the chunk shape, and not the shard shape. I'm not sure why the chunk shape was being set to the shard shape, but I am worried this is going to break things, or at least pulling on this might result in a bit of a mess 😬 

This is the root cause of, and fixes https://github.com/zarr-developers/zarr-python/issues/3221

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
