### PR TITLE
Add numcodecs to downstream projects to check before release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -25,6 +25,7 @@ assignees: ''
   - [ ] All tests pass in the ["GPU Tests" workflow](https://github.com/zarr-developers/zarr-python/actions/workflows/gpu_test.yml).
   - [ ] All tests pass in the ["Hypothesis" workflow](https://github.com/zarr-developers/zarr-python/actions/workflows/hypothesis.yaml).
   - [ ] Check that downstream libraries work well (maintainers can make executive decisions about whether all checks are required for this release).
+    - [ ] numcodecs 
     - [ ] Xarray (@jhamman @dcherian @TomNicholas)
         - Zarr's upstream compatibility is tested via the [Upstream Dev CI worklow](https://github.com/pydata/xarray/actions/workflows/upstream-dev-ci.yaml).
         - Click on the most recent workflow and check that the `upstream-dev` job has run and passed. `upstream-dev` is not run on all all workflow runs.


### PR DESCRIPTION
Zarr 3.1.0 broke numcodecs tests (see runs on https://github.com/zarr-developers/numcodecs/pull/762), so add `numcodecs` to the list of downstream packages to check before release in the future.