### PR TITLE
Apply ruff/flake8-pytest-style rule PT012

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,6 @@ extend-select = [
 ignore = [
     "ANN401",
     "PT011",  # TODO: apply this rule
-    "PT012",  # TODO: apply this rule
     "PT030",  # TODO: apply this rule
     "PT031",  # TODO: apply this rule
     "RET505",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -259,9 +259,9 @@ def test_save_errors() -> None:
     with pytest.raises(ValueError):
         # no arrays provided
         save("data/group.zarr")
+    a = np.arange(10)
     with pytest.raises(TypeError):
         # mode is no valid argument and would get handled as an array
-        a = np.arange(10)
         zarr.save("data/example.zarr", a, mode="w")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,8 +141,8 @@ def test_config_codec_pipeline_class(store: Store) -> None:
 
     _mock.call.assert_called()
 
+    config.set({"codec_pipeline.path": "wrong_name"})
     with pytest.raises(BadConfigError):
-        config.set({"codec_pipeline.path": "wrong_name"})
         get_pipeline_class()
 
     class MockEnvCodecPipeline(CodecPipeline):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -655,12 +655,13 @@ def test_group_create_array(
 
     if not overwrite:
         if method == "create_array":
-            with pytest.raises(ContainsArrayError):
+            with pytest.raises(ContainsArrayError):  # noqa: PT012
                 a = group.create_array(name=name, shape=shape, dtype=dtype)
                 a[:] = data
         elif method == "array":
-            with pytest.raises(ContainsArrayError), pytest.warns(DeprecationWarning):
-                a = group.array(name=name, shape=shape, dtype=dtype)
+            with pytest.raises(ContainsArrayError):  # noqa: PT012
+                with pytest.warns(DeprecationWarning):
+                    a = group.array(name=name, shape=shape, dtype=dtype)
                 a[:] = data
 
     assert array.path == normalize_path(name)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1093,17 +1093,17 @@ def test_get_coordinate_selection_2d(store: StorePath) -> None:
     ix1 = np.array([[1, 3, 2], [1, 0, 0]])
     _test_get_coordinate_selection(a, z, (ix0, ix1))
 
+    selection = slice(5, 15), [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = slice(5, 15), [1, 2, 3]
         z.get_coordinate_selection(selection)  # type:ignore[arg-type]
+    selection = [1, 2, 3], slice(5, 15)
     with pytest.raises(IndexError):
-        selection = [1, 2, 3], slice(5, 15)
         z.get_coordinate_selection(selection)  # type:ignore[arg-type]
+    selection = Ellipsis, [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = Ellipsis, [1, 2, 3]
         z.get_coordinate_selection(selection)  # type:ignore[arg-type]
+    selection = Ellipsis
     with pytest.raises(IndexError):
-        selection = Ellipsis
         z.get_coordinate_selection(selection)  # type:ignore[arg-type]
 
 
@@ -1299,14 +1299,14 @@ def test_get_block_selection_2d(store: StorePath) -> None:
     ):
         _test_get_block_selection(a, z, selection, expected_idx)
 
+    selection = slice(5, 15), [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = slice(5, 15), [1, 2, 3]
         z.get_block_selection(selection)
+    selection = Ellipsis, [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = Ellipsis, [1, 2, 3]
         z.get_block_selection(selection)
+    selection = slice(15, 20), slice(None)
     with pytest.raises(IndexError):  # out of bounds
-        selection = slice(15, 20), slice(None)
         z.get_block_selection(selection)
 
 
@@ -1360,14 +1360,14 @@ def test_set_block_selection_2d(store: StorePath) -> None:
     ):
         _test_set_block_selection(v, a, z, selection, expected_idx)
 
+    selection = slice(5, 15), [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = slice(5, 15), [1, 2, 3]
         z.set_block_selection(selection, 42)
+    selection = Ellipsis, [1, 2, 3]
     with pytest.raises(IndexError):
-        selection = Ellipsis, [1, 2, 3]
         z.set_block_selection(selection, 42)
+    selection = slice(15, 20), slice(None)
     with pytest.raises(IndexError):  # out of bounds
-        selection = slice(15, 20), slice(None)
         z.set_block_selection(selection, 42)
 
 


### PR DESCRIPTION
PT012 `pytest.raises()` block should contain a single simple statement

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
