### PR TITLE
Apply ruff/flake8-pytest-style rule PT030

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,6 @@ extend-select = [
 ignore = [
     "ANN401",
     "PT011",  # TODO: apply this rule
-    "PT030",  # TODO: apply this rule
     "RET505",
     "RET506",
     "RUF005",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -470,7 +470,7 @@ def test_tree() -> None:
     g3.create_group("baz")
     g5 = g3.create_group("qux")
     g5.create_array("baz", shape=(100,), chunks=(10,), dtype="float64")
-    with pytest.warns(DeprecationWarning):  # noqa: PT031
+    with pytest.warns(DeprecationWarning, match=r"Group\.tree instead\."):  # noqa: PT031
         assert repr(zarr.tree(g1)) == repr(g1.tree())
         assert str(zarr.tree(g1)) == str(g1.tree())
 

--- a/tests/test_codecs/test_codecs.py
+++ b/tests/test_codecs/test_codecs.py
@@ -355,7 +355,10 @@ def test_invalid_metadata(store: Store) -> None:
             ],
         )
     spath7 = StorePath(store, "warning_inefficient_codecs")
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+        UserWarning,
+        match="Combining a `sharding_indexed` codec disables partial reads and writes, which may lead to inefficient performance",
+    ):
         Array.create(
             spath7,
             shape=(16, 16),
@@ -372,7 +375,10 @@ def test_invalid_metadata(store: Store) -> None:
 @pytest.mark.parametrize("store", ["local", "memory"], indirect=["store"])
 def test_invalid_metadata_create_array(store: Store) -> None:
     spath = StorePath(store, "warning_inefficient_codecs")
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+        UserWarning,
+        match="codec disables partial reads and writes, which may lead to inefficient performance",
+    ):
         zarr.create_array(
             spath,
             shape=(16, 16),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -287,7 +287,7 @@ def test_warning_on_missing_codec_config() -> None:
 
     # warning because multiple implementations are available but none is selected in the config
     register_codec("new_codec", NewCodec2)
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match="not configured in config. Selecting any implementation"):
         get_codec_class("new_codec")
 
     # no warning if multiple implementations are available and one is selected in the config

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -648,7 +648,7 @@ def test_group_create_array(
         array = group.create_array(name=name, shape=shape, dtype=dtype)
         array[:] = data
     elif method == "array":
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."):
             array = group.array(name=name, data=data, shape=shape, dtype=dtype)
     else:
         raise AssertionError
@@ -660,7 +660,7 @@ def test_group_create_array(
                 a[:] = data
         elif method == "array":
             with pytest.raises(ContainsArrayError):  # noqa: PT012
-                with pytest.warns(DeprecationWarning):
+                with pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."):
                     a = group.array(name=name, shape=shape, dtype=dtype)
                 a[:] = data
 
@@ -1184,22 +1184,28 @@ def test_create_dataset_with_data(store: Store, zarr_format: ZarrFormat) -> None
     """
     root = Group.from_store(store=store, zarr_format=zarr_format)
     arr = np.random.random((5, 5))
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."):
         data = root.create_dataset("random", data=arr, shape=arr.shape)
     np.testing.assert_array_equal(np.asarray(data), arr)
 
 
 async def test_create_dataset(store: Store, zarr_format: ZarrFormat) -> None:
     root = await AsyncGroup.from_store(store=store, zarr_format=zarr_format)
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."):
         foo = await root.create_dataset("foo", shape=(10,), dtype="uint8")
     assert foo.shape == (10,)
 
-    with pytest.raises(ContainsArrayError), pytest.warns(DeprecationWarning):
+    with (
+        pytest.raises(ContainsArrayError),
+        pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."),
+    ):
         await root.create_dataset("foo", shape=(100,), dtype="int8")
 
     _ = await root.create_group("bar")
-    with pytest.raises(ContainsGroupError), pytest.warns(DeprecationWarning):
+    with (
+        pytest.raises(ContainsGroupError),
+        pytest.warns(DeprecationWarning, match=r"Group\.create_array instead\."),
+    ):
         await root.create_dataset("bar", shape=(100,), dtype="int8")
 
 


### PR DESCRIPTION
PT030 `pytest.warns(UserWarning)` is too broad, set the `match` parameter or use a more specific warning

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
