### PR TITLE
Give codecs docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -437,7 +437,6 @@ checks = [
     # Currently broken; see https://github.com/numpy/numpydoc/issues/573
     # "GL09",
     "GL10",
-    "SS02",
     "SS04",
     "PR02",
     "PR03",

--- a/src/zarr/codecs/blosc.py
+++ b/src/zarr/codecs/blosc.py
@@ -87,6 +87,8 @@ def parse_blocksize(data: JSON) -> int:
 
 @dataclass(frozen=True)
 class BloscCodec(BytesBytesCodec):
+    """blosc codec"""
+
     is_fixed_size = False
 
     typesize: int | None

--- a/src/zarr/codecs/bytes.py
+++ b/src/zarr/codecs/bytes.py
@@ -33,6 +33,8 @@ default_system_endian = Endian(sys.byteorder)
 
 @dataclass(frozen=True)
 class BytesCodec(ArrayBytesCodec):
+    """bytes codec"""
+
     is_fixed_size = True
 
     endian: Endian | None

--- a/src/zarr/codecs/crc32c_.py
+++ b/src/zarr/codecs/crc32c_.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Crc32cCodec(BytesBytesCodec):
+    """crc32c codec"""
+
     is_fixed_size = True
 
     @classmethod

--- a/src/zarr/codecs/gzip.py
+++ b/src/zarr/codecs/gzip.py
@@ -30,6 +30,8 @@ def parse_gzip_level(data: JSON) -> int:
 
 @dataclass(frozen=True)
 class GzipCodec(BytesBytesCodec):
+    """gzip codec"""
+
     is_fixed_size = False
 
     level: int = 5

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -333,6 +333,8 @@ class _MergingShardBuilder(ShardMutableMapping):
 class ShardingCodec(
     ArrayBytesCodec, ArrayBytesCodecPartialDecodeMixin, ArrayBytesCodecPartialEncodeMixin
 ):
+    """Sharding codec"""
+
     chunk_shape: ChunkCoords
     codecs: tuple[Codec, ...]
     index_codecs: tuple[Codec, ...]

--- a/src/zarr/codecs/transpose.py
+++ b/src/zarr/codecs/transpose.py
@@ -29,6 +29,8 @@ def parse_transpose_order(data: JSON | Iterable[int]) -> tuple[int, ...]:
 
 @dataclass(frozen=True)
 class TransposeCodec(ArrayArrayCodec):
+    """Transpose codec"""
+
     is_fixed_size = True
 
     order: tuple[int, ...]

--- a/src/zarr/codecs/vlen_utf8.py
+++ b/src/zarr/codecs/vlen_utf8.py
@@ -24,6 +24,8 @@ _vlen_bytes_codec = VLenBytes()
 
 @dataclass(frozen=True)
 class VLenUTF8Codec(ArrayBytesCodec):
+    """Variable-length UTF8 codec"""
+
     @classmethod
     def from_dict(cls, data: dict[str, JSON]) -> Self:
         _, configuration_parsed = parse_named_configuration(

--- a/src/zarr/codecs/zstd.py
+++ b/src/zarr/codecs/zstd.py
@@ -37,6 +37,8 @@ def parse_checksum(data: JSON) -> bool:
 
 @dataclass(frozen=True)
 class ZstdCodec(BytesBytesCodec):
+    """zstd codec"""
+
     is_fixed_size = True
 
     level: int = 0


### PR DESCRIPTION
This should improve the look of the table at https://zarr.readthedocs.io/en/stable/api/zarr/codecs/index.html, which currently just has a lot of base class docstrings.