### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
@@ -47,7 +47,6 @@ classifiers = [
     'Intended Audience :: Developers',
     'Intended Audience :: Information Technology',
     'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Operating System :: Unix',
@@ -56,7 +55,8 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
 ]
-license = {text = "MIT License"}
+license = "MIT"
+license-files = ["LICENSE.txt"]
 keywords = ["Python", "compressed", "ndimensional-arrays", "zarr"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Declare licenses using only these two fields, as per PEP 639:
* `license`:       SPDX license expression consisting of one or more license identifiers
* `license-files`: list of license file glob patterns

Supported by hatchling ≥ 1.27.0:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
