### PR TITLE
Fix incorrect Group.nmembers for consolidated metadata

### DIFF
--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -1307,7 +1307,7 @@ class AsyncGroup:
         # check if we can use consolidated metadata, which requires that we have non-None
         # consolidated metadata at all points in the hierarchy.
         if self.metadata.consolidated_metadata is not None:
-            return len(self.metadata.consolidated_metadata.flattened_metadata)
+            return len([x for x in self.metadata.consolidated_metadata.flattened_metadata if x.count("/") <= max_depth])
         # TODO: consider using aioitertools.builtins.sum for this
         # return await aioitertools.builtins.sum((1 async for _ in self.members()), start=0)
         n = 0

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1118,6 +1118,13 @@ async def test_group_members_async(store: Store, consolidated_metadata: bool) ->
             "consolidated_metadata",
             None,
         )
+        # test depth=0
+        nmembers = await group.nmembers(max_depth=0)
+        assert nmembers == 2
+        # test depth=1
+        nmembers = await group.nmembers(max_depth=1)
+        assert nmembers == 4
+        # test depth=None
         all_children = sorted(
             [x async for x in group.members(max_depth=None)], key=operator.itemgetter(0)
         )


### PR DESCRIPTION
Addresses the issue where `Group.nmembers()` doesn't honor the `max_depth` when the group has consolidated metadata. This simply filters `flattened_metadata` according to the number of `/` in the sub-elements' paths, which is analogous to checking the depth.

Closes #3252

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
