### PR TITLE
Put back parse_data_type import

### DIFF
--- a/src/zarr/dtype.py
+++ b/src/zarr/dtype.py
@@ -38,6 +38,9 @@ from zarr.core.dtype import (
     VariableLengthUTF8JSON_V2,
     ZDType,
     data_type_registry,
+    # Import for backwards compatibility, but not included in __all__
+    # so it doesn't show up in the docs
+    parse_data_type,  # noqa: F401
     parse_dtype,
 )
 

--- a/tests/test_dtype_registry.py
+++ b/tests/test_dtype_registry.py
@@ -13,18 +13,20 @@ from tests.conftest import skip_object_dtype
 from zarr.core.config import config
 from zarr.core.dtype import (
     AnyDType,
-    Bool,
     DataTypeRegistry,
-    FixedLengthUTF32,
     TBaseDType,
     TBaseScalar,
+    get_data_type_from_json,
+)
+from zarr.core.dtype.common import unpack_dtype_json
+from zarr.dtype import (  # type: ignore[attr-defined]
+    Bool,
+    FixedLengthUTF32,
     ZDType,
     data_type_registry,
-    get_data_type_from_json,
     parse_data_type,
     parse_dtype,
 )
-from zarr.core.dtype.common import unpack_dtype_json
 
 if TYPE_CHECKING:
     from collections.abc import Generator


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/pull/3264#issuecomment-3115427902.

I note that this error would have been much less likely to happen if we defined our API in one place, instead of defining it in `zarr.core` and re-exporting it. To make sure we're testing our public API, I've moved imports in the tests to come from `zarr.dtype` where possible.