### PR TITLE
Prevent mode='r+' from creating new directories

### DIFF
--- a/changes/3307.bugfix.rst
+++ b/changes/3307.bugfix.rst
@@ -1,0 +1,1 @@
+Opening an array or group with ``mode="r+"`` will no longer create new arrays or groups.

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -358,7 +358,7 @@ async def make_store_path(
 
     elif isinstance(store_like, Path):
         # Create a new LocalStore
-        store = await LocalStore.open(root=store_like, read_only=_read_only)
+        store = await LocalStore.open(root=store_like, mode=mode)
 
     elif isinstance(store_like, str):
         # Either a FSSpec URI or a local filesystem path

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -132,13 +132,19 @@ class LocalStore(Store):
         Store
             The opened store instance.
         """
+        # If mode = 'r+', want to open in read only mode (fail if exists),
+        # but return a writeable store
         if mode is not None:
             read_only_creation = mode in ["r", "r+"]
         else:
             read_only_creation = read_only
         store = cls(root, read_only=read_only_creation)
         await store._open()
-        return store.with_read_only(read_only)
+
+        # Set read_only state
+        store = store.with_read_only(read_only)
+        await store._open()
+        return store
 
     async def _open(self, *, mode: AccessModeLiteral | None = None) -> None:
         if not self.read_only:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -333,8 +333,12 @@ def test_open_with_mode_r(tmp_path: Path) -> None:
 
 def test_open_with_mode_r_plus(tmp_path: Path) -> None:
     # 'r+' means read/write (must exist)
+    new_store_path = tmp_path / "new_store.zarr"
+    assert not new_store_path.exists(), "Test should operate on non-existent directory"
     with pytest.raises(FileNotFoundError):
-        zarr.open(store=tmp_path, mode="r+")
+        zarr.open(store=new_store_path, mode="r+")
+    assert not new_store_path.exists(), "mode='r+' should not create directory"
+
     zarr.ones(store=tmp_path, shape=(3, 3))
     z2 = zarr.open(store=tmp_path, mode="r+")
     assert isinstance(z2, Array)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,7 +45,6 @@ from zarr.core.buffer import NDArrayLike
 from zarr.errors import (
     ArrayNotFoundError,
     MetadataValidationError,
-    NodeNotFoundError,
     ZarrDeprecationWarning,
     ZarrUserWarning,
 )
@@ -191,7 +190,7 @@ async def test_open_array(memory_store: MemoryStore, zarr_format: ZarrFormat) ->
     assert z.read_only
 
     # path not found
-    with pytest.raises(NodeNotFoundError):
+    with pytest.raises(FileNotFoundError):
         zarr.api.synchronous.open(store="doesnotexist", mode="r", zarr_format=zarr_format)
 
 


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-python/issues/3295. I'm not sure if I came up with the most elegant solution, but I couldn't think of a way to solve this without passing the mode to `LocalStore.open()`. Other suggestions very welcome if anyone has any better ideas?