### PR TITLE
No need for `license-files` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
 ]
 license = "MIT"
-license-files = ["LICENSE.txt"]
 keywords = ["Python", "compressed", "ndimensional-arrays", "zarr"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The default glob includes `LICEN[CS]E*` which covers `LICENSE.txt`.

[**hatch/backend/src/hatchling/metadata/core.py**](https://github.com/pypa/hatch/blob/28f233c535508247ffa9a40dab82c1d1cb2b700b/backend/src/hatchling/metadata/core.py#L746)
Line 746 in https://github.com/pypa/hatch/commit/28f233c535508247ffa9a40dab82c1d1cb2b700b
```python
                globs = ['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
