### PR TITLE
fix for failing numcodecs.zarr3 codecs

### DIFF
--- a/src/zarr/core/codec_pipeline.py
+++ b/src/zarr/core/codec_pipeline.py
@@ -315,7 +315,7 @@ class BatchedCodecPipeline(CodecPipeline):
             # TODO: For the last chunk, we could have is_complete_chunk=True
             #       that is smaller than the chunk_spec.shape but this throws
             #       an error in the _decode_single
-            return chunk_value
+            return chunk_value.copy()  # make a writable copy
         if existing_chunk_array is None:
             chunk_array = chunk_spec.prototype.nd_buffer.create(
                 shape=chunk_spec.shape,


### PR DESCRIPTION
Closes https://github.com/zarr-developers/zarr-python/issues/2900.

I did not add a unit test because it was already mentioned in https://github.com/zarr-developers/zarr-python/issues/2900 that all numcodecs should be better tested in CI, but I guess that belongs into another PR. 

You can verify that it works by running the following script:
```bash
#!/usr/bin/env -S uv run
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     # "zarr==3.0.2,<3.0.3", # WORKS
#     # "zarr==3.0.4", # FAILS
#     "zarr@git+https://github.com/terraputix/zarr-python.git@8f40aaf3f3fa1d23918520018c60dd0034997f76",  # WORKS
#     "numcodecs==0.15.0",
#     "zfpy==1.0.1",
#     "pcodec==0.3.2",
# ]
# ///
#


import numpy as np
import zarr
zarr.__version__ = "3.0.2"
from numcodecs.zarr3 import ZFPY, PCodec

for serializer in [
    ZFPY(mode=4, tolerance=0.01),
    PCodec(level=8, mode_spec="auto"),
]:
    array = zarr.create_array(
        store=zarr.storage.LocalStore("test"),
        shape=[2, 2],
        chunks=[2, 1],
        dtype=np.int64,
        serializer=serializer,
        compressors=None,
        overwrite=True,
    )
    array[...] = np.array([[0, 1], [2, 3]])
```

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
