### PR TITLE
DOC: update numpy versions in test case examples

### DIFF
--- a/docs/developers/contributing.rst
+++ b/docs/developers/contributing.rst
@@ -98,7 +98,7 @@ you can do something like the following::
 To verify that your development environment is working, you can run the unit tests
 for one of the test environments, e.g.::
 
-    $ hatch env run --env test.py3.12-2.1-optional run-pytest
+    $ hatch env run --env test.py3.12-2.2-optional run-pytest
 
 Creating a branch
 ~~~~~~~~~~~~~~~~~
@@ -140,7 +140,7 @@ Zarr includes a suite of unit tests. The simplest way to run the unit tests
 is to activate your development environment
 (see `creating a development environment`_ above) and invoke::
 
-    $ hatch env run --env test.py3.12-2.1-optional run-pytest
+    $ hatch env run --env test.py3.12-2.2-optional run-pytest
 
 All tests are automatically run via GitHub Actions for every pull
 request and must pass before code can be accepted. Test coverage is
@@ -188,14 +188,14 @@ Test coverage
 Zarr strives to maintain 100% test coverage under the latest Python stable release
 Both unit tests and docstring doctests are included when computing coverage. Running::
 
-    $ hatch env run --env test.py3.12-2.1-optional run-coverage
+    $ hatch env run --env test.py3.12-2.2-optional run-coverage
 
 will automatically run the test suite with coverage and produce a XML coverage report.
 This should be 100% before code can be accepted into the main code base.
 
 You can also generate an HTML coverage report by running::
 
-     $ hatch env run --env test.py3.12-2.1-optional run-coverage-html
+     $ hatch env run --env test.py3.12-2.2-optional run-coverage-html
 
 When submitting a pull request, coverage will also be collected across all supported
 Python versions via the Codecov service, and will be reported back within the pull


### PR DESCRIPTION
## Updated environment names in contribution guide

Hi there, first-timer here :) I went to go through the doc pages for contributing and tried running the test commands outlined there:

```
...
hatch env run --env test.py3.12-2.1-optional run-coverage
...
```

which leads to an error (`Unknown environment: test.py3.12-2.1-optional`) since the test matrix is specified with numpy 2.2:
```
[[tool.hatch.envs.test.matrix]]
python = ["3.11", "3.12", "3.13"]
numpy = ["1.26", "2.2"]
deps = ["minimal", "optional"]
```

So I just changed the example commands in the doc pages to work right away with the current `pyproject.toml`. It's a tiny little change but hopefully makes the entrance for some a little easier if they haven't worked with hatch, etc before.

Thanks for considering!