### PR TITLE
add modules for types

### DIFF
--- a/examples/custom_dtype.py
+++ b/examples/custom_dtype.py
@@ -29,7 +29,8 @@ from zarr.core.dtype.common import (
     DTypeJSON,
     check_dtype_spec_v2,
 )
-from zarr.core.types import JSON, ZarrFormat
+from zarr.core.types import JSON
+from zarr.types import ZarrFormat
 
 # This is the int2 array data type
 int2_dtype_cls = type(np.dtype("int2"))

--- a/examples/custom_dtype.py
+++ b/examples/custom_dtype.py
@@ -22,7 +22,6 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr.core.common import JSON, ZarrFormat
 from zarr.core.dtype import ZDType, data_type_registry
 from zarr.core.dtype.common import (
     DataTypeValidationError,
@@ -30,6 +29,7 @@ from zarr.core.dtype.common import (
     DTypeJSON,
     check_dtype_spec_v2,
 )
+from zarr.core.types import JSON, ZarrFormat
 
 # This is the int2 array data type
 int2_dtype_cls = type(np.dtype("int2"))

--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from zarr.abc.metadata import Metadata
 from zarr.core.buffer import Buffer, NDBuffer
-from zarr.core.common import ChunkCoords, concurrent_map
+from zarr.core.common import concurrent_map
 from zarr.core.config import config
 
 if TYPE_CHECKING:
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
     from zarr.core.indexing import SelectorTuple
     from zarr.core.metadata import ArrayMetadata
+    from zarr.core.types import ChunkCoords
 
 __all__ = [
     "ArrayArrayCodec",

--- a/src/zarr/abc/metadata.py
+++ b/src/zarr/abc/metadata.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Self
 
-    from zarr.core.common import JSON
+    from zarr.core.types import JSON
 
 from dataclasses import dataclass, fields
 

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from typing import Any, Self, TypeAlias
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
+    from zarr.core.types import BytesLike
 
 __all__ = ["ByteGetter", "ByteSetter", "Store", "set_or_delete"]
 

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -57,9 +57,9 @@ if TYPE_CHECKING:
         ChunkCoords,
         DimensionNames,
         MemoryOrder,
-        ZarrFormat,
     )
     from zarr.storage import StoreLike
+    from zarr.types import ZarrFormat
 
     # TODO: this type could use some more thought
     ArrayLike = AsyncArray[ArrayV2Metadata] | AsyncArray[ArrayV3Metadata] | Array | npt.NDArray[Any]

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -22,12 +22,6 @@ from zarr.core.array import (
 from zarr.core.array_spec import ArrayConfigLike, parse_array_config
 from zarr.core.buffer import NDArrayLike
 from zarr.core.common import (
-    JSON,
-    AccessModeLiteral,
-    ChunkCoords,
-    DimensionNames,
-    MemoryOrder,
-    ZarrFormat,
     _default_zarr_format,
     _warn_write_empty_chunks_kwarg,
 )
@@ -57,6 +51,14 @@ if TYPE_CHECKING:
     from zarr.abc.codec import Codec
     from zarr.core.buffer import NDArrayLikeOrScalar
     from zarr.core.chunk_key_encodings import ChunkKeyEncoding
+    from zarr.core.types import (
+        JSON,
+        AccessModeLiteral,
+        ChunkCoords,
+        DimensionNames,
+        MemoryOrder,
+        ZarrFormat,
+    )
     from zarr.storage import StoreLike
 
     # TODO: this type could use some more thought

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -38,9 +38,9 @@ if TYPE_CHECKING:
         DimensionNames,
         MemoryOrder,
         ShapeLike,
-        ZarrFormat,
     )
     from zarr.storage import StoreLike
+    from zarr.types import ZarrFormat
 
 __all__ = [
     "array",

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
     from zarr.core.array_spec import ArrayConfigLike
     from zarr.core.buffer import NDArrayLike, NDArrayLikeOrScalar
     from zarr.core.chunk_key_encodings import ChunkKeyEncoding, ChunkKeyEncodingLike
-    from zarr.core.common import (
+    from zarr.core.dtype import ZDTypeLike
+    from zarr.core.types import (
         JSON,
         AccessModeLiteral,
         ChunkCoords,
@@ -39,7 +40,6 @@ if TYPE_CHECKING:
         ShapeLike,
         ZarrFormat,
     )
-    from zarr.core.dtype import ZDTypeLike
     from zarr.storage import StoreLike
 
 __all__ = [

--- a/src/zarr/codecs/blosc.py
+++ b/src/zarr/codecs/blosc.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 
 from zarr.abc.codec import BytesBytesCodec
 from zarr.core.buffer.cpu import as_numpy_array_wrapper
-from zarr.core.common import JSON, parse_enum, parse_named_configuration
+from zarr.core.common import parse_enum, parse_named_configuration
 from zarr.core.dtype.common import HasItemSize
 from zarr.registry import register_codec
 
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer
+    from zarr.core.types import JSON
 
 
 class BloscShuffle(Enum):

--- a/src/zarr/codecs/bytes.py
+++ b/src/zarr/codecs/bytes.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from zarr.abc.codec import ArrayBytesCodec
 from zarr.core.buffer import Buffer, NDArrayLike, NDBuffer
-from zarr.core.common import JSON, parse_enum, parse_named_configuration
+from zarr.core.common import parse_enum, parse_named_configuration
 from zarr.core.dtype.common import HasEndianness
 from zarr.registry import register_codec
 
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.array_spec import ArraySpec
+    from zarr.core.types import JSON
 
 
 class Endian(Enum):

--- a/src/zarr/codecs/crc32c_.py
+++ b/src/zarr/codecs/crc32c_.py
@@ -8,7 +8,7 @@ import typing_extensions
 from crc32c import crc32c
 
 from zarr.abc.codec import BytesBytesCodec
-from zarr.core.common import JSON, parse_named_configuration
+from zarr.core.common import parse_named_configuration
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer
+    from zarr.core.types import JSON
 
 
 @dataclass(frozen=True)

--- a/src/zarr/codecs/gzip.py
+++ b/src/zarr/codecs/gzip.py
@@ -8,7 +8,7 @@ from numcodecs.gzip import GZip
 
 from zarr.abc.codec import BytesBytesCodec
 from zarr.core.buffer.cpu import as_numpy_array_wrapper
-from zarr.core.common import JSON, parse_named_configuration
+from zarr.core.common import parse_named_configuration
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer
+    from zarr.core.types import JSON
 
 
 def parse_gzip_level(data: JSON) -> int:

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -36,8 +36,6 @@ from zarr.core.buffer import (
 )
 from zarr.core.chunk_grids import ChunkGrid, RegularChunkGrid
 from zarr.core.common import (
-    ChunkCoords,
-    ChunkCoordsLike,
     parse_enum,
     parse_named_configuration,
     parse_shapelike,
@@ -52,14 +50,15 @@ from zarr.core.indexing import (
     morton_order_iter,
 )
 from zarr.core.metadata.v3 import parse_codecs
+from zarr.core.types import ChunkCoords, ChunkCoordsLike
 from zarr.registry import get_ndbuffer_class, get_pipeline_class, register_codec
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
     from typing import Self
 
-    from zarr.core.common import JSON
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import JSON
 
 MAX_UINT_64 = 2**64 - 1
 ShardMapping = Mapping[ChunkCoords, Buffer]

--- a/src/zarr/codecs/transpose.py
+++ b/src/zarr/codecs/transpose.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from zarr.abc.codec import ArrayArrayCodec
 from zarr.core.array_spec import ArraySpec
-from zarr.core.common import JSON, ChunkCoordsLike, parse_named_configuration
+from zarr.core.common import parse_named_configuration
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from zarr.core.buffer import NDBuffer
     from zarr.core.chunk_grids import ChunkGrid
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import JSON, ChunkCoordsLike
 
 
 def parse_transpose_order(data: JSON | Iterable[int]) -> tuple[int, ...]:

--- a/src/zarr/codecs/vlen_utf8.py
+++ b/src/zarr/codecs/vlen_utf8.py
@@ -8,13 +8,14 @@ from numcodecs.vlen import VLenBytes, VLenUTF8
 
 from zarr.abc.codec import ArrayBytesCodec
 from zarr.core.buffer import Buffer, NDBuffer
-from zarr.core.common import JSON, parse_named_configuration
+from zarr.core.common import parse_named_configuration
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.array_spec import ArraySpec
+    from zarr.core.types import JSON
 
 
 # can use a global because there are no parameters

--- a/src/zarr/codecs/zstd.py
+++ b/src/zarr/codecs/zstd.py
@@ -11,7 +11,7 @@ from packaging.version import Version
 
 from zarr.abc.codec import BytesBytesCodec
 from zarr.core.buffer.cpu import as_numpy_array_wrapper
-from zarr.core.common import JSON, parse_named_configuration
+from zarr.core.common import parse_named_configuration
 from zarr.registry import register_codec
 
 if TYPE_CHECKING:
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from zarr.core.array_spec import ArraySpec
     from zarr.core.buffer import Buffer
+    from zarr.core.types import JSON
 
 
 def parse_zstd_level(data: JSON) -> int:

--- a/src/zarr/core/_info.py
+++ b/src/zarr/core/_info.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
     from zarr.abc.codec import ArrayArrayCodec, ArrayBytesCodec, BytesBytesCodec
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/src/zarr/core/_info.py
+++ b/src/zarr/core/_info.py
@@ -8,8 +8,8 @@ if TYPE_CHECKING:
     import numcodecs.abc
 
     from zarr.abc.codec import ArrayArrayCodec, ArrayBytesCodec, BytesBytesCodec
-    from zarr.core.common import ZarrFormat
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import ZarrFormat
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -119,7 +119,6 @@ from zarr.core.types import (
     DimensionNames,
     MemoryOrder,
     ShapeLike,
-    ZarrFormat,
 )
 from zarr.errors import MetadataValidationError, ZarrDeprecationWarning, ZarrUserWarning
 from zarr.registry import (
@@ -142,6 +141,7 @@ if TYPE_CHECKING:
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar
     from zarr.core.group import AsyncGroup
     from zarr.storage import StoreLike
+    from zarr.types import ZarrFormat
 
 
 # Array and AsyncArray are defined in the base ``zarr`` namespace

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -50,15 +50,6 @@ from zarr.core.chunk_key_encodings import (
     V2ChunkKeyEncoding,
 )
 from zarr.core.common import (
-    JSON,
-    ZARR_JSON,
-    ZARRAY_JSON,
-    ZATTRS_JSON,
-    ChunkCoords,
-    DimensionNames,
-    MemoryOrder,
-    ShapeLike,
-    ZarrFormat,
     _default_zarr_format,
     _warn_order_kwarg,
     ceildiv,
@@ -106,9 +97,7 @@ from zarr.core.metadata import (
     ArrayMetadata,
     ArrayMetadataDict,
     ArrayV2Metadata,
-    ArrayV2MetadataDict,
     ArrayV3Metadata,
-    ArrayV3MetadataDict,
     T_ArrayMetadata,
 )
 from zarr.core.metadata.v2 import (
@@ -119,6 +108,19 @@ from zarr.core.metadata.v2 import (
 )
 from zarr.core.metadata.v3 import parse_node_type_array
 from zarr.core.sync import sync
+from zarr.core.types import (
+    JSON,
+    ZARR_JSON,
+    ZARRAY_JSON,
+    ZATTRS_JSON,
+    ArrayMetadataJSON_V2,
+    ArrayMetadataJSON_V3,
+    ChunkCoords,
+    DimensionNames,
+    MemoryOrder,
+    ShapeLike,
+    ZarrFormat,
+)
 from zarr.errors import MetadataValidationError, ZarrDeprecationWarning, ZarrUserWarning
 from zarr.registry import (
     _parse_array_array_codec,
@@ -294,7 +296,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
     @overload
     def __init__(
         self: AsyncArray[ArrayV2Metadata],
-        metadata: ArrayV2Metadata | ArrayV2MetadataDict,
+        metadata: ArrayV2Metadata | ArrayMetadataJSON_V2,
         store_path: StorePath,
         config: ArrayConfigLike | None = None,
     ) -> None: ...
@@ -302,7 +304,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
     @overload
     def __init__(
         self: AsyncArray[ArrayV3Metadata],
-        metadata: ArrayV3Metadata | ArrayV3MetadataDict,
+        metadata: ArrayV3Metadata | ArrayMetadataJSON_V3,
         store_path: StorePath,
         config: ArrayConfigLike | None = None,
     ) -> None: ...
@@ -962,7 +964,7 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         store_path = await make_store_path(store)
         metadata_dict = await get_array_metadata(store_path, zarr_format=zarr_format)
         # TODO: remove this cast when we have better type hints
-        _metadata_dict = cast("ArrayV3MetadataDict", metadata_dict)
+        _metadata_dict = cast("ArrayMetadataJSON_V3", metadata_dict)
         return cls(store_path=store_path, metadata=_metadata_dict)
 
     @property

--- a/src/zarr/core/array_spec.py
+++ b/src/zarr/core/array_spec.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, Literal, Self, TypedDict, cast
 
 from zarr.core.common import (
-    MemoryOrder,
     parse_bool,
     parse_fill_value,
     parse_order,
@@ -16,8 +15,8 @@ if TYPE_CHECKING:
     from typing import NotRequired
 
     from zarr.core.buffer import BufferPrototype
-    from zarr.core.common import ChunkCoords
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import ChunkCoords, MemoryOrder
 
 
 class ArrayConfigParams(TypedDict):

--- a/src/zarr/core/attributes.py
+++ b/src/zarr/core/attributes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
 
-from zarr.core.common import JSON
+from zarr.core.types import JSON
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from zarr.codecs.bytes import Endian
-    from zarr.core.common import BytesLike, ChunkCoords
+    from zarr.core.types import BytesLike, ChunkCoords
 
 # Everything here is imported into ``zarr.core.buffer`` namespace.
 __all__: list[str] = []

--- a/src/zarr/core/buffer/cpu.py
+++ b/src/zarr/core/buffer/cpu.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.buffer.core import ArrayLike, NDArrayLike
-    from zarr.core.common import BytesLike, ChunkCoords
+    from zarr.core.types import BytesLike, ChunkCoords
 
 
 class Buffer(core.Buffer):

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Self
 
-    from zarr.core.common import BytesLike, ChunkCoords
+    from zarr.core.types import BytesLike, ChunkCoords
 
 try:
     import cupy as cp

--- a/src/zarr/core/chunk_grids.py
+++ b/src/zarr/core/chunk_grids.py
@@ -14,10 +14,6 @@ import numpy as np
 
 from zarr.abc.metadata import Metadata
 from zarr.core.common import (
-    JSON,
-    ChunkCoords,
-    ChunkCoordsLike,
-    ShapeLike,
     ceildiv,
     parse_named_configuration,
     parse_shapelike,
@@ -29,6 +25,7 @@ if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.array import ShardsLike
+    from zarr.core.types import JSON, ChunkCoords, ChunkCoordsLike, ShapeLike
 
 
 def _guess_chunks(

--- a/src/zarr/core/chunk_key_encodings.py
+++ b/src/zarr/core/chunk_key_encodings.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict, cast
 if TYPE_CHECKING:
     from typing import NotRequired
 
+    from zarr.core.types import JSON, ChunkCoords
+
 from zarr.abc.metadata import Metadata
 from zarr.core.common import (
-    JSON,
-    ChunkCoords,
     parse_named_configuration,
 )
 

--- a/src/zarr/core/codec_pipeline.py
+++ b/src/zarr/core/codec_pipeline.py
@@ -14,7 +14,7 @@ from zarr.abc.codec import (
     Codec,
     CodecPipeline,
 )
-from zarr.core.common import ChunkCoords, concurrent_map
+from zarr.core.common import concurrent_map
 from zarr.core.config import config
 from zarr.core.indexing import SelectorTuple, is_scalar
 from zarr.errors import ZarrUserWarning
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from zarr.core.buffer import Buffer, BufferPrototype, NDBuffer
     from zarr.core.chunk_grids import ChunkGrid
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import ChunkCoords
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/src/zarr/core/common.py
+++ b/src/zarr/core/common.py
@@ -27,7 +27,8 @@ from zarr.errors import ZarrRuntimeWarning
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Iterator
 
-    from zarr.core.types import ChunkCoords, ZarrFormat
+    from zarr.core.types import ChunkCoords
+    from zarr.types import ZarrFormat
 
 
 def product(tup: ChunkCoords) -> int:

--- a/src/zarr/core/dtype/__init__.py
+++ b/src/zarr/core/dtype/__init__.py
@@ -32,14 +32,13 @@ from zarr.core.dtype.npy.time import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.common import ZarrFormat
+    from zarr.core.types import ZarrFormat
 
 from collections.abc import Mapping
 
 import numpy as np
 import numpy.typing as npt
 
-from zarr.core.common import JSON
 from zarr.core.dtype.npy.string import (
     FixedLengthUTF32,
     FixedLengthUTF32JSON_V2,
@@ -49,6 +48,7 @@ from zarr.core.dtype.npy.string import (
 )
 from zarr.core.dtype.registry import DataTypeRegistry
 from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+from zarr.core.types import JSON
 
 __all__ = [
     "Bool",

--- a/src/zarr/core/dtype/__init__.py
+++ b/src/zarr/core/dtype/__init__.py
@@ -32,7 +32,7 @@ from zarr.core.dtype.npy.time import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 from collections.abc import Mapping
 

--- a/src/zarr/core/dtype/common.py
+++ b/src/zarr/core/dtype/common.py
@@ -15,7 +15,7 @@ from typing import (
 
 from typing_extensions import ReadOnly
 
-from zarr.core.common import NamedConfig
+from zarr.core.types import NamedConfig
 from zarr.errors import UnstableSpecificationWarning
 
 EndiannessStr = Literal["little", "big"]

--- a/src/zarr/core/dtype/npy/bool.py
+++ b/src/zarr/core/dtype/npy/bool.py
@@ -15,7 +15,7 @@ from zarr.core.dtype.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/zarr/core/dtype/npy/bool.py
+++ b/src/zarr/core/dtype/npy/bool.py
@@ -15,7 +15,8 @@ from zarr.core.dtype.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)

--- a/src/zarr/core/dtype/npy/bytes.py
+++ b/src/zarr/core/dtype/npy/bytes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import re
 from dataclasses import dataclass
-from typing import ClassVar, Literal, Self, TypedDict, TypeGuard, cast, overload
+from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypedDict, TypeGuard, cast, overload
 
 import numpy as np
 
@@ -19,7 +19,10 @@ from zarr.core.dtype.common import (
 )
 from zarr.core.dtype.npy.common import check_json_str
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
-from zarr.core.types import JSON, NamedConfig, ZarrFormat
+from zarr.core.types import JSON, NamedConfig
+
+if TYPE_CHECKING:
+    from zarr.types import ZarrFormat
 
 BytesLike = np.bytes_ | str | bytes | int
 

--- a/src/zarr/core/dtype/npy/bytes.py
+++ b/src/zarr/core/dtype/npy/bytes.py
@@ -7,7 +7,6 @@ from typing import ClassVar, Literal, Self, TypedDict, TypeGuard, cast, overload
 
 import numpy as np
 
-from zarr.core.common import JSON, NamedConfig, ZarrFormat
 from zarr.core.dtype.common import (
     DataTypeValidationError,
     DTypeConfig_V2,
@@ -20,6 +19,7 @@ from zarr.core.dtype.common import (
 )
 from zarr.core.dtype.npy.common import check_json_str
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.core.types import JSON, NamedConfig, ZarrFormat
 
 BytesLike = np.bytes_ | str | bytes | int
 

--- a/src/zarr/core/dtype/npy/common.py
+++ b/src/zarr/core/dtype/npy/common.py
@@ -28,7 +28,7 @@ from zarr.core.dtype.common import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 IntLike = SupportsInt | SupportsIndex | bytes | str
 FloatLike = SupportsIndex | SupportsFloat | bytes | str

--- a/src/zarr/core/dtype/npy/common.py
+++ b/src/zarr/core/dtype/npy/common.py
@@ -28,7 +28,8 @@ from zarr.core.dtype.common import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 IntLike = SupportsInt | SupportsIndex | bytes | str
 FloatLike = SupportsIndex | SupportsFloat | bytes | str

--- a/src/zarr/core/dtype/npy/complex.py
+++ b/src/zarr/core/dtype/npy/complex.py
@@ -36,7 +36,8 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 
 @dataclass(frozen=True)

--- a/src/zarr/core/dtype/npy/complex.py
+++ b/src/zarr/core/dtype/npy/complex.py
@@ -36,7 +36,7 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 
 @dataclass(frozen=True)

--- a/src/zarr/core/dtype/npy/float.py
+++ b/src/zarr/core/dtype/npy/float.py
@@ -29,7 +29,8 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 
 @dataclass(frozen=True)

--- a/src/zarr/core/dtype/npy/float.py
+++ b/src/zarr/core/dtype/npy/float.py
@@ -29,7 +29,7 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 
 @dataclass(frozen=True)

--- a/src/zarr/core/dtype/npy/int.py
+++ b/src/zarr/core/dtype/npy/int.py
@@ -31,7 +31,8 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 _NumpyIntDType = (
     np.dtypes.Int8DType

--- a/src/zarr/core/dtype/npy/int.py
+++ b/src/zarr/core/dtype/npy/int.py
@@ -31,7 +31,7 @@ from zarr.core.dtype.npy.common import (
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 _NumpyIntDType = (
     np.dtypes.Int8DType

--- a/src/zarr/core/dtype/npy/string.py
+++ b/src/zarr/core/dtype/npy/string.py
@@ -33,11 +33,12 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TDType_co, ZDType
-from zarr.core.types import NamedConfig, ZarrFormat
+from zarr.core.types import NamedConfig
 
 if TYPE_CHECKING:
     from zarr.core.dtype.wrapper import TBaseDType
     from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 _NUMPY_SUPPORTS_VLEN_STRING = hasattr(np.dtypes, "StringDType")
 

--- a/src/zarr/core/dtype/npy/string.py
+++ b/src/zarr/core/dtype/npy/string.py
@@ -16,7 +16,6 @@ from typing import (
 
 import numpy as np
 
-from zarr.core.common import NamedConfig
 from zarr.core.dtype.common import (
     DataTypeValidationError,
     DTypeConfig_V2,
@@ -34,10 +33,11 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TDType_co, ZDType
+from zarr.core.types import NamedConfig, ZarrFormat
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
     from zarr.core.dtype.wrapper import TBaseDType
+    from zarr.core.types import JSON
 
 _NUMPY_SUPPORTS_VLEN_STRING = hasattr(np.dtypes, "StringDType")
 

--- a/src/zarr/core/dtype/npy/structured.py
+++ b/src/zarr/core/dtype/npy/structured.py
@@ -22,10 +22,11 @@ from zarr.core.dtype.npy.common import (
     check_json_str,
 )
 from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
-from zarr.core.types import NamedConfig, ZarrFormat
+from zarr.core.types import NamedConfig
 
 if TYPE_CHECKING:
     from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 StructuredScalarLike = list[object] | tuple[object, ...] | bytes | int
 

--- a/src/zarr/core/dtype/npy/structured.py
+++ b/src/zarr/core/dtype/npy/structured.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeGuard, cast, over
 
 import numpy as np
 
-from zarr.core.common import NamedConfig
 from zarr.core.dtype.common import (
     DataTypeValidationError,
     DTypeConfig_V2,
@@ -23,9 +22,10 @@ from zarr.core.dtype.npy.common import (
     check_json_str,
 )
 from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+from zarr.core.types import NamedConfig, ZarrFormat
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON
 
 StructuredScalarLike = list[object] | tuple[object, ...] | bytes | int
 

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -34,10 +34,11 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
-from zarr.core.types import NamedConfig, ZarrFormat
+from zarr.core.types import NamedConfig
 
 if TYPE_CHECKING:
     from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 TimeDeltaLike = str | int | bytes | np.timedelta64 | timedelta | None
 DateTimeLike = str | int | bytes | np.datetime64 | datetime | None

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -18,7 +18,6 @@ from typing import (
 import numpy as np
 from typing_extensions import ReadOnly
 
-from zarr.core.common import NamedConfig
 from zarr.core.dtype.common import (
     DataTypeValidationError,
     DTypeConfig_V2,
@@ -35,9 +34,10 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.core.types import NamedConfig, ZarrFormat
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON
 
 TimeDeltaLike = str | int | bytes | np.timedelta64 | timedelta | None
 DateTimeLike = str | int | bytes | np.datetime64 | datetime | None

--- a/src/zarr/core/dtype/registry.py
+++ b/src/zarr/core/dtype/registry.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
 
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 # This class is different from the other registry classes, which inherit from

--- a/src/zarr/core/dtype/registry.py
+++ b/src/zarr/core/dtype/registry.py
@@ -14,8 +14,8 @@ from zarr.core.dtype.common import (
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
 
-    from zarr.core.common import ZarrFormat
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+    from zarr.core.types import ZarrFormat
 
 
 # This class is different from the other registry classes, which inherit from

--- a/src/zarr/core/dtype/wrapper.py
+++ b/src/zarr/core/dtype/wrapper.py
@@ -40,7 +40,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from zarr.core.dtype.common import DTypeJSON, DTypeSpec_V2, DTypeSpec_V3
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 # This the upper bound for the scalar types we support. It's numpy scalars + str,
 # because the new variable-length string dtype in numpy does not have a corresponding scalar type

--- a/src/zarr/core/dtype/wrapper.py
+++ b/src/zarr/core/dtype/wrapper.py
@@ -39,8 +39,8 @@ from typing import (
 import numpy as np
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
     from zarr.core.dtype.common import DTypeJSON, DTypeSpec_V2, DTypeSpec_V3
+    from zarr.core.types import JSON, ZarrFormat
 
 # This the upper bound for the scalar types we support. It's numpy scalars + str,
 # because the new variable-length string dtype in numpy does not have a corresponding scalar type

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -35,6 +35,12 @@ from zarr.core.array import (
 from zarr.core.attributes import Attributes
 from zarr.core.buffer import default_buffer_prototype
 from zarr.core.common import (
+    parse_shapelike,
+)
+from zarr.core.config import config
+from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
+from zarr.core.sync import SyncMixin, sync
+from zarr.core.types import (
     JSON,
     ZARR_JSON,
     ZARRAY_JSON,
@@ -46,11 +52,7 @@ from zarr.core.common import (
     NodeType,
     ShapeLike,
     ZarrFormat,
-    parse_shapelike,
 )
-from zarr.core.config import config
-from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
-from zarr.core.sync import SyncMixin, sync
 from zarr.errors import (
     ContainsArrayError,
     ContainsGroupError,
@@ -77,8 +79,8 @@ if TYPE_CHECKING:
     from zarr.core.array_spec import ArrayConfig, ArrayConfigLike
     from zarr.core.buffer import Buffer, BufferPrototype
     from zarr.core.chunk_key_encodings import ChunkKeyEncodingLike
-    from zarr.core.common import MemoryOrder
     from zarr.core.dtype import ZDTypeLike
+    from zarr.core.types import MemoryOrder
 
 logger = logging.getLogger("zarr.group")
 

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -51,7 +51,6 @@ from zarr.core.types import (
     DimensionNames,
     NodeType,
     ShapeLike,
-    ZarrFormat,
 )
 from zarr.errors import (
     ContainsArrayError,
@@ -81,6 +80,7 @@ if TYPE_CHECKING:
     from zarr.core.chunk_key_encodings import ChunkKeyEncodingLike
     from zarr.core.dtype import ZDTypeLike
     from zarr.core.types import MemoryOrder
+    from zarr.types import ZarrFormat
 
 logger = logging.getLogger("zarr.group")
 

--- a/src/zarr/core/indexing.py
+++ b/src/zarr/core/indexing.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from zarr.core.array import Array, AsyncArray
     from zarr.core.buffer import NDArrayLikeOrScalar
     from zarr.core.chunk_grids import ChunkGrid
-    from zarr.core.common import ChunkCoords
+    from zarr.core.types import ChunkCoords
 
 
 IntSequence = list[int] | npt.NDArray[np.intp]

--- a/src/zarr/core/metadata/__init__.py
+++ b/src/zarr/core/metadata/__init__.py
@@ -1,17 +1,18 @@
 from typing import TypeAlias, TypeVar
 
-from .v2 import ArrayV2Metadata, ArrayV2MetadataDict
-from .v3 import ArrayV3Metadata, ArrayV3MetadataDict
+from ..types import ArrayMetadataJSON_V2, ArrayMetadataJSON_V3
+from .v2 import ArrayV2Metadata
+from .v3 import ArrayV3Metadata
 
 ArrayMetadata: TypeAlias = ArrayV2Metadata | ArrayV3Metadata
-ArrayMetadataDict: TypeAlias = ArrayV2MetadataDict | ArrayV3MetadataDict
+ArrayMetadataDict: TypeAlias = ArrayMetadataJSON_V2 | ArrayMetadataJSON_V3
 T_ArrayMetadata = TypeVar("T_ArrayMetadata", ArrayV2Metadata, ArrayV3Metadata)
 
 __all__ = [
     "ArrayMetadata",
     "ArrayMetadataDict",
+    "ArrayMetadataJSON_V2",
+    "ArrayMetadataJSON_V3",
     "ArrayV2Metadata",
-    "ArrayV2MetadataDict",
     "ArrayV3Metadata",
-    "ArrayV3MetadataDict",
 ]

--- a/src/zarr/core/metadata/common.py
+++ b/src/zarr/core/metadata/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON
+    from zarr.core.types import JSON
 
 
 def parse_attributes(data: dict[str, JSON] | None) -> dict[str, JSON]:

--- a/src/zarr/core/metadata/v2.py
+++ b/src/zarr/core/metadata/v2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable, Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numcodecs.abc
 
@@ -11,6 +11,7 @@ from zarr.abc.metadata import Metadata
 from zarr.core.chunk_grids import RegularChunkGrid
 from zarr.core.dtype import get_data_type_from_json
 from zarr.core.dtype.common import OBJECT_CODEC_IDS, DTypeSpec_V2
+from zarr.core.types import JSON, ZARRAY_JSON, ZATTRS_JSON, MemoryOrder
 from zarr.errors import ZarrUserWarning
 
 if TYPE_CHECKING:
@@ -19,7 +20,6 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import ChunkCoords
     from zarr.core.dtype.wrapper import (
         TBaseDType,
         TBaseScalar,
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         TScalar_co,
         ZDType,
     )
+    from zarr.core.types import ChunkCoords
 
 import json
 from dataclasses import dataclass, field, fields, replace
@@ -37,24 +38,10 @@ import numpy as np
 from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.chunk_key_encodings import parse_separator
 from zarr.core.common import (
-    JSON,
-    ZARRAY_JSON,
-    ZATTRS_JSON,
-    MemoryOrder,
     parse_shapelike,
 )
 from zarr.core.config import config, parse_indexing_order
 from zarr.core.metadata.common import parse_attributes
-
-
-class ArrayV2MetadataDict(TypedDict):
-    """
-    A typed dictionary model for Zarr format 2 metadata.
-    """
-
-    zarr_format: Literal[2]
-    attributes: dict[str, JSON]
-
 
 # Union of acceptable types for v2 compressors
 CompressorLikev2: TypeAlias = dict[str, JSON] | numcodecs.abc.Codec | None

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 from zarr.abc.metadata import Metadata
 from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.dtype import VariableLengthUTF8, ZDType, get_data_type_from_json
 from zarr.core.dtype.common import check_dtype_spec_v3
+from zarr.core.types import JSON, ZARR_JSON, ChunkCoords, DimensionNames
 
 if TYPE_CHECKING:
     from typing import Self
 
     from zarr.core.buffer import Buffer, BufferPrototype
     from zarr.core.chunk_grids import ChunkGrid
-    from zarr.core.common import JSON, ChunkCoords
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar
+    from zarr.core.types import ChunkCoords
 
 
 import json
@@ -26,10 +27,6 @@ from zarr.core.array_spec import ArrayConfig, ArraySpec
 from zarr.core.chunk_grids import ChunkGrid, RegularChunkGrid
 from zarr.core.chunk_key_encodings import ChunkKeyEncoding, ChunkKeyEncodingLike
 from zarr.core.common import (
-    JSON,
-    ZARR_JSON,
-    ChunkCoords,
-    DimensionNames,
     parse_named_configuration,
     parse_shapelike,
 )
@@ -125,15 +122,6 @@ def parse_storage_transformers(data: object) -> tuple[dict[str, JSON], ...]:
     raise TypeError(
         f"Invalid storage_transformers. Expected an iterable of dicts. Got {type(data)} instead."
     )
-
-
-class ArrayV3MetadataDict(TypedDict):
-    """
-    A typed dictionary model for zarr v3 metadata.
-    """
-
-    zarr_format: Literal[3]
-    attributes: dict[str, JSON]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/zarr/core/sync_group.py
+++ b/src/zarr/core/sync_group.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from zarr.abc.store import Store
     from zarr.core.array import Array
     from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 def create_nodes(

--- a/src/zarr/core/sync_group.py
+++ b/src/zarr/core/sync_group.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
     from zarr.abc.store import Store
     from zarr.core.array import Array
-    from zarr.core.common import ZarrFormat
     from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
+    from zarr.core.types import ZarrFormat
 
 
 def create_nodes(

--- a/src/zarr/core/types.py
+++ b/src/zarr/core/types.py
@@ -10,8 +10,6 @@ from typing_extensions import ReadOnly, TypedDict
 NodeType = Literal["array", "group"]
 """The names of the nodes in a Zarr hierarchy."""
 
-ZarrFormat = Literal[2, 3]
-"""The versions of Zarr that are supported."""
 
 BytesLike = bytes | bytearray | memoryview
 

--- a/src/zarr/core/types.py
+++ b/src/zarr/core/types.py
@@ -1,0 +1,124 @@
+"""Type definitions and typed constants for Zarr data structures."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Final, Generic, Literal, NotRequired, TypeVar
+
+from typing_extensions import ReadOnly, TypedDict
+
+NodeType = Literal["array", "group"]
+"""The names of the nodes in a Zarr hierarchy."""
+
+ZarrFormat = Literal[2, 3]
+"""The versions of Zarr that are supported."""
+
+BytesLike = bytes | bytearray | memoryview
+
+ChunkCoords = tuple[int, ...]
+
+ShapeLike = tuple[int, ...] | int
+"""A shape, either as a tuple of integers or a single integer."""
+
+JSON = str | int | float | Mapping[str, "JSON"] | Sequence["JSON"] | None
+"""A JSON value."""
+
+MemoryOrder = Literal["C", "F"]
+"""Memory order represented as a string using NumPy / Zarr V2 conventions."""
+
+MEMORY_ORDER: Final = "C", "F"
+
+DimensionSeparator_V2 = Literal[".", "/"]
+"""The possible values for the dimension separator in Zarr V2 array metadata."""
+
+ChunkCoordsLike = Iterable[int]
+AccessModeLiteral = Literal["r", "r+", "a", "w", "w-"]
+ACCESS_MODE_LITERAL: Final = "r", "r+", "a", "w", "w-"
+
+DimensionNames = Iterable[str | None] | None
+"""The possible types for the dimension names in Zarr V3 array metadata."""
+
+
+TName = TypeVar("TName", bound=str)
+TConfig = TypeVar("TConfig", bound=Mapping[str, object])
+
+
+class NamedConfig(TypedDict, Generic[TName, TConfig]):
+    """
+    A typed dictionary representing an object with a name and configuration, where the configuration
+    is a mapping of string keys to values, e.g. another typed dictionary or a JSON object.
+
+    This class is generic with two type parameters: the type of the name (``TName``) and the type of
+    the configuration (``TConfig``).
+    """
+
+    name: ReadOnly[TName]
+    """The name of the object."""
+
+    configuration: ReadOnly[TConfig]
+    """The configuration of the object."""
+
+
+ZARR_JSON: Final = "zarr.json"
+ZARRAY_JSON: Final = ".zarray"
+ZGROUP_JSON: Final = ".zgroup"
+ZATTRS_JSON: Final = ".zattrs"
+ZMETADATA_V2_JSON: Final = ".zmetadata"
+
+
+class CodecJSON_V2(TypedDict, Generic[TName]):
+    """The JSON representation of a codec for Zarr V2"""
+
+    id: ReadOnly[TName]
+
+
+class GroupMetadataJSON_V2(TypedDict):
+    """
+    A typed dictionary model for Zarr format 2 group metadata.
+    """
+
+    zarr_format: Literal[2]
+
+
+class ArrayMetadataJSON_V2(TypedDict):
+    """
+    A typed dictionary model for Zarr format 2 metadata.
+    """
+
+    zarr_format: Literal[2]
+    shape: tuple[int, ...]
+    chunks: tuple[int, ...]
+    dtype: str | tuple[tuple[str, object], ...]
+    compressor: CodecJSON_V2[str] | None
+    fill_value: object | None
+    order: MemoryOrder
+    filters: tuple[CodecJSON_V2[str], ...] | None
+    dimension_separator: NotRequired[DimensionSeparator_V2]
+
+
+class GroupMetadataJSON_V3(TypedDict):
+    """
+    A typed dictionary model for Zarr format 2 group metadata.
+    """
+
+    zarr_format: Literal[3]
+    node_type: Literal["group"]
+    attributes: NotRequired[Mapping[str, JSON]]
+
+
+class ArrayMetadataJSON_V3(TypedDict):
+    """
+    A typed dictionary model for zarr v3 metadata.
+    """
+
+    zarr_format: Literal[3]
+    node_type: Literal["array"]
+    data_type: str | NamedConfig[str, Mapping[str, object]]
+    shape: tuple[int, ...]
+    chunk_grid: NamedConfig[str, Mapping[str, object]]
+    chunk_key_encoding: NamedConfig[str, Mapping[str, object]]
+    fill_value: object
+    codecs: tuple[str | NamedConfig[str, Mapping[str, object]], ...]
+    attributes: NotRequired[Mapping[str, JSON]]
+    storage_transformers: NotRequired[tuple[NamedConfig[str, Mapping[str, object]], ...]]
+    dimension_names: NotRequired[tuple[str | None]]

--- a/src/zarr/registry.py
+++ b/src/zarr/registry.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
         CodecPipeline,
     )
     from zarr.core.buffer import Buffer, NDBuffer
-    from zarr.core.common import JSON
+    from zarr.core.types import JSON
 
 __all__ = [
     "Registry",

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -13,7 +13,6 @@ from zarr.core.types import (
     ZARRAY_JSON,
     ZGROUP_JSON,
     AccessModeLiteral,
-    ZarrFormat,
 )
 from zarr.errors import ContainsArrayAndGroupError, ContainsArrayError, ContainsGroupError
 from zarr.storage._local import LocalStore
@@ -28,6 +27,7 @@ else:
 
 if TYPE_CHECKING:
     from zarr.core.buffer import BufferPrototype
+    from zarr.types import ZarrFormat
 
 
 def _dereference_path(root: str, path: str) -> str:

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Literal, Self, TypeAlias
 
 from zarr.abc.store import ByteRequest, Store
 from zarr.core.buffer import Buffer, default_buffer_prototype
-from zarr.core.common import (
-    ANY_ACCESS_MODE,
+from zarr.core.types import (
+    ACCESS_MODE_LITERAL,
     ZARR_JSON,
     ZARRAY_JSON,
     ZGROUP_JSON,
@@ -103,8 +103,8 @@ class StorePath:
         if mode is None:
             return await cls._create_open_instance(store, path)
 
-        if mode not in ANY_ACCESS_MODE:
-            raise ValueError(f"Invalid mode: {mode}, expected one of {ANY_ACCESS_MODE}")
+        if mode not in ACCESS_MODE_LITERAL:
+            raise ValueError(f"Invalid mode: {mode}, expected one of {ACCESS_MODE_LITERAL}")
 
         if store.read_only:
             # Don't allow write operations on a read-only store

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from fsspec.mapping import FSMap
 
     from zarr.core.buffer import BufferPrototype
-    from zarr.core.common import BytesLike
+    from zarr.core.types import BytesLike
 
 
 ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (

--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from obstore.store import ObjectStore as _UpstreamObjectStore
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
+    from zarr.core.types import BytesLike
 
 __all__ = ["ObjectStore"]
 

--- a/src/zarr/storage/_wrapper.py
+++ b/src/zarr/storage/_wrapper.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
     from zarr.abc.store import ByteRequest
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
+    from zarr.core.types import BytesLike
 
 from zarr.abc.store import Store
 

--- a/src/zarr/testing/buffer.py
+++ b/src/zarr/testing/buffer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from typing import Self
 
-    from zarr.core.common import ChunkCoords
+    from zarr.core.types import ChunkCoords
 
 
 __all__ = [

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -19,10 +19,11 @@ from zarr.core.chunk_key_encodings import DefaultChunkKeyEncoding
 from zarr.core.dtype import get_data_type_from_native_dtype
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.sync import sync
-from zarr.core.types import JSON, ZarrFormat
+from zarr.core.types import JSON
 from zarr.storage import MemoryStore, StoreLike
 from zarr.storage._common import _dereference_path
 from zarr.storage._utils import normalize_path
+from zarr.types import ZarrFormat
 
 # Copied from Xarray
 _attr_keys = st.text(st.characters(), min_size=1)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -16,10 +16,10 @@ from zarr.codecs.bytes import BytesCodec
 from zarr.core.array import Array
 from zarr.core.chunk_grids import RegularChunkGrid
 from zarr.core.chunk_key_encodings import DefaultChunkKeyEncoding
-from zarr.core.common import JSON, ZarrFormat
 from zarr.core.dtype import get_data_type_from_native_dtype
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.sync import sync
+from zarr.core.types import JSON, ZarrFormat
 from zarr.storage import MemoryStore, StoreLike
 from zarr.storage._common import _dereference_path
 from zarr.storage._utils import normalize_path

--- a/src/zarr/testing/utils.py
+++ b/src/zarr/testing/utils.py
@@ -7,7 +7,7 @@ import pytest
 from zarr.core.buffer import Buffer
 
 if TYPE_CHECKING:
-    from zarr.core.common import BytesLike
+    from zarr.core.types import BytesLike
 
 __all__ = ["assert_bytes_equal"]
 

--- a/src/zarr/types.py
+++ b/src/zarr/types.py
@@ -1,1 +1,17 @@
 """Public type definitions and constants"""
+
+from zarr.core.types import (
+    ArrayMetadataJSON_V2,
+    ArrayMetadataJSON_V3,
+    GroupMetadataJSON_V2,
+    GroupMetadataJSON_V3,
+    ZarrFormat,
+)
+
+__all__ = [
+    "ArrayMetadataJSON_V2",
+    "ArrayMetadataJSON_V3",
+    "GroupMetadataJSON_V2",
+    "GroupMetadataJSON_V3",
+    "ZarrFormat",
+]

--- a/src/zarr/types.py
+++ b/src/zarr/types.py
@@ -1,0 +1,1 @@
+"""Public type definitions and constants"""

--- a/src/zarr/types.py
+++ b/src/zarr/types.py
@@ -1,11 +1,12 @@
 """Public type definitions and constants"""
 
+from typing import Literal
+
 from zarr.core.types import (
     ArrayMetadataJSON_V2,
     ArrayMetadataJSON_V3,
     GroupMetadataJSON_V2,
     GroupMetadataJSON_V3,
-    ZarrFormat,
 )
 
 __all__ = [
@@ -15,3 +16,5 @@ __all__ = [
     "GroupMetadataJSON_V3",
     "ZarrFormat",
 ]
+ZarrFormat = Literal[2, 3]
+"""The versions of Zarr that are supported."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from zarr.core.array import (
     _parse_chunk_key_encoding,
 )
 from zarr.core.chunk_grids import RegularChunkGrid, _auto_partition
-from zarr.core.common import JSON, DimensionNames, parse_shapelike
+from zarr.core.common import parse_shapelike
 from zarr.core.config import config as zarr_config
 from zarr.core.dtype import (
     get_data_type_from_native_dtype,
@@ -41,8 +41,15 @@ if TYPE_CHECKING:
     from zarr.abc.codec import Codec
     from zarr.core.array import CompressorsLike, FiltersLike, SerializerLike, ShardsLike
     from zarr.core.chunk_key_encodings import ChunkKeyEncoding, ChunkKeyEncodingLike
-    from zarr.core.common import ChunkCoords, MemoryOrder, ShapeLike, ZarrFormat
     from zarr.core.dtype.wrapper import ZDType
+    from zarr.core.types import (
+        JSON,
+        ChunkCoords,
+        DimensionNames,
+        MemoryOrder,
+        ShapeLike,
+        ZarrFormat,
+    )
 
 
 async def parse_store(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ if TYPE_CHECKING:
         DimensionNames,
         MemoryOrder,
         ShapeLike,
-        ZarrFormat,
     )
+    from zarr.types import ZarrFormat
 
 
 async def parse_store(

--- a/tests/package_with_entrypoint/__init__.py
+++ b/tests/package_with_entrypoint/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Any, ClassVar, Literal, Self
 
     from zarr.core.array_spec import ArraySpec
-    from zarr.core.common import ZarrFormat
+    from zarr.core.types import ZarrFormat
 
 
 class TestEntrypointCodec(ArrayBytesCodec):

--- a/tests/package_with_entrypoint/__init__.py
+++ b/tests/package_with_entrypoint/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from typing import Any, ClassVar, Literal, Self
 
     from zarr.core.array_spec import ArraySpec
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 class TestEntrypointCodec(ArrayBytesCodec):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from zarr.abc.store import Store
-    from zarr.core.common import JSON, MemoryOrder, ZarrFormat
+    from zarr.core.types import JSON, MemoryOrder, ZarrFormat
 
 import contextlib
 from typing import Literal

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from zarr.abc.store import Store
-    from zarr.core.types import JSON, MemoryOrder, ZarrFormat
+    from zarr.core.types import JSON, MemoryOrder
+    from zarr.types import ZarrFormat
 
 import contextlib
 from typing import Literal

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -41,7 +41,7 @@ from zarr.core.array import (
 from zarr.core.buffer import NDArrayLike, NDArrayLikeOrScalar, default_buffer_prototype
 from zarr.core.chunk_grids import _auto_partition
 from zarr.core.chunk_key_encodings import ChunkKeyEncodingParams
-from zarr.core.common import JSON, ZarrFormat, ceildiv
+from zarr.core.common import ceildiv
 from zarr.core.dtype import (
     DateTime64,
     Float32,
@@ -63,6 +63,7 @@ from zarr.core.indexing import BasicIndexer
 from zarr.core.metadata.v2 import ArrayV2Metadata
 from zarr.core.metadata.v3 import ArrayV3Metadata
 from zarr.core.sync import sync
+from zarr.core.types import JSON, ZarrFormat
 from zarr.errors import (
     ContainsArrayError,
     ContainsGroupError,

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -63,18 +63,19 @@ from zarr.core.indexing import BasicIndexer
 from zarr.core.metadata.v2 import ArrayV2Metadata
 from zarr.core.metadata.v3 import ArrayV3Metadata
 from zarr.core.sync import sync
-from zarr.core.types import JSON, ZarrFormat
 from zarr.errors import (
     ContainsArrayError,
     ContainsGroupError,
     ZarrUserWarning,
 )
 from zarr.storage import LocalStore, MemoryStore, StorePath
+from zarr.types import ZarrFormat
 
 from .test_dtype.conftest import zdtype_examples
 
 if TYPE_CHECKING:
     from zarr.core.metadata.v3 import ArrayV3Metadata
+    from zarr.core.types import JSON
 
 
 @pytest.mark.parametrize("store", ["local", "memory", "zip"], indirect=["store"])

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -8,7 +8,7 @@ import zarr.core
 import zarr.core.attributes
 import zarr.storage
 from tests.conftest import deep_nan_equal
-from zarr.core.common import ZarrFormat
+from zarr.core.types import ZarrFormat
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -8,7 +8,7 @@ import zarr.core
 import zarr.core.attributes
 import zarr.storage
 from tests.conftest import deep_nan_equal
-from zarr.core.types import ZarrFormat
+from zarr.types import ZarrFormat
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])

--- a/tests/test_codecs/test_codecs.py
+++ b/tests/test_codecs/test_codecs.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from zarr.abc.codec import Codec
     from zarr.abc.store import Store
     from zarr.core.buffer.core import NDArrayLikeOrScalar
-    from zarr.core.common import ChunkCoords, MemoryOrder
+    from zarr.core.types import ChunkCoords, MemoryOrder
 
 
 @dataclass(frozen=True)

--- a/tests/test_codecs/test_transpose.py
+++ b/tests/test_codecs/test_transpose.py
@@ -5,7 +5,7 @@ import zarr
 from zarr import AsyncArray, config
 from zarr.abc.store import Store
 from zarr.codecs import TransposeCodec
-from zarr.core.common import MemoryOrder
+from zarr.core.types import MemoryOrder
 from zarr.storage import StorePath
 
 from .test_codecs import _AsyncArrayProxy

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,13 +6,12 @@ import numpy as np
 import pytest
 
 from zarr.core.common import (
-    ANY_ACCESS_MODE,
-    AccessModeLiteral,
     parse_name,
     parse_shapelike,
     product,
 )
 from zarr.core.config import parse_indexing_order
+from zarr.core.types import ACCESS_MODE_LITERAL, AccessModeLiteral
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -28,7 +27,7 @@ def test_access_modes() -> None:
     """
     Test that the access modes type and variable for run-time checking are equivalent.
     """
-    assert set(ANY_ACCESS_MODE) == set(get_args(AccessModeLiteral))
+    assert set(ACCESS_MODE_LITERAL) == set(get_args(AccessModeLiteral))
 
 
 # todo: test

--- a/tests/test_dtype/test_npy/test_common.py
+++ b/tests/test_dtype/test_npy/test_common.py
@@ -32,7 +32,8 @@ from zarr.core.dtype.npy.common import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 
 json_float_v2_roundtrip_cases: tuple[tuple[JSONFloatV2, float | np.floating[Any]], ...] = (

--- a/tests/test_dtype/test_npy/test_common.py
+++ b/tests/test_dtype/test_npy/test_common.py
@@ -32,7 +32,7 @@ from zarr.core.dtype.npy.common import (
 )
 
 if TYPE_CHECKING:
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 
 json_float_v2_roundtrip_cases: tuple[tuple[JSONFloatV2, float | np.floating[Any]], ...] = (

--- a/tests/test_dtype_registry.py
+++ b/tests/test_dtype_registry.py
@@ -31,7 +31,7 @@ from zarr.dtype import (  # type: ignore[attr-defined]
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from zarr.core.common import ZarrFormat
+    from zarr.core.types import ZarrFormat
 
 from .test_dtype.conftest import zdtype_examples
 

--- a/tests/test_dtype_registry.py
+++ b/tests/test_dtype_registry.py
@@ -31,7 +31,7 @@ from zarr.dtype import (  # type: ignore[attr-defined]
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 from .test_dtype.conftest import zdtype_examples
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -60,7 +60,8 @@ if TYPE_CHECKING:
     from _pytest.compat import LEGACY_PATH
 
     from zarr.core.buffer.core import Buffer
-    from zarr.core.types import JSON, ZarrFormat
+    from zarr.core.types import JSON
+    from zarr.types import ZarrFormat
 
 
 @pytest.fixture(params=["local", "memory", "zip"])

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from _pytest.compat import LEGACY_PATH
 
     from zarr.core.buffer.core import Buffer
-    from zarr.core.common import JSON, ZarrFormat
+    from zarr.core.types import JSON, ZarrFormat
 
 
 @pytest.fixture(params=["local", "memory", "zip"])

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from zarr.core.buffer import BufferPrototype
     from zarr.core.buffer.core import Buffer
-    from zarr.core.common import ChunkCoords
+    from zarr.core.types import ChunkCoords
 
 
 @pytest.fixture

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -4,8 +4,8 @@ import pytest
 
 from zarr.codecs.bytes import BytesCodec
 from zarr.core._info import ArrayInfo, GroupInfo, human_readable_size
-from zarr.core.common import ZarrFormat
 from zarr.core.dtype.npy.int import Int32
+from zarr.core.types import ZarrFormat
 
 ZARR_FORMATS = [2, 3]
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -5,7 +5,7 @@ import pytest
 from zarr.codecs.bytes import BytesCodec
 from zarr.core._info import ArrayInfo, GroupInfo, human_readable_size
 from zarr.core.dtype.npy.int import Int32
-from zarr.core.types import ZarrFormat
+from zarr.types import ZarrFormat
 
 ZARR_FORMATS = [2, 3]
 

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -27,7 +27,7 @@ from zarr.storage import StorePath
 
 if TYPE_CHECKING:
     from zarr.abc.store import Store
-    from zarr.core.common import ZarrFormat
+    from zarr.core.types import ZarrFormat
 
 
 @pytest.fixture

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -27,7 +27,7 @@ from zarr.storage import StorePath
 
 if TYPE_CHECKING:
     from zarr.abc.store import Store
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 @pytest.fixture

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from zarr.abc.codec import Codec
-    from zarr.core.common import JSON
+    from zarr.core.types import JSON
 
 
 from zarr.core.metadata.v3 import (

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from zarr.core.buffer import default_buffer_prototype
+from zarr.core.types import ZARR_JSON, ZARRAY_JSON
 
 pytest.importorskip("hypothesis")
 
@@ -15,9 +16,9 @@ import hypothesis.strategies as st
 from hypothesis import assume, given, settings
 
 from zarr.abc.store import Store
-from zarr.core.common import ZARR_JSON, ZARRAY_JSON, ZATTRS_JSON
 from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 from zarr.core.sync import sync
+from zarr.core.types import ZATTRS_JSON
 from zarr.testing.strategies import (
     array_metadata,
     arrays,

--- a/tests/test_store/test_core.py
+++ b/tests/test_store/test_core.py
@@ -6,7 +6,7 @@ from _pytest.compat import LEGACY_PATH
 
 import zarr
 from zarr import Group
-from zarr.core.types import AccessModeLiteral, ZarrFormat
+from zarr.core.types import AccessModeLiteral
 from zarr.storage import FsspecStore, LocalStore, MemoryStore, StoreLike, StorePath, ZipStore
 from zarr.storage._common import contains_array, contains_group, make_store_path
 from zarr.storage._utils import (
@@ -16,6 +16,7 @@ from zarr.storage._utils import (
     _relativize_path,
     normalize_path,
 )
+from zarr.types import ZarrFormat
 
 
 @pytest.fixture(

--- a/tests/test_store/test_core.py
+++ b/tests/test_store/test_core.py
@@ -6,7 +6,7 @@ from _pytest.compat import LEGACY_PATH
 
 import zarr
 from zarr import Group
-from zarr.core.common import AccessModeLiteral, ZarrFormat
+from zarr.core.types import AccessModeLiteral, ZarrFormat
 from zarr.storage import FsspecStore, LocalStore, MemoryStore, StoreLike, StorePath, ZipStore
 from zarr.storage._common import contains_array, contains_group, make_store_path
 from zarr.storage._utils import (

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     import botocore.client
     import s3fs
 
-    from zarr.core.common import JSON
+    from zarr.core.types import JSON
 
 
 # Warning filter due to https://github.com/boto/boto3/issues/3889

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -15,7 +15,7 @@ from zarr.testing.store import StoreTests
 from zarr.testing.utils import gpu_test
 
 if TYPE_CHECKING:
-    from zarr.core.types import ZarrFormat
+    from zarr.types import ZarrFormat
 
 
 # TODO: work out where this warning is coming from and fix it

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -15,7 +15,7 @@ from zarr.testing.store import StoreTests
 from zarr.testing.utils import gpu_test
 
 if TYPE_CHECKING:
-    from zarr.core.common import ZarrFormat
+    from zarr.core.types import ZarrFormat
 
 
 # TODO: work out where this warning is coming from and fix it


### PR DESCRIPTION
This does a few things:
- collects a lot of type definitions and constants in `zarr.core.types`, 
- exports some of those types from `zarr.types`
- defines complete typeddict models for zarr v2 and zarr v3 metadata documents. These are useful enough on their own that we should add them to the library even if this PR goes nowhere.