### PR TITLE
ensure that we test examples with a fresh env

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -72,7 +72,9 @@ def test_scripts_can_run(script_path: Path, tmp_path: Path) -> None:
     # and then test its behavior.
     # This allows the example to be useful to users who don't have Zarr installed, but also testable.
     resave_script(script_path, dest_path)
-    result = subprocess.run(["uv", "run", str(dest_path)], capture_output=True, text=True)
+    result = subprocess.run(
+        ["uv", "run", "--refresh", str(dest_path)], capture_output=True, text=True
+    )
     assert result.returncode == 0, (
         f"Script at {script_path} failed to run. Output: {result.stdout} Error: {result.stderr}"
     )


### PR DESCRIPTION
In `main` it's possible to have the executable examples test against a stale environment. This PR adds a [`--refresh` flag](https://docs.astral.sh/uv/reference/cli/#uv-run) to the invocation of `uv run` to ensure that the environment is fresh for every test invocation. 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
