### PR TITLE
use local imports in store ABC to avoid circular import issues

### DIFF
--- a/changes/3372.misc.rst
+++ b/changes/3372.misc.rst
@@ -1,0 +1,2 @@
+Make certain imports in ``zarr.abc.store`` local to method definitions. This minimizes the risk of
+circular imports when adding new classes to ``zarr.abc.store``.

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -6,10 +6,6 @@ from dataclasses import dataclass
 from itertools import starmap
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from zarr.core.buffer.core import default_buffer_prototype
-from zarr.core.common import concurrent_map
-from zarr.core.config import config
-
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Iterable
     from types import TracebackType
@@ -438,6 +434,9 @@ class Store(ABC):
         # Note to implementers: this default implementation is very inefficient since
         # it requires reading the entire object. Many systems will have ways to get the
         # size of an object without reading it.
+        # avoid circular import
+        from zarr.core.buffer.core import default_buffer_prototype
+
         value = await self.get(key, prototype=default_buffer_prototype())
         if value is None:
             raise FileNotFoundError(key)
@@ -476,6 +475,11 @@ class Store(ABC):
         # on to getting sizes. Ideally we would overlap those two, which should
         # improve tail latency and might reduce memory pressure (since not all keys
         # would be in memory at once).
+
+        # avoid circular import
+        from zarr.core.common import concurrent_map
+        from zarr.core.config import config
+
         keys = [(x,) async for x in self.list_prefix(prefix)]
         limit = config.get("async.concurrency")
         sizes = await concurrent_map(keys, self.getsize, limit=limit)


### PR DESCRIPTION
`zarr.abc.store` imports symbols from modules in `zarr.core`; if you add a new ABC to `zarr.abc.store`, and use it in one of the modules that `zarr.abc.store` is depending on in `zarr.core`, you will get a circular import. 

This PR puts a band-aid on this problem by moving those imports to within the methods that actually need them. A better fix would be to re-organize the dependencies of this package so that we are structurally avoiding circularity. That can come later.

closes #3338 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
