### PR TITLE
Update docs for user-facing `create_array` api on on `Group`. 

### DIFF
--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -783,13 +783,12 @@ def create_array(
         The name of the array within the store. If ``name`` is ``None``, the array will be located
         at the root of the store.
     shape : ChunkCoords, optional
-        Shape of the array. Can be ``None`` if ``data`` is provided.
+        Shape of the array. Must be ``None`` if ``data`` is provided.
     dtype : ZDTypeLike, optional
-        Data type of the array. Can be ``None`` if ``data`` is provided.
+        Data type of the array. Must be ``None`` if ``data`` is provided.
     data : np.ndarray, optional
         Array-like data to use for initializing the array. If this parameter is provided, the
-        ``shape`` and ``dtype`` parameters must be identical to ``data.shape`` and ``data.dtype``,
-        or ``None``.
+        ``shape`` and ``dtype`` parameters must be ``None``.
     chunks : ChunkCoords, optional
         Chunk shape of the array.
         If not specified, default are guessed based on the shape and dtype.

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -2476,12 +2476,11 @@ class Group(SyncMixin):
             The name of the array relative to the group. If ``path`` is ``None``, the array will be located
             at the root of the store.
         shape : ChunkCoords, optional
-            Shape of the array. Can be ``None`` if ``data`` is provided.
+            Shape of the array. Must be ``None`` if ``data`` is provided.
         dtype : npt.DTypeLike | None
-            Data type of the array. Can be ``None`` if ``data`` is provided.
+            Data type of the array. Must be ``None`` if ``data`` is provided.
         data : Array-like data to use for initializing the array. If this parameter is provided, the
-            ``shape`` and ``dtype`` parameters must be identical to ``data.shape`` and ``data.dtype``,
-            or ``None``.
+            ``shape`` and ``dtype`` parameters must be ``None``.
         chunks : ChunkCoords, optional
             Chunk shape of the array.
             If not specified, default are guessed based on the shape and dtype.


### PR DESCRIPTION
When creating an array with data, the docs incorrectly said you could provide the dtype and shape as long as it matched the data's, but when you try to set all three parameters, an error is thrown.

```
Python 3.11.11 (main, Mar 17 2025, 19:26:36) [Clang 16.0.0 (clang-1600.0.26.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import zarr
>>> from zarr.storage import LocalStore
>>> store = LocalStore("test")
>>> a = zarr.create_group(store=store)
>>> import numpy as np
>>> b = np.array([1,2,3])
>>> a.create_array(data=b, dtype=b.dtype, shape=b.shape, name="array")
...
    raise ValueError(msg)
ValueError: The data parameter was used, but the shape parameter was also used. This is an error. Either use the data parameter, or the shape parameter, but not both.
```

Docs for dtype, shape and data parameter are updated based on the behaviour here: https://github.com/zarr-developers/zarr-python/blob/18419f012642f563a0be0556e0b7a3e8611316de/src/zarr/core/array.py#L4978-L4992