### PR TITLE
Fix: respect write_empty_chunks when opening an existing array

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -358,7 +358,9 @@ async def open(
             zarr_format = _metadata_dict["zarr_format"]
             is_v3_array = zarr_format == 3 and _metadata_dict.get("node_type") == "array"
             if is_v3_array or zarr_format == 2:
-                return AsyncArray(store_path=store_path, metadata=_metadata_dict)
+                return AsyncArray(
+                    store_path=store_path, metadata=_metadata_dict, config=kwargs.get("config")
+                )
         except (AssertionError, FileNotFoundError, NodeTypeValidationError):
             pass
         return await open_group(store=store_path, zarr_format=zarr_format, mode=mode, **kwargs)


### PR DESCRIPTION
When you opened an existing array the write_empty_chunks config was being ignored. As indirectly reported in https://github.com/pydata/xarray/issues/10633 this fixes the one branch of this function where the config was not being handled

minimal zarr reproducer

```python
#!/usr/bin/env -S uv run
# /// script
# requires-python = ">=3.10"
# dependencies = [
#     "zarr@git+https://github.com/zarr-developers/zarr-python.git@main",
#     "numpy",
# ]
# ///

import os

import numpy as np
import zarr

# Create array
store = zarr.open_group("test.zarr", mode="w")
arr = store.create(
    "data",
    shape=(20,),
    chunks=(10,),
    dtype="f8",
    fill_value=0.0,
    config={"write_empty_chunks": True},
)

# Reopen (like xarray does with regions)
store = zarr.open_group("test.zarr", mode="r+")
arr = zarr.open(store=store.store, path="data", config={"write_empty_chunks": True})

# Write zeros - should create chunk but doesn't
arr[0:10] = np.zeros(10)

# Check what was written
chunk_dir = "test.zarr/data/c"
chunks = (
    [f for f in os.listdir(chunk_dir) if f.isdigit()]
    if os.path.exists(chunk_dir)
    else []
)
print(f"Chunks written: {sorted(chunks)}")
print("Expected: ['0'] (chunk with zeros should be written)")

```


* [x] Add unit tests and/or doctests in docstrings
* [NA] Add docstrings and API docs for any new/modified user-facing classes and functions
* [NA] New/modified features documented in `docs/user-guide/*.rst`
* [NA?] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
