### PR TITLE
Optimize getitem with empty chunks

### DIFF
--- a/changes/3368.misc.rst
+++ b/changes/3368.misc.rst
@@ -1,0 +1,2 @@
+Improved performance of reading arrays by not unnecessarily using
+the fill value.

--- a/src/zarr/abc/codec.py
+++ b/src/zarr/abc/codec.py
@@ -423,6 +423,11 @@ class CodecPipeline:
             The second slice selection determines where in the output array the chunk data will be written.
             The ByteGetter is used to fetch the necessary bytes.
             The chunk spec contains information about the construction of an array from the bytes.
+
+            If the Store returns ``None`` for a chunk, then the chunk was not
+            written and the implementation must set the values of that chunk (or
+            ``out``) to the fill value for the array.
+
         out : NDBuffer
         """
         ...

--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -452,11 +452,10 @@ class ShardingCodec(
         )
 
         # setup output array
-        out = chunk_spec.prototype.nd_buffer.create(
+        out = chunk_spec.prototype.nd_buffer.empty(
             shape=shard_shape,
             dtype=shard_spec.dtype.to_native_dtype(),
             order=shard_spec.order,
-            fill_value=0,
         )
         shard_dict = await _ShardReader.from_bytes(shard_bytes, self, chunks_per_shard)
 
@@ -499,11 +498,10 @@ class ShardingCodec(
         )
 
         # setup output array
-        out = shard_spec.prototype.nd_buffer.create(
+        out = shard_spec.prototype.nd_buffer.empty(
             shape=indexer.shape,
             dtype=shard_spec.dtype.to_native_dtype(),
             order=shard_spec.order,
-            fill_value=0,
         )
 
         indexed_chunks = list(indexer)

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1350,11 +1350,10 @@ class AsyncArray(Generic[T_ArrayMetadata]):
                     f"shape of out argument doesn't match. Expected {indexer.shape}, got {out.shape}"
                 )
         else:
-            out_buffer = prototype.nd_buffer.create(
+            out_buffer = prototype.nd_buffer.empty(
                 shape=indexer.shape,
                 dtype=out_dtype,
                 order=self.order,
-                fill_value=self.metadata.fill_value,
             )
         if product(indexer.shape) > 0:
             # need to use the order from the metadata for v2


### PR DESCRIPTION
This optimizes our read performance by using `NDBuffer.empty` instead of `NDBuffer.create` with a fill value. All chunks are filled, either with the values from the Store if that chunk was initialized, or the fill value if the Store returns `None` (the 
chunk wasn't initialized). By not memsetting values that will be overwritten anyway, things will be a bit faster.

I didn't see any documentation about CodecPipeline in the docs. Technically, users might see a behavior change, if the user's codec pipeline happened to rely on receiving an array filled with the `fill_value`. Do we know of anyone writing / using custom codec pipelines?

Here's a mini benchmark:

<details>

```python
import asyncio
import statistics
import time

import zarr.api.asynchronous
import zarr.storage


async def main():
    store = zarr.storage.MemoryStore()
    array = await zarr.api.asynchronous.create_array(
        store, shape=(125_000_000,), dtype="float64", chunks=(125_000,), fill_value=1.0
    )
    times = []
    for _ in range(10):
        t0 = time.monotonic()
        await array.getitem(slice(None))
        t1 = time.monotonic()
        times.append(t1 - t0)

    print("Unitialized", statistics.median(times))

    await array.setitem(slice(None), 2.0)
    times = []
    for _ in range(10):
        t0 = time.monotonic()
        await array.getitem(slice(None))
        t1 = time.monotonic()
        times.append(t1 - t0)
    print("Initialized", statistics.median(times))


if __name__ == "__main__":
    asyncio.run(main())

```

</details>


`main`:

```
❯ python bench.py
Unitialized 0.6652364450274035
Initialized 0.9079880800272804
```


HEAD:

```
❯ python bench.py
Unitialized 0.5070544500194956
Initialized 0.8395943949872162
```


Closes #3368 


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
