### PR TITLE
docs: Update the link to sharding in the Zarr roadmap

### DIFF
--- a/docs/developers/roadmap.rst
+++ b/docs/developers/roadmap.rst
@@ -56,7 +56,7 @@ Goals
 -  Provide a complete implementation of Zarr V3 through the Zarr-Python
    API
 -  Clear the way for exciting extensions / ZEPs
-   (i.e. `sharding <https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/v1.0.html>`__,
+   (i.e. `sharding <https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/>`__,
    `variable chunking <https://zarr.dev/zeps/draft/ZEP0003.html>`__,
    etc.)
 -  Provide a developer API that can be used to implement and register V3


### PR DESCRIPTION
Update the link to sharding in the Zarr roadmap:
https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/

Original link does not work:
https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/v1.0.html

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
