### PR TITLE
Relax obsolete constraints on setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27.0", "hatch-vcs", "setuptools-scm!=9.0.0"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
This reverts e77f803e1a813a496d59c3d091a263602c308bf1.

No need to explicitly avoid a yanked release. Release `9.0.0` has been yanked on PyPI. Actually all `9.*.*` releases so far have been yanked, except for the current `9.2.0`:
	https://pypi.org/project/setuptools-scm/#history

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
