### PR TITLE
Fix typing in metadata tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,6 +352,7 @@ module = [
     "tests.test_store.test_fsspec",
     "tests.test_store.test_memory",
     "tests.test_codecs.test_codecs",
+    "tests.test_metadata.*",
 ]
 strict = false
 
@@ -359,7 +360,6 @@ strict = false
 # and fix the errors
 [[tool.mypy.overrides]]
 module = [
-    "tests.test_metadata.*",
     "tests.test_store.test_core",
     "tests.test_store.test_logging",
     "tests.test_store.test_object",

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import warnings
 from asyncio import gather
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from itertools import starmap
 from logging import getLogger
@@ -3907,7 +3907,7 @@ CompressorLike: TypeAlias = dict[str, JSON] | BytesBytesCodec | Numcodec | Liter
 
 CompressorsLike: TypeAlias = (
     Iterable[dict[str, JSON] | BytesBytesCodec | Numcodec]
-    | dict[str, JSON]
+    | Mapping[str, JSON]
     | BytesBytesCodec
     | Numcodec
     | Literal["auto"]

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -128,7 +128,7 @@ def test_jsonify_fill_value_complex(fill_value: Any, dtype_str: str) -> None:
     Test that parse_fill_value(fill_value, dtype) correctly handles complex values represented
     as length-2 sequences
     """
-    zarr_format = 3
+    zarr_format: Literal[3] = 3
     dtype = get_data_type_from_native_dtype(dtype_str)
     expected = dtype.to_native_dtype().type(complex(*fill_value))
     observed = dtype.from_json_scalar(fill_value, zarr_format=zarr_format)
@@ -249,7 +249,7 @@ def test_metadata_to_dict(
 
 
 @pytest.mark.parametrize("indent", [2, 4, None])
-def test_json_indent(indent: int):
+def test_json_indent(indent: int) -> None:
     with config.set({"json_indent": indent}):
         m = GroupMetadata()
         d = m.to_buffer_dict(default_buffer_prototype())["zarr.json"].to_bytes()
@@ -258,9 +258,9 @@ def test_json_indent(indent: int):
 
 @pytest.mark.parametrize("fill_value", [-1, 0, 1, 2932897])
 @pytest.mark.parametrize("precision", ["ns", "D"])
-async def test_datetime_metadata(fill_value: int, precision: str) -> None:
+async def test_datetime_metadata(fill_value: int, precision: Literal["ns", "D"]) -> None:
     dtype = DateTime64(unit=precision)
-    metadata_dict = {
+    metadata_dict: dict[str, Any] = {
         "zarr_format": 3,
         "node_type": "array",
         "shape": (1,),
@@ -284,7 +284,7 @@ async def test_datetime_metadata(fill_value: int, precision: str) -> None:
     ("data_type", "fill_value"), [("uint8", {}), ("int32", [0, 1]), ("float32", "foo")]
 )
 async def test_invalid_fill_value_raises(data_type: str, fill_value: float) -> None:
-    metadata_dict = {
+    metadata_dict: dict[str, Any] = {
         "zarr_format": 3,
         "node_type": "array",
         "shape": (1,),
@@ -301,7 +301,7 @@ async def test_invalid_fill_value_raises(data_type: str, fill_value: float) -> N
 
 @pytest.mark.parametrize("fill_value", [("NaN"), "Infinity", "-Infinity"])
 async def test_special_float_fill_values(fill_value: str) -> None:
-    metadata_dict = {
+    metadata_dict: dict[str, Any] = {
         "zarr_format": 3,
         "node_type": "array",
         "shape": (1,),


### PR DESCRIPTION
Another train journey = continuing the crusade against typing errors, this time in the metadata tests. I made one change to the API typing, switching out `dict` for `Mapping` in `CompressorsLike`, because `Mapping` is covariant in it's parameters.