### PR TITLE
reraise the `KeyError` for unknown codecs with a more specific error class

### DIFF
--- a/changes/3395.bugfix.rst
+++ b/changes/3395.bugfix.rst
@@ -1,0 +1,1 @@
+Raise a Zarr-specific error class when a codec can't be found by name when deserializing the given codecs. This avoids hiding this error behind a "not part of a zarr hierarchy" warning.

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -67,7 +67,7 @@ def parse_codecs(data: object) -> tuple[Codec, ...]:
             try:
                 out += (get_codec_class(name_parsed).from_dict(c),)
             except KeyError as e:
-                raise UnknownCodecError(e.args[0]) from e
+                raise UnknownCodecError(f"Unknown codec: {e.args[0]!r}") from e
 
     return out
 

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -34,7 +34,7 @@ from zarr.core.common import (
 )
 from zarr.core.config import config
 from zarr.core.metadata.common import parse_attributes
-from zarr.errors import MetadataValidationError, NodeTypeValidationError
+from zarr.errors import MetadataValidationError, NodeTypeValidationError, UnknownCodecError
 from zarr.registry import get_codec_class
 
 
@@ -63,7 +63,11 @@ def parse_codecs(data: object) -> tuple[Codec, ...]:
             out += (c,)
         else:
             name_parsed, _ = parse_named_configuration(c, require_configuration=False)
-            out += (get_codec_class(name_parsed).from_dict(c),)
+
+            try:
+                out += (get_codec_class(name_parsed).from_dict(c),)
+            except KeyError as e:
+                raise UnknownCodecError(e.args[0]) from e
 
     return out
 

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -106,7 +106,7 @@ class UnknownCodecError(BaseZarrError):
     Raised when a unknown codec was used.
     """
 
-    _msg = "Unknown codec {!r}."
+    _msg = "{}"
 
 
 class NodeTypeValidationError(MetadataValidationError):

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -26,6 +26,14 @@ class BaseZarrError(ValueError):
         super().__init__(self._msg.format(*args))
 
 
+class UnknownCodecError(BaseZarrError):
+    """
+    Raised when a unknown codec was used.
+    """
+
+    _msg = "Unknown codec {!r}."
+
+
 class GroupNotFoundError(BaseZarrError, FileNotFoundError):
     """
     Raised when a group isn't found at a certain path.

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -17,10 +17,11 @@ from zarr.core.dtype.npy.time import DateTime64
 from zarr.core.group import GroupMetadata, parse_node_type
 from zarr.core.metadata.v3 import (
     ArrayV3Metadata,
+    parse_codecs,
     parse_dimension_names,
     parse_zarr_format,
 )
-from zarr.errors import MetadataValidationError, NodeTypeValidationError
+from zarr.errors import MetadataValidationError, NodeTypeValidationError, UnknownCodecError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -323,3 +324,9 @@ async def test_special_float_fill_values(fill_value: str) -> None:
     elif fill_value == "-Infinity":
         assert np.isneginf(m.fill_value)
         assert d["fill_value"] == "-Infinity"
+
+
+def test_parse_codecs_unknown_codec_raises() -> None:
+    codecs = [{"name": "unknown"}]
+    with pytest.raises(UnknownCodecError):
+        parse_codecs(codecs)

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -326,7 +326,15 @@ async def test_special_float_fill_values(fill_value: str) -> None:
         assert d["fill_value"] == "-Infinity"
 
 
-def test_parse_codecs_unknown_codec_raises() -> None:
+def test_parse_codecs_unknown_codec_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from collections import defaultdict
+
+    import zarr.registry
+    from zarr.registry import Registry
+
+    # to make sure the codec is always unknown (not sure if that's necessary)
+    monkeypatch.setattr(zarr.registry, "__codec_registries", defaultdict(Registry))
+
     codecs = [{"name": "unknown"}]
     with pytest.raises(UnknownCodecError):
         parse_codecs(codecs)


### PR DESCRIPTION
- [x] closes #3384

This converts the `KeyError` to a new zarr-specific `UnknownCodecError`, which since it indirectly inherits from `ValueError` won't be confused with responses by the store.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)