### PR TITLE
Prevent creation of arrays/groups under a parent array

### DIFF
--- a/src/zarr/core/metadata/io.py
+++ b/src/zarr/core/metadata/io.py
@@ -87,7 +87,10 @@ async def save_metadata(
         try:
             await asyncio.gather(*ensure_array_awaitables)
         except ContainsArrayError as e:
-            set_awaitables = []  # clear awaitables to avoid printed RuntimeWarning: coroutine was never awaited
+            # clear awaitables to avoid RuntimeWarning: coroutine was never awaited
+            for awaitable in set_awaitables:
+                awaitable.close()
+
             raise ValueError(
                 f"A parent of {store_path} is an array - only groups may have child nodes."
             ) from e

--- a/src/zarr/core/metadata/io.py
+++ b/src/zarr/core/metadata/io.py
@@ -55,7 +55,7 @@ async def save_metadata(
     metadata : ArrayMetadata | GroupMetadata
         Metadata to save.
     ensure_parents : bool, optional
-        Whether to create any missing parent groups
+        Create any missing parent groups, and check no existing parents are arrays.
 
     Raises
     ------

--- a/src/zarr/core/metadata/io.py
+++ b/src/zarr/core/metadata/io.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from zarr.abc.store import set_or_delete
+from zarr.core.buffer.core import default_buffer_prototype
+from zarr.errors import ContainsArrayError
+from zarr.storage._common import StorePath, ensure_no_existing_node
+
+if TYPE_CHECKING:
+    from zarr.core.common import ZarrFormat
+    from zarr.core.group import AsyncGroup, GroupMetadata
+    from zarr.core.metadata import ArrayMetadata
+
+
+def _build_parents(store_path: StorePath, zarr_format: ZarrFormat) -> list[AsyncGroup]:
+    from zarr.core.group import AsyncGroup, GroupMetadata
+
+    store = store_path.store
+    path = store_path.path
+    if not path:
+        return []
+
+    required_parts = path.split("/")[:-1]
+    parents = [
+        # the root group
+        AsyncGroup(
+            metadata=GroupMetadata(zarr_format=zarr_format),
+            store_path=StorePath(store=store, path=""),
+        )
+    ]
+
+    for i, part in enumerate(required_parts):
+        p = "/".join(required_parts[:i] + [part])
+        parents.append(
+            AsyncGroup(
+                metadata=GroupMetadata(zarr_format=zarr_format),
+                store_path=StorePath(store=store, path=p),
+            )
+        )
+
+    return parents
+
+
+async def save_metadata(
+    store_path: StorePath, metadata: ArrayMetadata | GroupMetadata, ensure_parents: bool = False
+) -> None:
+    """Asynchronously save the array or group metadata.
+
+    Parameters
+    ----------
+    store_path : StorePath
+        Location to save metadata.
+    metadata : ArrayMetadata | GroupMetadata
+        Metadata to save.
+    ensure_parents : bool, optional
+        Whether to create any missing parent groups
+
+    Raises
+    ------
+    ValueError
+    """
+    to_save = metadata.to_buffer_dict(default_buffer_prototype())
+    set_awaitables = [set_or_delete(store_path / key, value) for key, value in to_save.items()]
+
+    if ensure_parents:
+        # To enable zarr.create(store, path="a/b/c"), we need to create all the intermediate groups.
+        parents = _build_parents(store_path, metadata.zarr_format)
+        ensure_array_awaitables = []
+
+        for parent in parents:
+            # Error if an array already exists at any parent location. Only groups can have child nodes.
+            ensure_array_awaitables.append(
+                ensure_no_existing_node(parent.store_path, metadata.zarr_format, node_type="array")
+            )
+            set_awaitables.extend(
+                [
+                    (parent.store_path / key).set_if_not_exists(value)
+                    for key, value in parent.metadata.to_buffer_dict(
+                        default_buffer_prototype()
+                    ).items()
+                ]
+            )
+
+        # Checks for parent arrays must happen first, before any metadata is modified
+        try:
+            await asyncio.gather(*ensure_array_awaitables)
+        except ContainsArrayError as e:
+            set_awaitables = []  # clear awaitables to avoid printed RuntimeWarning: coroutine was never awaited
+            raise ValueError(
+                f"A parent of {store_path} is an array - only groups may have child nodes."
+            ) from e
+
+    await asyncio.gather(*set_awaitables)

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -427,14 +427,21 @@ async def ensure_no_existing_node(
     elif zarr_format == 3:
         extant_node = await _contains_node_v3(store_path)
 
-    if extant_node == "array" and node_type != "group":
-        raise ContainsArrayError(store_path.store, store_path.path)
-    elif extant_node == "group" and node_type != "array":
-        raise ContainsGroupError(store_path.store, store_path.path)
-    elif extant_node == "nothing":
-        return
-    msg = f"Invalid value for extant_node: {extant_node}"
-    raise ValueError(msg)
+    match extant_node:
+        case "array":
+            if node_type != "group":
+                raise ContainsArrayError(store_path.store, store_path.path)
+
+        case "group":
+            if node_type != "array":
+                raise ContainsGroupError(store_path.store, store_path.path)
+
+        case "nothing":
+            return
+
+        case _:
+            msg = f"Invalid value for extant_node: {extant_node}"  # type: ignore[unreachable]
+            raise ValueError(msg)
 
 
 async def _contains_node_v3(store_path: StorePath) -> Literal["array", "group", "nothing"]:

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -761,6 +761,24 @@ def test_group_create_array(
     assert np.array_equal(array[:], data)
 
 
+@pytest.mark.parametrize("method", ["create_array", "create_group"])
+def test_create_with_parent_array(store: Store, zarr_format: ZarrFormat, method: str):
+    """Test that groups/arrays cannot be created under a parent array."""
+
+    # create a group with a child array
+    group = Group.from_store(store, zarr_format=zarr_format)
+    group.create_array(name="arr_1", shape=(10, 10), dtype="uint8")
+
+    error_msg = r"A parent of .* is an array - only groups may have child nodes."
+    if method == "create_array":
+        with pytest.raises(ValueError, match=error_msg):
+            group.create_array("arr_1/group_1/group_2/arr_2", shape=(10, 10), dtype="uint8")
+
+    else:
+        with pytest.raises(ValueError, match=error_msg):
+            group.create_group("arr_1/group_1/group_2/group_3")
+
+
 def test_group_array_creation(
     store: Store,
     zarr_format: ZarrFormat,

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -2042,14 +2042,14 @@ class TestAsync:
 
     @pytest.mark.asyncio
     async def test_async_oindex_with_zarr_array(self, store):
-        z1 = zarr.create_array(store=store, shape=(2, 2), chunks=(1, 1), zarr_format=3, dtype="i8")
+        group = zarr.create_group(store=store, zarr_format=3)
+
+        z1 = group.create_array(name="z1", shape=(2, 2), chunks=(1, 1), dtype="i8")
         z1[...] = np.array([[1, 2], [3, 4]])
         async_zarr = z1._async_array
 
         # create boolean zarr array to index with
-        z2 = zarr.create_array(
-            store=store, name="z2", shape=(2,), chunks=(1,), zarr_format=3, dtype="?"
-        )
+        z2 = group.create_array(name="z2", shape=(2,), chunks=(1,), dtype="?")
         z2[...] = np.array([True, False])
 
         result = await async_zarr.oindex.getitem(z2)
@@ -2075,14 +2075,14 @@ class TestAsync:
 
     @pytest.mark.asyncio
     async def test_async_vindex_with_zarr_array(self, store):
-        z1 = zarr.create_array(store=store, shape=(2, 2), chunks=(1, 1), zarr_format=3, dtype="i8")
+        group = zarr.create_group(store=store, zarr_format=3)
+
+        z1 = group.create_array(name="z1", shape=(2, 2), chunks=(1, 1), dtype="i8")
         z1[...] = np.array([[1, 2], [3, 4]])
         async_zarr = z1._async_array
 
         # create boolean zarr array to index with
-        z2 = zarr.create_array(
-            store=store, name="z2", shape=(2, 2), chunks=(1, 1), zarr_format=3, dtype="?"
-        )
+        z2 = group.create_array(name="z2", shape=(2, 2), chunks=(1, 1), dtype="?")
         z2[...] = np.array([[False, True], [False, True]])
 
         result = await async_zarr.vindex.getitem(z2)


### PR DESCRIPTION
Closes https://github.com/zarr-developers/zarr-python/issues/2582

Prevents creation of arrays / groups under a parent array with `.create_array` and `.create_group` e.g. `root.create_array(name='foo/bar')` (where `foo` is an existing array)

This required changes to the `_save_metadata` function of both `zarr/core/array.py` and `zarr/core/group.py`. As both used pretty much identical code, I refactored this into a common function in `zarr/core/metadata/io.py` (along with the `_build_parents` function both relied upon). Happy to move this elsewhere - if there is a more suitable location for it!

I tried to avoid looping over the parents multiple times in `_save_metadata` for the sake of performance (potentially this path could be deeply nested). Hence looping once, and creating two sets of awaitables: one for checking if an array exists at the location + one to actually modify the metadata there. Again, happy to update this if there's a simpler solution.


TODO:
* [X] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
