### PR TITLE
Use atomic writes for new files in LocalStore

### DIFF
--- a/changes/3411.bugfix.rst
+++ b/changes/3411.bugfix.rst
@@ -1,0 +1,1 @@
+LocalStore now uses atomic writes, which should prevent some cases of corrupted data.

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -44,7 +44,7 @@ def _get(path: Path, prototype: BufferPrototype, byte_range: ByteRequest | None)
         return prototype.buffer.from_bytes(f.read())
 
 
-if sys.platform == 'win32':
+if sys.platform == "win32":
     # Per the os.rename docs:
     # On Windows, if dst exists a FileExistsError is always raised.
     _safe_move = os.rename
@@ -64,7 +64,7 @@ def _atomic_write(
     mode: Literal["r+b", "wb"],
     exclusive: bool = False,
 ) -> Iterator[BinaryIO]:
-    tmp_path = path.with_suffix(f'.{uuid.uuid4().hex}.partial')
+    tmp_path = path.with_suffix(f".{uuid.uuid4().hex}.partial")
     try:
         with tmp_path.open(mode) as f:
             yield f

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 import contextlib
 import io
 import os
@@ -23,7 +22,7 @@ from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.common import AccessModeLiteral, concurrent_map
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable
+    from collections.abc import AsyncIterator, Iterable, Iterator
 
     from zarr.core.buffer import BufferPrototype
 

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -6,9 +6,9 @@ import io
 import os
 import shutil
 import sys
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Literal, Self
-import uuid
 
 from zarr.abc.store import (
     ByteRequest,

--- a/src/zarr/storage/_local.py
+++ b/src/zarr/storage/_local.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, BinaryIO, Self
+from typing import TYPE_CHECKING, BinaryIO, Literal, Self
 import uuid
 
 from zarr.abc.store import (

--- a/tests/test_store/test_local.py
+++ b/tests/test_store/test_local.py
@@ -114,42 +114,42 @@ class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
 
 @pytest.mark.parametrize("exclusive", [True, False])
 def test_atomic_write_successful(tmp_path: pathlib.Path, exclusive: bool) -> None:
-    path = pathlib.Path(tmp_path) / 'data'
-    with _atomic_write(path, 'wb', exclusive=exclusive) as f:
-        f.write(b'abc')
-    assert path.read_bytes() == b'abc'
+    path = pathlib.Path(tmp_path) / "data"
+    with _atomic_write(path, "wb", exclusive=exclusive) as f:
+        f.write(b"abc")
+    assert path.read_bytes() == b"abc"
     assert list(path.parent.iterdir()) == [path]  # no temp files
 
 
 @pytest.mark.parametrize("exclusive", [True, False])
 def test_atomic_write_incomplete(tmp_path: pathlib.Path, exclusive: bool) -> None:
-    path = pathlib.Path(tmp_path) / 'data'
+    path = pathlib.Path(tmp_path) / "data"
     with pytest.raises(RuntimeError):  # noqa: PT012
-        with _atomic_write(path, 'wb', exclusive=exclusive) as f:
-            f.write(b'a')
+        with _atomic_write(path, "wb", exclusive=exclusive) as f:
+            f.write(b"a")
             raise RuntimeError
     assert not path.exists()
     assert list(path.parent.iterdir()) == []  # no temp files
 
 
 def test_atomic_write_non_exclusive_preexisting(tmp_path: pathlib.Path) -> None:
-    path = pathlib.Path(tmp_path) / 'data'
-    with path.open('wb') as f:
-        f.write(b'xyz')
-    assert path.read_bytes() == b'xyz'
-    with _atomic_write(path, 'wb', exclusive=False) as f:
-        f.write(b'abc')
-    assert path.read_bytes() == b'abc'
+    path = pathlib.Path(tmp_path) / "data"
+    with path.open("wb") as f:
+        f.write(b"xyz")
+    assert path.read_bytes() == b"xyz"
+    with _atomic_write(path, "wb", exclusive=False) as f:
+        f.write(b"abc")
+    assert path.read_bytes() == b"abc"
     assert list(path.parent.iterdir()) == [path]  # no temp files
 
 
 def test_atomic_write_exclusive_preexisting(tmp_path: pathlib.Path) -> None:
-    path = pathlib.Path(tmp_path) / 'data'
-    with path.open('wb') as f:
-        f.write(b'xyz')
-    assert path.read_bytes() == b'xyz'
+    path = pathlib.Path(tmp_path) / "data"
+    with path.open("wb") as f:
+        f.write(b"xyz")
+    assert path.read_bytes() == b"xyz"
     with pytest.raises(FileExistsError):
-        with _atomic_write(path, 'wb', exclusive=True) as f:
-            f.write(b'abc')
-    assert path.read_bytes() == b'xyz'
+        with _atomic_write(path, "wb", exclusive=True) as f:
+            f.write(b"abc")
+    assert path.read_bytes() == b"xyz"
     assert list(path.parent.iterdir()) == [path]  # no temp files

--- a/tests/test_store/test_local.py
+++ b/tests/test_store/test_local.py
@@ -10,6 +10,7 @@ import zarr
 from zarr import create_array
 from zarr.core.buffer import Buffer, cpu
 from zarr.storage import LocalStore
+from zarr.storage._local import _atomic_write
 from zarr.testing.store import StoreTests
 from zarr.testing.utils import assert_bytes_equal
 
@@ -109,3 +110,46 @@ class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
             FileExistsError, match=re.escape(f"Destination root {destination} already exists")
         ):
             await store2.move(destination)
+
+
+@pytest.mark.parametrize("exclusive", [True, False])
+def test_atomic_write_successful(tmp_path: pathlib.Path, exclusive: bool) -> None:
+    path = pathlib.Path(tmp_path) / 'data'
+    with _atomic_write(path, 'wb', exclusive=exclusive) as f:
+        f.write(b'abc')
+    assert path.read_bytes() == b'abc'
+    assert list(path.parent.iterdir()) == [path]  # no temp files
+
+
+@pytest.mark.parametrize("exclusive", [True, False])
+def test_atomic_write_incomplete(tmp_path: pathlib.Path, exclusive: bool) -> None:
+    path = pathlib.Path(tmp_path) / 'data'
+    with pytest.raises(RuntimeError):
+        with _atomic_write(path, 'wb', exclusive=exclusive) as f:
+            f.write(b'a')
+            raise RuntimeError
+    assert not path.exists()
+    assert list(path.parent.iterdir()) == []  # no temp files
+
+
+def test_atomic_write_non_exclusive_preexisting(tmp_path: pathlib.Path) -> None:
+    path = pathlib.Path(tmp_path) / 'data'
+    with path.open('wb') as f:
+        f.write(b'xyz')
+    assert path.read_bytes() == b'xyz'
+    with _atomic_write(path, 'wb', exclusive=False) as f:
+        f.write(b'abc')
+    assert path.read_bytes() == b'abc'
+    assert list(path.parent.iterdir()) == [path]  # no temp files
+
+
+def test_atomic_write_exclusive_preexisting(tmp_path: pathlib.Path) -> None:
+    path = pathlib.Path(tmp_path) / 'data'
+    with path.open('wb') as f:
+        f.write(b'xyz')
+    assert path.read_bytes() == b'xyz'
+    with pytest.raises(FileExistsError):
+        with _atomic_write(path, 'wb', exclusive=True) as f:
+            f.write(b'abc')
+    assert path.read_bytes() == b'xyz'
+    assert list(path.parent.iterdir()) == [path]  # no temp files

--- a/tests/test_store/test_local.py
+++ b/tests/test_store/test_local.py
@@ -124,7 +124,7 @@ def test_atomic_write_successful(tmp_path: pathlib.Path, exclusive: bool) -> Non
 @pytest.mark.parametrize("exclusive", [True, False])
 def test_atomic_write_incomplete(tmp_path: pathlib.Path, exclusive: bool) -> None:
     path = pathlib.Path(tmp_path) / 'data'
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError):  # noqa: PT012
         with _atomic_write(path, 'wb', exclusive=exclusive) as f:
             f.write(b'a')
             raise RuntimeError


### PR DESCRIPTION
Fixes #3411

I use the standard strategy of writing to a temporary file in the same directory, and then renaming it to the desired name. This ensure that Zarr writes are either complete or not written at all.

It would be nice if partial writes (`_put()` with `start`) could also be atomic, but I'm honestly not sure if both atomic and efficient partial writes of files are possible. Interestingly, I don't see any uses of `set_partial_values()` inside Zarr, so maybe this feature isn't needed after all? (see https://github.com/zarr-developers/zarr-python/issues/2859 for discussion)

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
