### PR TITLE
Remove Store.set_partial_writes

### DIFF
--- a/changes/2859.removal.rst
+++ b/changes/2859.removal.rst
@@ -1,0 +1,2 @@
+The ``Store.set_partial_writes`` method, which was not used by Zarr-Python, has been removed.
+``store.supports_partial_writes`` is now always ``False``.

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from typing import Any, Self, TypeAlias
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 __all__ = ["ByteGetter", "ByteSetter", "Store", "set_or_delete"]
 

--- a/src/zarr/abc/store.py
+++ b/src/zarr/abc/store.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from asyncio import gather
 from dataclasses import dataclass
 from itertools import starmap
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator, Iterable
@@ -310,25 +310,12 @@ class Store(ABC):
         ...
 
     @property
-    @abstractmethod
-    def supports_partial_writes(self) -> bool:
-        """Does the store support partial writes?"""
-        ...
+    def supports_partial_writes(self) -> Literal[False]:
+        """Does the store support partial writes?
 
-    @abstractmethod
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
-        """Store values at a given key, starting at byte range_start.
-
-        Parameters
-        ----------
-        key_start_values : list[tuple[str, int, BytesLike]]
-            set of key, range_start, values triples, a key may occur multiple times with different
-            range_starts, range_starts (considering the length of the respective values) must not
-            specify overlapping ranges for the same key
+        Partial writes are no longer used by Zarr, so this is always false.
         """
-        ...
+        return False
 
     @property
     @abstractmethod
@@ -499,7 +486,7 @@ class ByteSetter(Protocol):
         self, prototype: BufferPrototype, byte_range: ByteRequest | None = None
     ) -> Buffer | None: ...
 
-    async def set(self, value: Buffer, byte_range: ByteRequest | None = None) -> None: ...
+    async def set(self, value: Buffer) -> None: ...
 
     async def delete(self) -> None: ...
 

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -163,7 +163,7 @@ class StorePath:
             prototype = default_buffer_prototype()
         return await self.store.get(self.path, prototype=prototype, byte_range=byte_range)
 
-    async def set(self, value: Buffer, byte_range: ByteRequest | None = None) -> None:
+    async def set(self, value: Buffer) -> None:
         """
         Write bytes to the store.
 
@@ -171,16 +171,7 @@ class StorePath:
         ----------
         value : Buffer
             The buffer to write.
-        byte_range : ByteRequest, optional
-            The range of bytes to write. If None, the entire buffer is written.
-
-        Raises
-        ------
-        NotImplementedError
-            If `byte_range` is not None, because Store.set does not support partial writes yet.
         """
-        if byte_range is not None:
-            raise NotImplementedError("Store.set does not have partial writes yet")
         await self.store.set(self.path, value)
 
     async def delete(self) -> None:

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -89,7 +89,6 @@ class FsspecStore(Store):
     allowed_exceptions
     supports_writes
     supports_deletes
-    supports_partial_writes
     supports_listing
 
     Raises
@@ -113,7 +112,6 @@ class FsspecStore(Store):
     # based on FSSpec
     supports_writes: bool = True
     supports_deletes: bool = True
-    supports_partial_writes: bool = False
     supports_listing: bool = True
 
     fs: AsyncFileSystem

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from fsspec.mapping import FSMap
 
     from zarr.core.buffer import BufferPrototype
-    from zarr.core.common import BytesLike
 
 
 ALLOWED_EXCEPTIONS: tuple[type[Exception], ...] = (

--- a/src/zarr/storage/_fsspec.py
+++ b/src/zarr/storage/_fsspec.py
@@ -418,12 +418,6 @@ class FsspecStore(Store):
 
         return [None if isinstance(r, Exception) else prototype.buffer.from_bytes(r) for r in res]
 
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
-        # docstring inherited
-        raise NotImplementedError
-
     async def list(self) -> AsyncIterator[str]:
         # docstring inherited
         allfiles = await self.fs._find(self.path, detail=False, withdirs=False)

--- a/src/zarr/storage/_logging.py
+++ b/src/zarr/storage/_logging.py
@@ -116,11 +116,6 @@ class LoggingStore(WrapperStore[T_Store]):
             return self._store.supports_deletes
 
     @property
-    def supports_partial_writes(self) -> bool:
-        with self.log():
-            return self._store.supports_partial_writes
-
-    @property
     def supports_listing(self) -> bool:
         with self.log():
             return self._store.supports_listing
@@ -206,14 +201,6 @@ class LoggingStore(WrapperStore[T_Store]):
         # docstring inherited
         with self.log(key):
             return await self._store.delete(key=key)
-
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, bytes | bytearray | memoryview]]
-    ) -> None:
-        # docstring inherited
-        keys = ",".join([k[0] for k in key_start_values])
-        with self.log(keys):
-            return await self._store.set_partial_values(key_start_values=key_start_values)
 
     async def list(self) -> AsyncGenerator[str, None]:
         # docstring inherited

--- a/src/zarr/storage/_memory.py
+++ b/src/zarr/storage/_memory.py
@@ -32,13 +32,11 @@ class MemoryStore(Store):
     ----------
     supports_writes
     supports_deletes
-    supports_partial_writes
     supports_listing
     """
 
     supports_writes: bool = True
     supports_deletes: bool = True
-    supports_partial_writes: bool = True
     supports_listing: bool = True
 
     _store_dict: MutableMapping[str, Buffer]
@@ -142,12 +140,6 @@ class MemoryStore(Store):
             del self._store_dict[key]
         except KeyError:
             logger.debug("Key %s does not exist.", key)
-
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, bytes | bytearray | memoryview[int]]]
-    ) -> None:
-        # docstring inherited
-        raise NotImplementedError
 
     async def list(self) -> AsyncIterator[str]:
         # docstring inherited

--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -197,17 +197,6 @@ class ObjectStore(Store):
             await obs.delete_async(self.store, key)
 
     @property
-    def supports_partial_writes(self) -> bool:
-        # docstring inherited
-        return False
-
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
-        # docstring inherited
-        raise NotImplementedError
-
-    @property
     def supports_listing(self) -> bool:
         # docstring inherited
         return True

--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from obstore.store import ObjectStore as _UpstreamObjectStore
 
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 __all__ = ["ObjectStore"]
 

--- a/src/zarr/storage/_wrapper.py
+++ b/src/zarr/storage/_wrapper.py
@@ -120,15 +120,6 @@ class WrapperStore(Store, Generic[T_Store]):
         await self._store.delete(key)
 
     @property
-    def supports_partial_writes(self) -> bool:
-        return self._store.supports_partial_writes
-
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, BytesLike]]
-    ) -> None:
-        return await self._store.set_partial_values(key_start_values)
-
-    @property
     def supports_listing(self) -> bool:
         return self._store.supports_listing
 

--- a/src/zarr/storage/_wrapper.py
+++ b/src/zarr/storage/_wrapper.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
     from zarr.abc.store import ByteRequest
     from zarr.core.buffer import Buffer, BufferPrototype
-    from zarr.core.common import BytesLike
 
 from zarr.abc.store import Store
 

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -48,7 +48,6 @@ class ZipStore(Store):
     allowed_exceptions
     supports_writes
     supports_deletes
-    supports_partial_writes
     supports_listing
     path
     compression
@@ -57,7 +56,6 @@ class ZipStore(Store):
 
     supports_writes: bool = True
     supports_deletes: bool = False
-    supports_partial_writes: bool = False
     supports_listing: bool = True
 
     path: Path
@@ -221,11 +219,6 @@ class ZipStore(Store):
             )
         with self._lock:
             self._set(key, value)
-
-    async def set_partial_values(
-        self, key_start_values: Iterable[tuple[str, int, bytes | bytearray | memoryview[int]]]
-    ) -> None:
-        raise NotImplementedError
 
     async def set_if_not_exists(self, key: str, value: Buffer) -> None:
         self._check_writable()

--- a/src/zarr/testing/stateful.py
+++ b/src/zarr/testing/stateful.py
@@ -467,16 +467,9 @@ class SyncStoreWrapper(zarr.core.sync.SyncMixin):
     def list_prefix(self, prefix: str) -> None:
         raise NotImplementedError
 
-    def set_partial_values(self, key_start_values: Any) -> None:
-        raise NotImplementedError
-
     @property
     def supports_listing(self) -> bool:
         return self.store.supports_listing
-
-    @property
-    def supports_partial_writes(self) -> bool:
-        return self.supports_partial_writes
 
     @property
     def supports_writes(self) -> bool:

--- a/src/zarr/testing/store.py
+++ b/src/zarr/testing/store.py
@@ -68,8 +68,8 @@ class StoreTests(Generic[S, B]):
     @abstractmethod
     def test_store_supports_writes(self, store: S) -> None: ...
 
-    @abstractmethod
-    def test_store_supports_partial_writes(self, store: S) -> None: ...
+    def test_store_supports_partial_writes(self, store: S) -> None:
+        assert not store.supports_partial_writes
 
     @abstractmethod
     def test_store_supports_listing(self, store: S) -> None: ...

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -169,9 +169,6 @@ class TestFsspecStoreS3(StoreTests[FsspecStore, cpu.Buffer]):
     def test_store_supports_writes(self, store: FsspecStore) -> None:
         assert store.supports_writes
 
-    def test_store_supports_partial_writes(self, store: FsspecStore) -> None:
-        assert not store.supports_partial_writes
-
     def test_store_supports_listing(self, store: FsspecStore) -> None:
         assert store.supports_listing
 

--- a/tests/test_store/test_local.py
+++ b/tests/test_store/test_local.py
@@ -38,9 +38,6 @@ class TestLocalStore(StoreTests[LocalStore, cpu.Buffer]):
     def test_store_supports_writes(self, store: LocalStore) -> None:
         assert store.supports_writes
 
-    def test_store_supports_partial_writes(self, store: LocalStore) -> None:
-        assert store.supports_partial_writes
-
     def test_store_supports_listing(self, store: LocalStore) -> None:
         assert store.supports_listing
 

--- a/tests/test_store/test_logging.py
+++ b/tests/test_store/test_logging.py
@@ -44,9 +44,6 @@ class TestLoggingStore(StoreTests[LoggingStore, cpu.Buffer]):
     def test_store_supports_writes(self, store: LoggingStore) -> None:
         assert store.supports_writes
 
-    def test_store_supports_partial_writes(self, store: LoggingStore) -> None:
-        assert store.supports_partial_writes
-
     def test_store_supports_listing(self, store: LoggingStore) -> None:
         assert store.supports_listing
 

--- a/tests/test_store/test_memory.py
+++ b/tests/test_store/test_memory.py
@@ -54,9 +54,6 @@ class TestMemoryStore(StoreTests[MemoryStore, cpu.Buffer]):
     def test_store_supports_listing(self, store: MemoryStore) -> None:
         assert store.supports_listing
 
-    def test_store_supports_partial_writes(self, store: MemoryStore) -> None:
-        assert store.supports_partial_writes
-
     async def test_list_prefix(self, store: MemoryStore) -> None:
         assert True
 
@@ -114,9 +111,6 @@ class TestGpuMemoryStore(StoreTests[GpuMemoryStore, gpu.Buffer]):
 
     def test_store_supports_listing(self, store: GpuMemoryStore) -> None:
         assert store.supports_listing
-
-    def test_store_supports_partial_writes(self, store: GpuMemoryStore) -> None:
-        assert store.supports_partial_writes
 
     async def test_list_prefix(self, store: GpuMemoryStore) -> None:
         assert True

--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -48,11 +48,6 @@ class TestObjectStore(StoreTests[ObjectStore, cpu.Buffer]):
     def test_store_supports_writes(self, store: ObjectStore) -> None:
         assert store.supports_writes
 
-    async def test_store_supports_partial_writes(self, store: ObjectStore) -> None:
-        assert not store.supports_partial_writes
-        with pytest.raises(NotImplementedError):
-            await store.set_partial_values([("foo", 0, b"\x01\x02\x03\x04")])
-
     def test_store_supports_listing(self, store: ObjectStore) -> None:
         assert store.supports_listing
 

--- a/tests/test_store/test_wrapper.py
+++ b/tests/test_store/test_wrapper.py
@@ -43,9 +43,6 @@ class TestWrapperStore(StoreTests[WrapperStore, Buffer]):
     def test_store_supports_writes(self, store: WrapperStore) -> None:
         assert store.supports_writes
 
-    def test_store_supports_partial_writes(self, store: WrapperStore) -> None:
-        assert store.supports_partial_writes
-
     def test_store_supports_listing(self, store: WrapperStore) -> None:
         assert store.supports_listing
 

--- a/tests/test_store/test_zip.py
+++ b/tests/test_store/test_zip.py
@@ -72,9 +72,6 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
     def test_store_supports_writes(self, store: ZipStore) -> None:
         assert store.supports_writes
 
-    def test_store_supports_partial_writes(self, store: ZipStore) -> None:
-        assert store.supports_partial_writes is False
-
     def test_store_supports_listing(self, store: ZipStore) -> None:
         assert store.supports_listing
 


### PR DESCRIPTION
This feature was unused by the rest of Zarr-Python, and was only implemented for LocalStore and stores that wrap other stores.

The Zarr v3 spec still mentions partial writes, so it should probably also be updated.

Fixes #2859

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.rst`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
