### PR TITLE
fix/shard iteration redux

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -4421,7 +4421,7 @@ async def from_array(
 
             # Stream data from the source array to the new array
             await concurrent_map(
-                [(region, data) for region in result._iter_chunk_regions()],
+                [(region, data) for region in result._iter_shard_regions()],
                 _copy_arraylike_region,
                 zarr.core.config.config.get("async.concurrency"),
             )


### PR DESCRIPTION
Completes the work of #3299 by replacing a second invocation of `_iter_chunk_coords` with `_iter_shard_coords`. 

In a separate PR, we need to refactor this code block: https://github.com/zarr-developers/zarr-python/blob/b8dbf564d5f585e2fcecbfe124273e0dc04a80f4/src/zarr/core/array.py#L4402-L4428. It's massive code smell to have special "write one array to another" logic defined in the tail end of an array creation function.

I add a test that checks how many `get` requests we make when calling `create_array(data=..)`. In `main`, it's 1 `get` per chunk (bad). In this PR, it's 1 `get` per shard (better). But we can also get to 0 `get`s per shard by introducing some special logic for full shard writes. expect this in a later PR.