### PR TITLE
specify default event loop for async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -379,6 +379,7 @@ testpaths = ["tests", "docs/user-guide"]
 log_cli_level = "INFO"
 xfail_strict = true
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",


### PR DESCRIPTION
Sets the default asyncio fixture loop scope to "function". This only affects our async tests.

This PR silences the following warning, which one sees whenever one runs our test suite:

```
PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```

I don't think this needs any release notes.