### PR TITLE
fix/group no error

### DIFF
--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -677,7 +677,7 @@ async def group(
     if overwrite:
         mode = "w"
     else:
-        mode = "a"
+        mode = "w-"
     store_path = await make_store_path(store, path=path, mode=mode, storage_options=storage_options)
 
     if chunk_store is not None:

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -677,7 +677,7 @@ async def group(
     if overwrite:
         mode = "w"
     else:
-        mode = "r+"
+        mode = "a"
     store_path = await make_store_path(store, path=path, mode=mode, storage_options=storage_options)
 
     if chunk_store is not None:

--- a/tests/test_api/test_asynchronous.py
+++ b/tests/test_api/test_asynchronous.py
@@ -116,3 +116,15 @@ async def test_open_group_new_path(tmp_path: Path) -> None:
     # tmp_path exists, but tmp_path / "test.zarr" will not, which is important for this test
     store = tmp_path / "test.zarr"
     await group(store=store)
+
+
+async def test_open_group_old_path(tmp_path: Path) -> None:
+    """
+    Test that zarr.api.asynchronous.group will not overwrite an existing file.
+
+    See https://github.com/zarr-developers/zarr-python/issues/3406
+    """
+    store = tmp_path
+    await group(store=store, overwrite=True, attributes={"existing_group": True})
+    with pytest.raises(FileExistsError):
+        await group(store=store)

--- a/tests/test_api/test_asynchronous.py
+++ b/tests/test_api/test_asynchronous.py
@@ -8,10 +8,11 @@ import numpy as np
 import pytest
 
 from zarr import create_array
-from zarr.api.asynchronous import _get_shape_chunks, _like_args, open
+from zarr.api.asynchronous import _get_shape_chunks, _like_args, group, open
 from zarr.core.buffer.core import default_buffer_prototype
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from typing import Any
 
     import numpy.typing as npt
@@ -103,3 +104,15 @@ async def test_open_no_array() -> None:
         TypeError, match=r"open_group\(\) got an unexpected keyword argument 'shape'"
     ):
         await open(store=store, shape=(1,))
+
+
+async def test_open_group_new_path(tmp_path: Path) -> None:
+    """
+    Test that zarr.api.asynchronous.group properly handles a string representation of a local file
+    path that does not yet exist.
+
+    See https://github.com/zarr-developers/zarr-python/issues/3406
+    """
+    # tmp_path exists, but tmp_path / "test.zarr" will not, which is important for this test
+    store = tmp_path / "test.zarr"
+    await group(store=store)


### PR DESCRIPTION
This PR adds tests for the error reported in #3406, and makes a change to the mode handling in `zarr.api.asynchronous.group` that resolves the error reported there, but causes tests elsewhere in the test suite to fail. 

I'm posting this incomplete PR so that anyone who enjoys debugging store permissions problems can pick it up. 
