### PR TITLE
Ensure absolute paths work with consolidate metadata

### DIFF
--- a/changes/3428.bugfix.rst
+++ b/changes/3428.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure syntax like ``root['/subgroup']`` works equivalently to ``root['subgroup']`` when using consolidated metadata.

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -735,7 +735,7 @@ class AsyncGroup:
         assert self.metadata.consolidated_metadata is not None
 
         # we support nested getitems like group/subgroup/array
-        indexers = key.split("/")
+        indexers = normalize_path(key).split("/")
         indexers.reverse()
         metadata: ArrayV2Metadata | ArrayV3Metadata | GroupMetadata = self.metadata
 

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -692,9 +692,7 @@ class TestConsolidated:
         expected = ["b", "b/c"]
         assert result == expected
 
-    async def test_absolute_path_for_subgroup(
-        self, memory_store: zarr.storage.MemoryStore
-    ) -> None:
+    async def test_absolute_path_for_subgroup(self, memory_store: zarr.storage.MemoryStore) -> None:
         root = await zarr.api.asynchronous.create_group(store=memory_store)
         await root.create_group("a/b")
         with pytest.warns(

--- a/tests/test_metadata/test_consolidated.py
+++ b/tests/test_metadata/test_consolidated.py
@@ -705,7 +705,8 @@ class TestConsolidated:
 
         group = await zarr.api.asynchronous.open_group(store=memory_store)
         subgroup = await group.getitem("/a")
-        members = [x async for x in subgroup.keys()]  # type: ignore[union-attr]
+        assert isinstance(subgroup, AsyncGroup)
+        members = [x async for x in subgroup.keys()]  # noqa: SIM118
         assert members == ["b"]
 
 


### PR DESCRIPTION
This ensures syntax like `root['/subgroup']` works equivalently to `root['subgroup']` when using consolidated metadata.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
