### PR TITLE
Pass read_only into LocalStore.open()

### DIFF
--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -349,7 +349,7 @@ async def make_store_path(
 
     elif isinstance(store_like, Path):
         # Create a new LocalStore
-        store = await LocalStore.open(root=store_like, mode=mode)
+        store = await LocalStore.open(root=store_like, mode=mode, read_only=_read_only)
 
     elif isinstance(store_like, str):
         # Either a FSSpec URI or a local filesystem path


### PR DESCRIPTION
Currently, `read_only` is not passed in `open()`, which means the default value of `read_only=False` is confusingly used instead.

This mostly just surprisng, but also has minor performance implications because `read_only=False` means Zarr attempts to create directories on this line (which is a no-op because `exist_ok=True`): https://github.com/zarr-developers/zarr-python/blob/e738e2fb88dbead26a853d9982ff46eab64f313f/src/zarr/storage/_local.py#L167-L169

TODO:
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
