### PR TITLE
Refactor `AsyncGroup.open()`

### DIFF
--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -488,7 +488,8 @@ class AsyncGroup:
         zarr_format: ZarrFormat | None = 3,
         use_consolidated: bool | str | None = None,
     ) -> AsyncGroup:
-        """Open a new AsyncGroup
+        """
+        Create a new AsyncGroup from an existing group.
 
         Parameters
         ----------


### PR DESCRIPTION
This is a refactor of `AsyncGroup.open()` for readbility/logic simplification:

- Factor out the code for guessing the Zarr version from a store to the top of the method
- This then allows the number of if branches to be reduced, so all the v2 code is in one branch and all the v3 code is in another branch.