### PR TITLE
fix pcodec resolution failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,9 @@ test = [
     "pytest-xdist",
     "packaging",
     "tomlkit",
-    "uv"
+    "uv",
+    "pcodec",
+    "zfpy",
 ]
 remote_tests = [
     'zarr[remote]',

--- a/src/zarr/codecs/__init__.py
+++ b/src/zarr/codecs/__init__.py
@@ -85,7 +85,7 @@ register_codec("numcodecs.gzip", GZip, qualname="zarr.codecs.numcodecs.GZip")
 register_codec(
     "numcodecs.jenkins_lookup3", JenkinsLookup3, qualname="zarr.codecs.numcodecs.JenkinsLookup3"
 )
-register_codec("numcodecs.pcodec", PCodec, qualname="zarr.codecs.numcodecs.pcodec")
+register_codec("numcodecs.pcodec", PCodec, qualname="zarr.codecs.numcodecs.PCodec")
 register_codec("numcodecs.packbits", PackBits, qualname="zarr.codecs.numcodecs.PackBits")
 register_codec("numcodecs.quantize", Quantize, qualname="zarr.codecs.numcodecs.Quantize")
 register_codec("numcodecs.shuffle", Shuffle, qualname="zarr.codecs.numcodecs.Shuffle")


### PR DESCRIPTION
fixes a typo leading to failure to register pcodec properly in the config. 

this PR adds pcodec and zfpy to our main test dependencies. we should consider splitting these codecs out into their own dependency group if necessary.

I also fix some tests that were not running properly, and adapt some docstring tests to the new docs.

closes #3482 
