### PR TITLE
Include shard/chunk shapes in size mismatch error

### DIFF
--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -431,7 +431,8 @@ class ShardingCodec(
             )
         ):
             raise ValueError(
-                "The array's `chunk_shape` needs to be divisible by the shard's inner `chunk_shape`."
+                f"The array's `chunk_shape` (got {chunk_grid.chunk_shape}) "
+                f"needs to be divisible by the shard's inner `chunk_shape` (got {self.chunk_shape})."
             )
 
     async def _decode_single(

--- a/tests/test_codecs/test_sharding.py
+++ b/tests/test_codecs/test_sharding.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 from typing import Any
 
 import numpy as np
@@ -483,6 +484,23 @@ def test_invalid_metadata(store: Store) -> None:
             shape=(16, 16),
             shards=(16, 16),
             chunks=(8, 7),
+            dtype=np.dtype("uint8"),
+            fill_value=0,
+        )
+
+
+def test_invalid_shard_shape() -> None:
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "The array's `chunk_shape` (got (16, 16)) needs to be divisible by the shard's inner `chunk_shape` (got (9,))."
+        ),
+    ):
+        zarr.create_array(
+            {},
+            shape=(16, 16),
+            shards=(16, 16),
+            chunks=(9,),
             dtype=np.dtype("uint8"),
             fill_value=0,
         )


### PR DESCRIPTION
A minor quality of life improvement in the error message. I'm not sure this error was tested, so this might add test coverage to the error message lines too.