### PR TITLE
add experimental module

### DIFF
--- a/changes/3490.feature.md
+++ b/changes/3490.feature.md
@@ -1,0 +1,1 @@
+Adds a `zarr.experimental` module for unstable user-facing features.

--- a/src/zarr/experimental/__init__.py
+++ b/src/zarr/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""The experimental module is a site for exporting new or experimental Zarr features."""


### PR DESCRIPTION
Adds a `zarr.experimental` module. We can use this module to deliver new features that might be useful but might also evolve significantly in the future. The "experimental" designation should temper user expectations about stability.

closes #3484 

