### PR TITLE
attempt to autodetect an s3 compatible URL

### DIFF
--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -438,3 +438,171 @@ async def test_with_read_only_auto_mkdir(tmp_path: Path) -> None:
 
     store_w = FsspecStore.from_url(f"file://{tmp_path}", storage_options={"auto_mkdir": False})
     _ = store_w.with_read_only()
+
+
+class TestS3AutoDetection:
+    """Test automatic detection and conversion of S3-compatible URLs."""
+
+    @pytest.mark.parametrize(
+        ("url", "expected_detect"),
+        [
+            # Should detect as S3
+            ("https://s3.amazonaws.com/bucket/path", True),
+            ("https://s3-us-west-2.amazonaws.com/bucket/path", True),
+            ("https://bucket.s3.amazonaws.com/path", True),
+            ("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/file.zarr", True),
+            ("https://us-west-2-s3.example.com/bucket/path", True),
+            ("https://minio.example.com/bucket/path", True),
+            ("https://ceph.example.com/bucket/path", True),
+            ("https://ceph-rgw.example.com/bucket/path", True),
+            ("https://rgw.example.com/bucket/path", True),
+            ("https://object-store.example.com/bucket/path", True),
+            ("https://my-objectstore.example.com/bucket/path", True),
+            # Should NOT detect as S3 (false positives to avoid)
+            ("https://someurls345.com/data/file.zarr", False),
+            ("https://descriptions.example.com/file.zarr", False),
+            ("https://users3000.example.com/file.zarr", False),
+            ("https://s3tuff.example.com/file.zarr", False),
+            ("https://s3archive.example.com/file.zarr", False),
+            ("https://example.com/data/s3/file.zarr", False),  # s3 in path, not hostname
+            ("https://example.com/file.zarr", False),
+        ],
+    )
+    def test_s3_detection_patterns(self, url: str, expected_detect: bool) -> None:
+        """Test that S3 URL patterns are correctly identified."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        converted_url, opts = _maybe_convert_http_to_s3(url, None)
+        was_detected = converted_url.startswith("s3://")
+
+        assert was_detected == expected_detect, (
+            f"URL {url} detection mismatch: got {was_detected}, expected {expected_detect}"
+        )
+
+        if was_detected:
+            # Verify S3 URL format is correct
+            assert converted_url.startswith("s3://")
+            # Verify endpoint_url was set
+            assert "client_kwargs" in opts
+            assert "endpoint_url" in opts["client_kwargs"]
+            # We don't set anon by default - users must set it explicitly
+
+    def test_s3_detection_preserves_user_options(self) -> None:
+        """Test that user-provided storage options are preserved."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        url = "https://uk1s3.example.com/bucket/path"
+        user_opts = {"anon": False, "other_option": "value"}
+
+        converted_url, opts = _maybe_convert_http_to_s3(url, user_opts)
+
+        # Should still convert to S3
+        assert converted_url.startswith("s3://")
+        # Should preserve user's anon setting
+        assert opts["anon"] is False
+        # Should preserve other options
+        assert opts["other_option"] == "value"
+        # Should add endpoint_url
+        assert "endpoint_url" in opts["client_kwargs"]
+
+    def test_s3_detection_preserves_user_client_kwargs(self) -> None:
+        """Test that user's existing client_kwargs are preserved when adding endpoint_url."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        url = "https://uk1s3.example.com/bucket/path"
+        user_opts = {
+            "anon": False,
+            "client_kwargs": {"region_name": "us-west-2", "use_ssl": True},
+        }
+
+        # Call the function - it may modify user_opts, and that's okay
+        _, result_opts = _maybe_convert_http_to_s3(url, user_opts)
+
+        # Result should have endpoint_url added
+        result_client_kwargs = result_opts["client_kwargs"]
+        assert isinstance(result_client_kwargs, dict)
+        assert "endpoint_url" in result_client_kwargs
+        assert result_client_kwargs["endpoint_url"] == "https://uk1s3.example.com"
+
+        # Result should preserve user's other client_kwargs (not override them)
+        assert result_client_kwargs["region_name"] == "us-west-2"
+        assert result_client_kwargs["use_ssl"] is True
+
+        # User's anon setting should be preserved (not overridden to True)
+        assert result_opts["anon"] is False
+
+    def test_s3_detection_preserves_explicit_credentials(self) -> None:
+        """Test that explicit credentials are preserved."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        url = "https://uk1s3.example.com/bucket/path"
+
+        # Test with key/secret
+        user_opts = {"key": "my_key", "secret": "my_secret"}
+        converted_url, opts = _maybe_convert_http_to_s3(url, user_opts)
+
+        # Should convert to S3
+        assert converted_url.startswith("s3://")
+        # Credentials should be preserved
+        assert opts["key"] == "my_key"
+        assert opts["secret"] == "my_secret"
+        # Endpoint should be added
+        assert opts["client_kwargs"]["endpoint_url"] == "https://uk1s3.example.com"
+
+    def test_s3_detection_respects_existing_endpoint(self) -> None:
+        """Test that existing endpoint_url is not overridden."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        url = "https://uk1s3.example.com/bucket/path"
+        user_opts = {"client_kwargs": {"endpoint_url": "https://custom-endpoint.com"}}
+
+        converted_url, opts = _maybe_convert_http_to_s3(url, user_opts)
+
+        # Should NOT convert if endpoint already specified
+        assert converted_url == url
+        assert opts["client_kwargs"]["endpoint_url"] == "https://custom-endpoint.com"
+
+    @pytest.mark.parametrize(
+        ("url", "expected_bucket", "expected_key"),
+        [
+            (
+                "https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/file.zarr",
+                "idr",
+                "zarr/v0.5/file.zarr",
+            ),
+            ("https://s3.amazonaws.com/my-bucket/path/to/data", "my-bucket", "path/to/data"),
+            ("https://s3.amazonaws.com/bucket", "bucket", ""),  # No path
+            (
+                "https://s3.amazonaws.com/bucket/deep/nested/path/file.zarr",
+                "bucket",
+                "deep/nested/path/file.zarr",
+            ),
+        ],
+    )
+    def test_s3_url_parsing(self, url: str, expected_bucket: str, expected_key: str) -> None:
+        """Test that S3 URLs are correctly parsed into bucket and key."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        converted_url, _ = _maybe_convert_http_to_s3(url, None)
+
+        if expected_key:
+            expected_s3_url = f"s3://{expected_bucket}/{expected_key}"
+        else:
+            expected_s3_url = f"s3://{expected_bucket}/"
+
+        assert converted_url == expected_s3_url
+
+    def test_s3_detection_non_http_urls(self) -> None:
+        """Test that non-HTTP URLs are not affected."""
+        from zarr.storage._common import _maybe_convert_http_to_s3
+
+        urls = [
+            "s3://bucket/path",  # Already S3
+            "file:///local/path",  # Local file
+            "gs://bucket/path",  # Google Cloud Storage
+            "/local/path",  # Plain path
+        ]
+
+        for url in urls:
+            converted_url, _ = _maybe_convert_http_to_s3(url, None)
+            assert converted_url == url, f"Non-HTTP URL {url} should not be modified"


### PR DESCRIPTION
Addresses part of https://github.com/zarr-developers/zarr-python/issues/3495 by attempting to autodetect if a URL is S3 compatible or not. 
With this change the following "just works"

```python
import zarr
z = zarr.open("https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr", storage_options={"anon":True})
print(list(z.keys()))
```

This is equivalent to:

```python
  zarr.open(
      "s3://idr/zarr/v0.5/idr0062A/6001240_labels.zarr",
      storage_options={
          "anon": True,
          "client_kwargs": {"endpoint_url": "https://uk1s3.embassy.ebi.ac.uk"}
      }
  )
```

but now zarr handles that splitting for the user


* [x] Add unit tests and/or doctests in docstrings
* [NA?] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
