### PR TITLE
feature: update default config setting for async.concurrency from 10->64

### DIFF
--- a/src/zarr/core/config.py
+++ b/src/zarr/core/config.py
@@ -107,7 +107,7 @@ config = Config(
                 "order": "C",
                 "write_empty_chunks": False,
             },
-            "async": {"concurrency": 10, "timeout": None},
+            "async": {"concurrency": 64, "timeout": None},
             "threading": {"max_workers": None},
             "json_indent": 2,
             "codec_pipeline": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ def test_config_defaults_set() -> None:
                     "order": "C",
                     "write_empty_chunks": False,
                 },
-                "async": {"concurrency": 10, "timeout": None},
+                "async": {"concurrency": 64, "timeout": None},
                 "threading": {"max_workers": None},
                 "json_indent": 2,
                 "codec_pipeline": {
@@ -100,7 +100,7 @@ def test_config_defaults_set() -> None:
         ]
     )
     assert config.get("array.order") == "C"
-    assert config.get("async.concurrency") == 10
+    assert config.get("async.concurrency") == 64
     assert config.get("async.timeout") is None
     assert config.get("codec_pipeline.batch_size") == 1
     assert config.get("json_indent") == 2
@@ -108,7 +108,7 @@ def test_config_defaults_set() -> None:
 
 @pytest.mark.parametrize(
     ("key", "old_val", "new_val"),
-    [("array.order", "C", "F"), ("async.concurrency", 10, 20), ("json_indent", 2, 0)],
+    [("array.order", "C", "F"), ("async.concurrency", 64, 128), ("json_indent", 2, 0)],
 )
 def test_config_defaults_can_be_overridden(key: str, old_val: Any, new_val: Any) -> None:
     assert config.get(key) == old_val


### PR DESCRIPTION
This PR updates the default async.concurrency setting in Zarr from 10 to 64. We've repeatedly seen ([example 1](https://earthmover.io/blog/xarray-open-zarr-improvements), [example 2](https://github.com/maxrjones/zarr-obstore-performance)) that Zarr performs much better at larger concurrency settings and the default value of 10 was a hold over from the very early experiments with Zarr-Python 3. 

I talked this over with @d-v-b and @normanrz here at the Zarr Summit and both were cool with the change 😎 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
