### PR TITLE
Add an issue template for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Propose a new major feature
+  - name: Propose a new Zarr specification feature
     url: https://github.com/zarr-developers/zarr-specs
-    about: A new major feature should be discussed in the Zarr specifications repository.
+    about: A new feature for the Zarr storage specification should be opened on the zarr-specs repository.
   - name: Discuss something on ZulipChat
     url: https://ossci.zulipchat.com/
     about: For questions like "How do I do X with Zarr?", consider posting your question to our developer chat.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,11 @@
+name: Feature Request
+description: Request a new feature for zarr-python
+# labels: []
+body:
+- type: textarea
+  attributes:
+    label: Describe the new feature you'd like
+    description: >
+      Please provide a description of what new feature or functionality you'd like to see in zarr-python.
+  validations:
+    required: true


### PR DESCRIPTION
Previously the list of issue types only allowed for feature reqeusts to be divered to `zarr-specs`, but I think there's definitely feature requests that are valid for zarr-python. I tried to delineate between these two types of feature reqeusts, but there may well be better ways to word this.

Fixes https://github.com/zarr-developers/zarr-python/issues/2453