### PR TITLE
DOC: Correct typos in zarr-python documentation

### DIFF
--- a/docs/user-guide/performance.md
+++ b/docs/user-guide/performance.md
@@ -265,7 +265,7 @@ If an array or group is backed by a persistent store such as the a `zarr.storage
 **are not** pickled. The only thing that is pickled is the necessary parameters to allow the store
 to re-open any underlying files or databases upon being unpickled.
 
-E.g., pickle/unpickle an local store array:
+E.g., pickle/unpickle a local store array:
 
 ```python exec="true" session="performance" source="above" result="ansi"
 import pickle

--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -125,7 +125,7 @@ class Buffer(ABC):
 
     We use Buffer throughout Zarr to represent a contiguous block of memory.
 
-    A Buffer is backed by a underlying array-like instance that represents
+    A Buffer is backed by an underlying array-like instance that represents
     the memory. The memory type is unspecified; can be regular host memory,
     CUDA device memory, or something else. The only requirement is that the
     array-like instance can be copied/converted to a regular Numpy array
@@ -315,7 +315,7 @@ class NDBuffer:
 
     We use NDBuffer throughout Zarr to represent a n-dimensional memory block.
 
-    A NDBuffer is backed by a underlying ndarray-like instance that represents
+    A NDBuffer is backed by an underlying ndarray-like instance that represents
     the memory. The memory type is unspecified; can be regular host memory,
     CUDA device memory, or something else. The only requirement is that the
     ndarray-like instance can be copied/converted to a regular Numpy array

--- a/src/zarr/core/buffer/gpu.py
+++ b/src/zarr/core/buffer/gpu.py
@@ -36,7 +36,7 @@ class Buffer(core.Buffer):
 
     We use Buffer throughout Zarr to represent a contiguous block of memory.
 
-    A Buffer is backed by a underlying array-like instance that represents
+    A Buffer is backed by an underlying array-like instance that represents
     the memory. The memory type is unspecified; can be regular host memory,
     CUDA device memory, or something else. The only requirement is that the
     array-like instance can be copied/converted to a regular Numpy array
@@ -90,7 +90,7 @@ class Buffer(core.Buffer):
 
     @classmethod
     def from_buffer(cls, buffer: core.Buffer) -> Self:
-        """Create an GPU Buffer given an arbitrary Buffer
+        """Create a GPU Buffer given an arbitrary Buffer
         This will try to be zero-copy if `buffer` is already on the
         GPU and will trigger a copy if not.
 
@@ -123,7 +123,7 @@ class NDBuffer(core.NDBuffer):
 
     We use NDBuffer throughout Zarr to represent a n-dimensional memory block.
 
-    A NDBuffer is backed by a underlying ndarray-like instance that represents
+    A NDBuffer is backed by an underlying ndarray-like instance that represents
     the memory. The memory type is unspecified; can be regular host memory,
     CUDA device memory, or something else. The only requirement is that the
     ndarray-like instance can be copied/converted to a regular Numpy array

--- a/src/zarr/core/dtype/common.py
+++ b/src/zarr/core/dtype/common.py
@@ -98,7 +98,7 @@ def check_structured_dtype_name_v2(data: Sequence[object]) -> TypeGuard[Structur
 
 def check_dtype_name_v2(data: object) -> TypeGuard[DTypeName_V2]:
     """
-    Type guard for narrowing the type of a python object to an valid zarr v2 dtype name.
+    Type guard for narrowing the type of a python object to a valid zarr v2 dtype name.
     """
     if isinstance(data, str):
         return True

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -91,7 +91,7 @@ class MetadataValidationError(BaseZarrError):
 
 class UnknownCodecError(BaseZarrError):
     """
-    Raised when a unknown codec was used.
+    Raised when an unknown codec was used.
     """
 
 

--- a/src/zarr/registry.py
+++ b/src/zarr/registry.py
@@ -227,11 +227,11 @@ def _parse_array_bytes_codec(data: dict[str, JSON] | Codec) -> ArrayBytesCodec:
     if isinstance(data, dict):
         result = _resolve_codec(data)
         if not isinstance(result, ArrayBytesCodec):
-            msg = f"Expected a dict representation of a ArrayBytesCodec; got a dict representation of a {type(result)} instead."
+            msg = f"Expected a dict representation of an ArrayBytesCodec; got a dict representation of a {type(result)} instead."
             raise TypeError(msg)
     else:
         if not isinstance(data, ArrayBytesCodec):
-            raise TypeError(f"Expected a ArrayBytesCodec. Got {type(data)} instead.")
+            raise TypeError(f"Expected an ArrayBytesCodec. Got {type(data)} instead.")
         result = data
     return result
 
@@ -247,11 +247,11 @@ def _parse_array_array_codec(data: dict[str, JSON] | Codec) -> ArrayArrayCodec:
     if isinstance(data, dict):
         result = _resolve_codec(data)
         if not isinstance(result, ArrayArrayCodec):
-            msg = f"Expected a dict representation of a ArrayArrayCodec; got a dict representation of a {type(result)} instead."
+            msg = f"Expected a dict representation of an ArrayArrayCodec; got a dict representation of a {type(result)} instead."
             raise TypeError(msg)
     else:
         if not isinstance(data, ArrayArrayCodec):
-            raise TypeError(f"Expected a ArrayArrayCodec. Got {type(data)} instead.")
+            raise TypeError(f"Expected an ArrayArrayCodec. Got {type(data)} instead.")
         result = data
     return result
 

--- a/src/zarr/testing/buffer.py
+++ b/src/zarr/testing/buffer.py
@@ -45,7 +45,7 @@ class NDBufferUsingTestNDArrayLike(cpu.NDBuffer):
         order: Literal["C", "F"] = "C",
         fill_value: Any | None = None,
     ) -> Self:
-        """Overwrite `NDBuffer.create` to create an TestNDArrayLike instance"""
+        """Overwrite `NDBuffer.create` to create a TestNDArrayLike instance"""
         ret = cls(TestNDArrayLike(shape=shape, dtype=dtype, order=order))
         if fill_value is not None:
             ret.fill(fill_value)

--- a/src/zarr/testing/strategies.py
+++ b/src/zarr/testing/strategies.py
@@ -377,7 +377,7 @@ def orthogonal_indices(
     """
     Strategy that returns
     (1) a tuple of integer arrays used for orthogonal indexing of Zarr arrays.
-    (2) an tuple of integer arrays that can be used for equivalent indexing of numpy arrays
+    (2) a tuple of integer arrays that can be used for equivalent indexing of numpy arrays
     """
     zindexer = []
     npindexer = []


### PR DESCRIPTION
Correct typos in zarr-python documentation
