### PR TITLE
Update MemoryStore.get signature to match other stores

### DIFF
--- a/src/zarr/storage/_memory.py
+++ b/src/zarr/storage/_memory.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Self
 
 from zarr.abc.store import ByteRequest, Store
 from zarr.core.buffer import Buffer, gpu
+from zarr.core.buffer.core import default_buffer_prototype
 from zarr.core.common import concurrent_map
 from zarr.storage._utils import _normalize_byte_range_index
 
@@ -79,10 +80,12 @@ class MemoryStore(Store):
     async def get(
         self,
         key: str,
-        prototype: BufferPrototype,
+        prototype: BufferPrototype | None = None,
         byte_range: ByteRequest | None = None,
     ) -> Buffer | None:
         # docstring inherited
+        if prototype is None:
+            prototype = default_buffer_prototype()
         if not self._is_open:
             await self._open()
         assert isinstance(key, str)


### PR DESCRIPTION
The MemoryStore's .get function has a different function signature compared to other stores such as LocalStore. This PR ensures the default value for the `prototype` parameter is `None` for the MemoryStore

https://github.com/keller-mark/zarr-python/blob/7d0b62da45f6d8e5f5d93953d71fe9ef76f79e1c/src/zarr/storage/_local.py#L193

More generally, userland code should be able to assume a generic Store API that has consistent function signatures for important methods such as `Store.get`. This is an important benefit of the Store abstraction.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
