### PR TITLE
3.1.5 release notes

### DIFF
--- a/changes/3594.bugfix.md
+++ b/changes/3594.bugfix.md
@@ -1,1 +1,0 @@
-Fix formatting errors in the release notes section of the docs.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+# zarr 3.1.5 (2025-11-21)
+
+## Bugfixes
+
+- Fix formatting errors in the release notes section of the docs. ([#3594](https://github.com/zarr-developers/zarr-python/issues/3594))
+
+
 ## 3.1.4 (2025-11-20)
 
 ### Features


### PR DESCRIPTION
The release notes for 3.1.5. Like the initial release notes for 3.1.4, towncrier is not constructing github urls correctly. This had to be manually fixed.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
