### PR TITLE
chore/pin pytest asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ test = [
     "coverage>=7.10",
     # Pin possibly due to https://github.com/pytest-dev/pytest-cov/issues/693
     "pytest<8.4",
-    "pytest-asyncio<=1.2.0",
+    "pytest-asyncio<1.2.0",
     "pytest-cov",
     "pytest-accept",
     "rich",


### PR DESCRIPTION
`pytest-asyncio` 1.2.0 requires `typing-extensions >= 4.12` for python versions under 3.13. This is newer than our minimum supported version of `typing-extensions` (>=4.9), so until we bump that minimum dependency, we must pin `pytest-asyncio`.
