### PR TITLE
use the result of the broadcasted array to check the contents

### DIFF
--- a/src/zarr/core/buffer/core.py
+++ b/src/zarr/core/buffer/core.py
@@ -542,7 +542,7 @@ class NDBuffer:
         # every single time we have to write data?
         _data, other = np.broadcast_arrays(self._data, other)
         return np.array_equal(
-            self._data,
+            _data,
             other,
             equal_nan=equal_nan
             if self._data.dtype.kind not in ("U", "S", "T", "O", "V")


### PR DESCRIPTION
Isn't this the point?

I'm implementing a super innefficient broadcast operation for my lazy array, but then i stuck on the fact that I didn't implement a very inefficient operation for `np.array_equal`

related to: https://github.com/zarr-developers/zarr-python/issues/3627

The result of np.broadcast... is used in the if statement a few lines above.

Do I need to go through the todo?
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
