### PR TITLE
Refactor Codec interface

### DIFF
--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -16,6 +16,8 @@ from zarr.abc.codec import (
     ArrayBytesCodecPartialEncodeMixin,
     Codec,
     CodecPipeline,
+    ReadBatchInfo,
+    WriteBatchInfo,
 )
 from zarr.abc.store import (
     ByteGetter,
@@ -358,12 +360,12 @@ class ShardingCodec(
         # decoding chunks and writing them into the output buffer
         await self.codec_pipeline.read(
             [
-                (
-                    _ShardingByteGetter(shard_dict, chunk_coords),
-                    chunk_spec,
-                    chunk_selection,
-                    out_selection,
-                    is_complete_shard,
+                ReadBatchInfo(
+                    byte_operator=_ShardingByteGetter(shard_dict, chunk_coords),
+                    array_spec=chunk_spec,
+                    chunk_selection=chunk_selection,
+                    out_selection=out_selection,
+                    is_complete_chunk=is_complete_shard,
                 )
                 for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
@@ -430,12 +432,12 @@ class ShardingCodec(
         # decoding chunks and writing them into the output buffer
         await self.codec_pipeline.read(
             [
-                (
-                    _ShardingByteGetter(shard_dict, chunk_coords),
-                    chunk_spec,
-                    chunk_selection,
-                    out_selection,
-                    is_complete_shard,
+                ReadBatchInfo(
+                    byte_operator=_ShardingByteGetter(shard_dict, chunk_coords),
+                    array_spec=chunk_spec,
+                    chunk_selection=chunk_selection,
+                    out_selection=out_selection,
+                    is_complete_chunk=is_complete_shard,
                 )
                 for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
@@ -469,12 +471,12 @@ class ShardingCodec(
 
         await self.codec_pipeline.write(
             [
-                (
-                    _ShardingByteSetter(shard_builder, chunk_coords),
-                    chunk_spec,
-                    chunk_selection,
-                    out_selection,
-                    is_complete_shard,
+                WriteBatchInfo(
+                    byte_operator=_ShardingByteSetter(shard_builder, chunk_coords),
+                    array_spec=chunk_spec,
+                    chunk_selection=chunk_selection,
+                    out_selection=out_selection,
+                    is_complete_chunk=is_complete_shard,
                 )
                 for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],
@@ -515,12 +517,12 @@ class ShardingCodec(
 
         await self.codec_pipeline.write(
             [
-                (
-                    _ShardingByteSetter(shard_dict, chunk_coords),
-                    chunk_spec,
-                    chunk_selection,
-                    out_selection,
-                    is_complete_shard,
+                WriteBatchInfo(
+                    byte_operator=_ShardingByteSetter(shard_dict, chunk_coords),
+                    array_spec=chunk_spec,
+                    chunk_selection=chunk_selection,
+                    out_selection=out_selection,
+                    is_complete_chunk=is_complete_shard,
                 )
                 for chunk_coords, chunk_selection, out_selection, is_complete_shard in indexer
             ],

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -23,7 +23,14 @@ import numpy as np
 from typing_extensions import deprecated
 
 import zarr
-from zarr.abc.codec import ArrayArrayCodec, ArrayBytesCodec, BytesBytesCodec, Codec
+from zarr.abc.codec import (
+    ArrayArrayCodec,
+    ArrayBytesCodec,
+    BytesBytesCodec,
+    Codec,
+    ReadBatchInfo,
+    WriteBatchInfo,
+)
 from zarr.abc.numcodec import Numcodec, _is_numcodec
 from zarr.codecs._v2 import V2Codec
 from zarr.codecs.bytes import BytesCodec
@@ -1564,12 +1571,15 @@ class AsyncArray(Generic[T_ArrayMetadata]):
             # reading chunks and decoding them
             await self.codec_pipeline.read(
                 [
-                    (
-                        self.store_path / self.metadata.encode_chunk_key(chunk_coords),
-                        self.metadata.get_chunk_spec(chunk_coords, _config, prototype=prototype),
-                        chunk_selection,
-                        out_selection,
-                        is_complete_chunk,
+                    ReadBatchInfo(
+                        byte_operator=self.store_path
+                        / self.metadata.encode_chunk_key(chunk_coords),
+                        array_spec=self.metadata.get_chunk_spec(
+                            chunk_coords, _config, prototype=prototype
+                        ),
+                        chunk_selection=chunk_selection,
+                        out_selection=out_selection,
+                        is_complete_chunk=is_complete_chunk,
                     )
                     for chunk_coords, chunk_selection, out_selection, is_complete_chunk in indexer
                 ],
@@ -1735,12 +1745,12 @@ class AsyncArray(Generic[T_ArrayMetadata]):
         # merging with existing data and encoding chunks
         await self.codec_pipeline.write(
             [
-                (
-                    self.store_path / self.metadata.encode_chunk_key(chunk_coords),
-                    self.metadata.get_chunk_spec(chunk_coords, _config, prototype),
-                    chunk_selection,
-                    out_selection,
-                    is_complete_chunk,
+                WriteBatchInfo(
+                    byte_operator=self.store_path / self.metadata.encode_chunk_key(chunk_coords),
+                    array_spec=self.metadata.get_chunk_spec(chunk_coords, _config, prototype),
+                    chunk_selection=chunk_selection,
+                    out_selection=out_selection,
+                    is_complete_chunk=is_complete_chunk,
                 )
                 for chunk_coords, chunk_selection, out_selection, is_complete_chunk in indexer
             ],

--- a/tests/test_abc/test_codec.py
+++ b/tests/test_abc/test_codec.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from zarr.abc.codec import _check_codecjson_v2
+from typing import TYPE_CHECKING
+
+from zarr.abc.codec import ReadBatchInfo, WriteBatchInfo, _check_codecjson_v2
+from zarr.core.array_spec import ArrayConfig, ArraySpec
+from zarr.core.buffer import Buffer, BufferPrototype, default_buffer_prototype
+from zarr.dtype import UInt8
+
+if TYPE_CHECKING:
+    from zarr.abc.store import ByteRequest
 
 
 def test_check_codecjson_v2_valid() -> None:
@@ -10,3 +18,74 @@ def test_check_codecjson_v2_valid() -> None:
     assert _check_codecjson_v2({"id": "gzip"})
     assert not _check_codecjson_v2({"id": 10})
     assert not _check_codecjson_v2([10, 11])
+
+
+def test_read_batch_info_iterable() -> None:
+    class ByteGetter:
+        async def get(
+            self, prototype: BufferPrototype, byte_range: ByteRequest | None = None
+        ) -> Buffer | None:
+            pass
+
+    byte_getter = ByteGetter()
+    info = ReadBatchInfo(
+        byte_operator=byte_getter,
+        array_spec=ArraySpec(
+            shape=(16, 16),
+            dtype=UInt8(),
+            fill_value=0,
+            config=ArrayConfig(order="C", write_empty_chunks=True),
+            prototype=default_buffer_prototype(),
+        ),
+        chunk_selection=(0, 0),
+        out_selection=(0, 0),
+        is_complete_chunk=True,
+    )
+
+    assert tuple(info) == (
+        info.byte_operator,
+        info.array_spec,
+        info.chunk_selection,
+        info.out_selection,
+        info.is_complete_chunk,
+    )
+
+
+def test_write_batch_info_iterable() -> None:
+    class ByteSetter:
+        async def get(
+            self, prototype: BufferPrototype, byte_range: ByteRequest | None = None
+        ) -> Buffer | None:
+            pass
+
+        async def set(self, value: Buffer) -> None:
+            pass
+
+        async def delete(self) -> None:
+            pass
+
+        async def set_if_not_exists(self, default: Buffer) -> None:
+            pass
+
+    byte_setter = ByteSetter()
+
+    info = WriteBatchInfo(
+        byte_operator=byte_setter,
+        array_spec=ArraySpec(
+            shape=(16, 16),
+            dtype=UInt8(),
+            fill_value=0,
+            config=ArrayConfig(order="C", write_empty_chunks=True),
+            prototype=default_buffer_prototype(),
+        ),
+        chunk_selection=(0, 0),
+        out_selection=(0, 0),
+        is_complete_chunk=True,
+    )
+    assert tuple(info) == (
+        info.byte_operator,
+        info.array_spec,
+        info.chunk_selection,
+        info.out_selection,
+        info.is_complete_chunk,
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,8 +9,8 @@ import pytest
 
 import zarr
 from zarr import zeros
-from zarr.abc.codec import CodecPipeline
-from zarr.abc.store import ByteSetter, Store
+from zarr.abc.codec import CodecPipeline, WriteBatchInfo
+from zarr.abc.store import Store
 from zarr.codecs import (
     BloscCodec,
     BytesCodec,
@@ -22,7 +22,6 @@ from zarr.core.buffer import NDBuffer
 from zarr.core.buffer.core import Buffer
 from zarr.core.codec_pipeline import BatchedCodecPipeline
 from zarr.core.config import BadConfigError, config
-from zarr.core.indexing import SelectorTuple
 from zarr.errors import ZarrUserWarning
 from zarr.registry import (
     fully_qualified_name,
@@ -140,7 +139,7 @@ def test_config_codec_pipeline_class(store: Store) -> None:
     class MockCodecPipeline(BatchedCodecPipeline):
         async def write(
             self,
-            batch_info: Iterable[tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple, bool]],
+            batch_info: Iterable[WriteBatchInfo],
             value: NDBuffer,
             drop_axes: tuple[int, ...] = (),
         ) -> None:


### PR DESCRIPTION
This refactors the interface of `Codec.read` and `Codec.write` to move from an `Iterable[tuple[...]` to an `Iterable[BatchInfo]`.

Two things motivate this change

1. Readability: I struggle to remember what the 4th member of these complex tuples is. Having the name `info.out_selection` to remind me is helpful.
2. Possible future-proofing: right now, any change to the interface is a hard break since the number of elements in the tuple will change. There may be a class of changes to the interface where we can add additional information to `BatchInfo` without breaking backwards compatibility.

I don't want to oversell motivation 2 though. If something is important enough to add to the interface, then presumably we expected implementations to, you know, use it.
