### PR TITLE
Clean up test extra dependencies

### DIFF
--- a/changes/3656.misc.md
+++ b/changes/3656.misc.md
@@ -1,1 +1,1 @@
-Removed *rich*, *mypy*, and *uv* from the `[test]` dependencies, and added a new `[dev]` dependency group that can be used to install all the development dependencies.
+Removed *rich* and *mypy* from the `[test]` dependencies, and added a new `[dev]` dependency group that can be used to install all the development dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ test = [
     "pytest-codspeed",
     "packaging",
     "tomlkit",
+    "uv",
 ]
 remote_tests = [
     'zarr[remote]',


### PR DESCRIPTION
I noticed that there were a few dependencies under `[test]` that were superfluous, since this extra should contain only dependencies for running the tests, not optional extras. This allows the `min_deps` run on GH actions to then truly be a minimal dependencies run.

Because it looked like some of these dependencies were useful developement dependencies, I added a new `[dev]` extra that is helpful for developers who just want to install everything useful for development.