### PR TITLE
DOC: fix write_empty_chunks default claim in performance guide

### DIFF
--- a/docs/user-guide/performance.md
+++ b/docs/user-guide/performance.md
@@ -125,7 +125,7 @@ This optimization prevents storing redundant objects and can speed up reads, but
 added computation during array writes, since the contents of
 each chunk must be compared to the fill value, and these advantages are contingent on the content of the array.
 If you know that your data will form chunks that are almost always non-empty, then there is no advantage to the optimization described above.
-In this case, creating an array with `write_empty_chunks=True` (the default) will instruct Zarr to write every chunk without checking for emptiness.
+In this case, creating an array with `write_empty_chunks=True`will instruct Zarr to write every chunk without checking for emptiness.
 
 The following example illustrates the effect of the `write_empty_chunks` flag on
 the time required to write an array with different values.:


### PR DESCRIPTION
Fixes #3666.

The performance guide states that `write_empty_chunks=True` is “the default”, but the actual runtime configuration default is `False` (e.g. `zarr.config.get("array.write_empty_chunks")`). This PR removes the incorrect default claim to keep the documentation consistent with the implementation.

