### PR TITLE
chore: Pre-commit hook for multi-character lstrip/rstrip

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
       - id: ban-lstrip-rstrip
         name: ban lstrip/rstrip
         language: pygrep
+        # Matches .lstrip() or .rstrip() where the string argument is 2+ characters.
         entry: "\\.(lstrip|rstrip)\\([\"'][^\"']{2,}[\"']\\)"
         types: [python]
         files: ^(src|tests)/


### PR DESCRIPTION
Adds a pre-commit hook to avoid bugs related to lstrip/rstrip mis-use, suggested by https://github.com/zarr-developers/zarr-python/issues/3753#issuecomment-4025989209.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
