### PR TITLE
docs: use dark text color on light mode search bar

### DIFF
--- a/docs/overrides/stylesheets/extra.css
+++ b/docs/overrides/stylesheets/extra.css
@@ -52,14 +52,14 @@
   color: white;
 }
 
-/* Search box styling */
-.md-search__input {
+/* Search box styling in the header */
+.md-header .md-search__input {
   background-color: rgba(255, 255, 255, 0.15);
   border: 1px solid rgba(255, 255, 255, 0.2);
   color: white;
 }
 
-.md-search__input::placeholder {
+.md-header .md-search__input::placeholder {
   color: rgba(255, 255, 255, 0.7);
 }
 


### PR DESCRIPTION
The text color in the search bar isn't visible in light mode, this fixes that.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
