### PR TITLE
docs: fix docstring for Array.cdata_shape

### DIFF
--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1235,28 +1235,28 @@ class AsyncArray(Generic[T_ArrayMetadata]):
     @property
     def cdata_shape(self) -> tuple[int, ...]:
         """
-        The number of independently compressible units along each dimension.
+        The number of chunks along each dimension.
 
         When sharding is used, this counts inner chunks (not shards) per dimension.
 
         Returns
         -------
         tuple[int, ...]
-            The number of independently compressible units along each dimension.
+            The number of chunks along each dimension.
         """
         return self._chunk_grid_shape
 
     @property
     def _chunk_grid_shape(self) -> tuple[int, ...]:
         """
-        The number of independently compressible units along each dimension.
+        The number of chunks along each dimension.
 
         When sharding is used, this counts inner chunks (not shards) per dimension.
 
         Returns
         -------
         tuple[int, ...]
-            The number of independently compressible units along each dimension.
+            The number of chunks along each dimension.
         """
         return tuple(starmap(ceildiv, zip(self.shape, self.chunks, strict=True)))
 
@@ -2403,7 +2403,7 @@ class Array(Generic[T_ArrayMetadata]):
     @property
     def cdata_shape(self) -> tuple[int, ...]:
         """
-        The number of independently compressible units along each dimension.
+        The number of chunks along each dimension.
 
         When sharding is used, this counts inner chunks (not shards) per dimension.
         """
@@ -2412,14 +2412,14 @@ class Array(Generic[T_ArrayMetadata]):
     @property
     def _chunk_grid_shape(self) -> tuple[int, ...]:
         """
-        The number of independently compressible units along each dimension.
+        The number of chunks along each dimension.
 
         When sharding is used, this counts inner chunks (not shards) per dimension.
 
         Returns
         -------
         tuple[int, ...]
-            The number of independently compressible units along each dimension.
+            The number of chunks along each dimension.
         """
         return self.async_array._chunk_grid_shape
 


### PR DESCRIPTION
The `cdata_shape` docstring states that it returns the shape of the chunk grid. However, Zarr-Python's internals use the chunk grid to model the outer boundaries (xref https://github.com/zarr-developers/zarr-python/pull/3767). This changes the docstring to align with the implementation, which returns a shape for inner chunks.

This also applies to the function named `_chunk_grid_shape`. I updated that docstring but chose not to rename to something more technically accurate.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
