### PR TITLE
chore: less frequent codspeed runs

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,4 +1,4 @@
-name: Codspeed benchmarks
+name: CodSpeed Benchmarks
 
 on:
   schedule:


### PR DESCRIPTION
We keep running through our codspeed usage half way through the month, so this PR updates the triggers to run less frequently:

- use a cron job rather than every commit to main (which can be multiple per day)
- run on PRs when the label is applied rather than every commit thereafter

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
