### PR TITLE
Add missing slash character to towncrier issue format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,7 +445,7 @@ checks = [
 directory = 'changes'
 filename = "docs/release-notes.md"
 underlines = ["", "", ""]
-issue_format = "[#{issue}](https://github.com/zarr-developers/zarr-python/issues{issue})"
+issue_format = "[#{issue}](https://github.com/zarr-developers/zarr-python/issues/{issue})"
 start_string = "<!-- towncrier release notes start -->\n"
 
 [tool.codespell]


### PR DESCRIPTION
Our towncrier issue format generates busted URLs because we are missing a "/" character. This PR adds that "/" character.
