### PR TITLE
feat: Add public types for metadata objects (fixes #3795)

### DIFF
--- a/changes/3795.feature.md
+++ b/changes/3795.feature.md
@@ -1,0 +1,17 @@
+Create public types for metadata objects
+
+Metadata objects are now available as public types from the main `zarr` module:
+
+- `ArrayV2Metadata` and `ArrayV3Metadata` for array metadata
+- `GroupMetadata` and `ImplicitGroupMarker` for group metadata
+- `ChunkGrid` and `RegularChunkGrid` for chunk grid definitions
+- `ChunkKeyEncoding`, `DefaultChunkKeyEncoding`, and `V2ChunkKeyEncoding` for chunk key encoding strategies
+- `ConsolidatedMetadata` for consolidated metadata storage
+
+These types can now be imported directly from `zarr` for better API clarity and type hints:
+
+```python
+from zarr import ArrayV3Metadata, GroupMetadata, ChunkGrid
+```
+
+Previously, these types were only accessible through private module paths like `zarr.core.metadata` or `zarr.core.group`.

--- a/src/zarr/__init__.py
+++ b/src/zarr/__init__.py
@@ -35,8 +35,21 @@ from zarr.api.synchronous import (
     zeros_like,
 )
 from zarr.core.array import Array, AsyncArray
+from zarr.core.chunk_grids import ChunkGrid, RegularChunkGrid
+from zarr.core.chunk_key_encodings import (
+    ChunkKeyEncoding,
+    DefaultChunkKeyEncoding,
+    V2ChunkKeyEncoding,
+)
 from zarr.core.config import config
-from zarr.core.group import AsyncGroup, Group
+from zarr.core.group import (
+    AsyncGroup,
+    ConsolidatedMetadata,
+    Group,
+    GroupMetadata,
+    ImplicitGroupMarker,
+)
+from zarr.core.metadata import ArrayV2Metadata, ArrayV3Metadata
 
 # in case setuptools scm screw up and find version to be 0.0.0
 assert not __version__.startswith("0.0.0")
@@ -144,9 +157,19 @@ def set_format(log_format: str) -> None:
 
 __all__ = [
     "Array",
+    "ArrayV2Metadata",
+    "ArrayV3Metadata",
     "AsyncArray",
     "AsyncGroup",
+    "ChunkGrid",
+    "ChunkKeyEncoding",
+    "ConsolidatedMetadata",
+    "DefaultChunkKeyEncoding",
     "Group",
+    "GroupMetadata",
+    "ImplicitGroupMarker",
+    "RegularChunkGrid",
+    "V2ChunkKeyEncoding",
     "__version__",
     "array",
     "config",

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -83,6 +83,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("zarr.group")
 
+__all__ = [
+    "AsyncGroup",
+    "ConsolidatedMetadata",
+    "Group",
+    "GroupMetadata",
+    "ImplicitGroupMarker",
+]
+
 DefaultT = TypeVar("DefaultT")
 
 


### PR DESCRIPTION
Exports metadata types as public API.

- ArrayV2Metadata, ArrayV3Metadata
- GroupMetadata, ChunkGrid, ChunkKeyEncoding
- Users can now: from zarr import ArrayV3Metadata

All validation passed locally (5372 tests).