### PR TITLE
Revert the changes applied in #3821 + #3822

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -6,11 +6,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Git tag to build and publish (e.g. v3.1.6)'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -21,26 +16,7 @@ concurrency:
 
 jobs:
 
-  validate_tag:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate tag format
-        run: |
-          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([a-z]+[0-9]*)?$ ]]; then
-            echo "::error::Invalid tag format '${{ inputs.tag }}'. Expected format: v1.2.3, v1.2.3a1, v1.2.3rc1"
-            exit 1
-          fi
-      - name: Verify tag exists
-        run: |
-          git ls-remote --tags "${{ github.server_url }}/${{ github.repository }}" "${{ inputs.tag }}" | grep -q "${{ inputs.tag }}" || {
-            echo "::error::Tag '${{ inputs.tag }}' does not exist in the repository"
-            exit 1
-          }
-
   build_artifacts:
-    needs: [validate_tag]
-    if: always() && (needs.validate_tag.result == 'success' || needs.validate_tag.result == 'skipped')
     name: Build wheel on ubuntu-latest
     runs-on: ubuntu-latest
     strategy:
@@ -49,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
           submodules: true
           fetch-depth: 0
 
@@ -86,9 +61,7 @@ jobs:
   upload_pypi:
     needs: [build_artifacts, test_dist_pypi]
     runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v'))
-      || (github.event_name == 'workflow_dispatch' && startsWith(inputs.tag, 'v'))
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     environment:
       name: releases
       url: https://pypi.org/p/zarr


### PR DESCRIPTION
Reverts our `releases.yml` workflow to the state as of 93dd0e45, i.e. no option to publish a tag declared in workflow dispatch.

closes #3823