### PR TITLE
fix: auto-open ZipStore in list(), list_dir() and exists()

### DIFF
--- a/changes/3846.bugfix.md
+++ b/changes/3846.bugfix.md
@@ -1,0 +1,1 @@
+Fix `ZipStore.list()`, `list_dir()`, and `exists()` to auto-open the zip file when called before `open()`, consistent with the existing behavior of `get()` and `set()`.

--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -245,6 +245,8 @@ class ZipStore(Store):
 
     async def exists(self, key: str) -> bool:
         # docstring inherited
+        if not self._is_open:
+            self._sync_open()
         with self._lock:
             try:
                 self._zf.getinfo(key)
@@ -255,6 +257,8 @@ class ZipStore(Store):
 
     async def list(self) -> AsyncIterator[str]:
         # docstring inherited
+        if not self._is_open:
+            self._sync_open()
         with self._lock:
             for key in self._zf.namelist():
                 yield key
@@ -267,6 +271,8 @@ class ZipStore(Store):
 
     async def list_dir(self, prefix: str) -> AsyncIterator[str]:
         # docstring inherited
+        if not self._is_open:
+            self._sync_open()
         prefix = prefix.rstrip("/")
 
         keys = self._zf.namelist()

--- a/tests/test_store/test_zip.py
+++ b/tests/test_store/test_zip.py
@@ -139,6 +139,31 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
         assert isinstance(group := zipped["foo"], Group)
         assert list(group.keys()) == list(group.keys())
 
+    async def test_list_without_explicit_open(self, tmp_path: Path) -> None:
+        # ZipStore.list(), list_dir(), and exists() should auto-open
+        # the zip file just like _get() and _set() do.
+        zip_path = tmp_path / "data.zip"
+        zarr_path = tmp_path / "foo.zarr"
+        root = zarr.open_group(store=zarr_path, mode="w")
+        root["x"] = np.array([1, 2, 3])
+        shutil.make_archive(str(zarr_path), "zip", zarr_path)
+        shutil.move(str(zarr_path) + ".zip", zip_path)
+
+        store = ZipStore(zip_path, mode="r")
+        assert not store._is_open
+
+        keys = [k async for k in store.list()]
+        assert len(keys) > 0
+
+        store2 = ZipStore(zip_path, mode="r")
+        assert not store2._is_open
+        assert await store2.exists(keys[0])
+
+        store3 = ZipStore(zip_path, mode="r")
+        assert not store3._is_open
+        dir_keys = [k async for k in store3.list_dir("")]
+        assert len(dir_keys) > 0
+
     async def test_move(self, tmp_path: Path) -> None:
         origin = tmp_path / "origin.zip"
         destination = tmp_path / "some_folder" / "destination.zip"


### PR DESCRIPTION
Currently `ZipStore._get()` and `._set()` guard against the store not being open:

```python
if not self._is_open:
    self._sync_open()
```

But `list()`, `list_dir()`, and `exists()` access `self._zf` directly and crash with an `AttributeError` when called before `open()` (see #3846).

This PR applies the same auto-open pattern to those three methods so all store operations behave consistently.

A regression test in `test_zip.py` covers the three methods being called on an unopened store.

Closes #3846

Made with [Cursor](https://cursor.com)