### PR TITLE
fix: convert zarr Array to numpy before __setitem__ async dispatch

### DIFF
--- a/changes/3611.bugfix.md
+++ b/changes/3611.bugfix.md
@@ -1,0 +1,1 @@
+Fix `SyncError` raised when assigning a `zarr.Array` as the value in a `__setitem__` call (e.g. `dst[:] = src` where `src` is a zarr array). The source array is now converted to a NumPy array before entering the async codec pipeline.

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -2929,6 +2929,12 @@ class Array[T_ArrayMetadata: (ArrayV2Metadata, ArrayV3Metadata)]:
         [blocks][zarr.Array.blocks], [__getitem__][zarr.Array.__getitem__]
 
         """
+        # Converting a zarr Array to numpy here avoids a SyncError that occurs when
+        # value.__getitem__ is called inside the async codec pipeline (which already
+        # runs within a running event loop).  np.asarray triggers Array.__array__,
+        # which reads the data synchronously before we enter the async context.
+        if isinstance(value, Array):
+            value = np.asarray(value)
         fields, pure_selection = pop_fields(selection)
         if is_pure_fancy_indexing(pure_selection, self.ndim):
             self.vindex[cast("CoordinateSelection | MaskSelection", selection)] = value

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -443,7 +443,6 @@ def test_orthogonal_indexing_fallback_on_getitem_2d(
     np.testing.assert_array_equal(z[index], expected_result)
 
 
-@pytest.mark.skip(reason="fails on ubuntu, windows; numpy=2.2; in CI")
 def test_setitem_zarr_array_as_value() -> None:
     # Regression test for https://github.com/zarr-developers/zarr-python/issues/3611
     # Assigning a zarr Array as the value used to raise
@@ -462,6 +461,7 @@ def test_setitem_zarr_array_as_value() -> None:
     assert_array_equal(dst2[2:7], np.arange(2, 7))
 
 
+@pytest.mark.skip(reason="fails on ubuntu, windows; numpy=2.2; in CI")
 def test_setitem_repeated_index():
     array = zarr.array(data=np.zeros((4,)), chunks=(1,))
     indexer = np.array([-1, -1, 0, 0])

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -444,6 +444,24 @@ def test_orthogonal_indexing_fallback_on_getitem_2d(
 
 
 @pytest.mark.skip(reason="fails on ubuntu, windows; numpy=2.2; in CI")
+def test_setitem_zarr_array_as_value() -> None:
+    # Regression test for https://github.com/zarr-developers/zarr-python/issues/3611
+    # Assigning a zarr Array as the value used to raise
+    # SyncError("Calling sync() from within a running loop") because the codec
+    # pipeline tried to index the zarr array inside an already-running async loop.
+    src = zarr.array(np.arange(10), chunks=(5,))
+    dst = zarr.zeros(10, chunks=(5,), dtype=src.dtype)
+
+    # Full assignment
+    dst[:] = src
+    assert_array_equal(dst[:], np.arange(10))
+
+    # Slice assignment
+    dst2 = zarr.zeros(10, chunks=(5,), dtype=src.dtype)
+    dst2[2:7] = src[2:7]
+    assert_array_equal(dst2[2:7], np.arange(2, 7))
+
+
 def test_setitem_repeated_index():
     array = zarr.array(data=np.zeros((4,)), chunks=(1,))
     indexer = np.array([-1, -1, 0, 0])


### PR DESCRIPTION
Assigning a `zarr.Array` as the value in a slice assignment fails with:

```
zarr.core.sync.SyncError: Calling sync() from within a running loop
```

The root cause is that the codec pipeline calls `value[out_selection]` from inside an already-running async event loop. When `value` is a zarr `Array`, that indexing triggers another `sync()` call, which raises the error.

The fix is to convert the value to a NumPy array in `Array.__setitem__` before dispatching to the async codec pipeline. `np.asarray(value)` calls `Array.__array__`, which reads data synchronously and safely before we enter the async context.

```python
src = zarr.array(np.arange(10))
dst = zarr.zeros(10, dtype=src.dtype)
dst[:] = src  # previously raised SyncError, now works
```

Closes #3611

Made with [Cursor](https://cursor.com)