### PR TITLE
Document kwargs in zarr.create

### DIFF
--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -770,12 +770,12 @@ def create(
         If using an fsspec URL to create the store, these will be passed to
         the backend implementation. Ignored otherwise.
     config : ArrayConfigLike, optional
-        Runtime configuration of the array. If provided, will override the
-        default values from `zarr.config.array`.
+    Runtime configuration of the array. If provided, will override the
+    default values from :obj:`zarr.config.array`.
 
-    **kwargs
+**kwargs
     Additional keyword arguments passed through to
-    [`zarr.api.asynchronous.create`][].
+    :func:`zarr.api.asynchronous.create`.
 
     Returns
     -------

--- a/src/zarr/api/synchronous.py
+++ b/src/zarr/api/synchronous.py
@@ -773,6 +773,10 @@ def create(
         Runtime configuration of the array. If provided, will override the
         default values from `zarr.config.array`.
 
+    **kwargs
+    Additional keyword arguments passed through to
+    [`zarr.api.asynchronous.create`][].
+
     Returns
     -------
     z : Array


### PR DESCRIPTION
## Summary

Added documentation for `**kwargs` in `zarr.create()`.

## Changes Made

* Added a `**kwargs` section to the docstring
* Clarified that additional keyword arguments are passed through to `zarr.api.asynchronous.create`

Closes #2599
