### PR TITLE
fix: numpy default NaT handling

### DIFF
--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -545,7 +545,7 @@ class TimeDelta64(TimeDTypeBase[np.dtypes.TimeDelta64DType, np.timedelta64], Has
         raise a TypeError.
         """
         if self._check_scalar(data):
-            if isinstance(data, np.timedelta64) and np.isnan(data):
+            if isinstance(data, np.timedelta64) and np.isnat(data):
                 return np.timedelta64("NaT", self.unit)
             return self._cast_scalar_unchecked(data)
         msg = (

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -559,7 +559,7 @@ class TimeDelta64(TimeDTypeBase[np.dtypes.TimeDelta64DType, np.timedelta64], Has
         This method provides a default value for the timedelta64 scalar, which is
         a 'Not-a-Time' (NaT) value.
         """
-        return np.timedelta64("NaT")
+        return np.timedelta64("NaT", self.unit)
 
     def from_json_scalar(self, data: JSON, *, zarr_format: ZarrFormat) -> np.timedelta64:
         """

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -545,6 +545,8 @@ class TimeDelta64(TimeDTypeBase[np.dtypes.TimeDelta64DType, np.timedelta64], Has
         raise a TypeError.
         """
         if self._check_scalar(data):
+            if isinstance(data, np.timedelta64) and np.isnan(data):
+                return np.timedelta64("NaT", self.unit)
             return self._cast_scalar_unchecked(data)
         msg = (
             f"Cannot convert object {data!r} with type {type(data)} to a scalar compatible with the "

--- a/tests/test_dtype/test_npy/test_time.py
+++ b/tests/test_dtype/test_npy/test_time.py
@@ -115,7 +115,7 @@ class TestTimeDelta64(_TestTimeBase):
 
     cast_value_params = (
         (TimeDelta64(unit="ns", scale_factor=1), "1", np.timedelta64(1, "ns")),
-        (TimeDelta64(unit="ns", scale_factor=1), "NaT", np.timedelta64("NaT")),
+        (TimeDelta64(unit="ns", scale_factor=1), "NaT", np.timedelta64("NaT", "ns")),
     )
     invalid_scalar_params = (
         (TimeDelta64(unit="Y", scale_factor=1), 1.3),
@@ -146,6 +146,12 @@ def test_time_scale_factor_too_low() -> None:
         DateTime64(scale_factor=scale_factor)
     with pytest.raises(ValueError, match=msg):
         TimeDelta64(scale_factor=scale_factor)
+
+
+def test_default_is_NaT() -> None:
+    np.testing.assert_equal(
+        TimeDelta64(unit="ns", scale_factor=1).default_scalar(), np.timedelta64("NaT", "ns")
+    )
 
 
 def test_time_scale_factor_too_high() -> None:


### PR DESCRIPTION
Upstream CI started failing because of `numpy` `NaT` requiring a unit, not sure if this is intended on their side since `NaT` would be the one time I might not expect a unit..  ~~I am going to open an issue~~ Judging by https://github.com/numpy/numpy/pull/29619#issuecomment-3587365654, this is the intention.  

I don't really get this as a newbie to datetimes since:

```python
import numpy as np
np.testing.assert_equal(np.timedelta64("NaT", "m"), np.timedelta64("NaT", "ns"))
```
works.

See: https://github.com/zarr-developers/zarr-python/actions/runs/23841178099/job/69496895274?pr=3826 for the failures


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
