### PR TITLE
chore: separate benchmarks into a distinct CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,27 @@ jobs:
       run: |
         hatch run doctest:test
 
+  benchmarks:
+    name: Benchmark smoke test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+    - name: Install Hatch
+      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
+      with:
+        version: '1.16.5'
+    - name: Run Benchmarks
+      run: |
+        hatch env run --env "test.py3.13-minimal" run-benchmark
+
   test-complete:
     name: Test complete
 
@@ -162,7 +183,8 @@ jobs:
       [
         test,
         test-upstream-and-min-deps,
-        doctests
+        doctests,
+        benchmarks
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,11 +172,11 @@ matrix.deps.dependency-groups = [
 
 [tool.hatch.envs.test.scripts]
 run-coverage = [
-    "coverage run --source=src -m pytest --junitxml=junit.xml -o junit_family=legacy {args:}",
+    "coverage run --source=src -m pytest --ignore tests/benchmarks --junitxml=junit.xml -o junit_family=legacy {args:}",
     "coverage xml",
 ]
 run-coverage-html = [
-    "coverage run --source=src -m pytest {args:}",
+    "coverage run --source=src -m pytest --ignore tests/benchmarks {args:}",
     "coverage html",
 ]
 run = "pytest --ignore tests/benchmarks"

--- a/tests/test_codecs/test_codecs.py
+++ b/tests/test_codecs/test_codecs.py
@@ -219,6 +219,7 @@ def test_morton_exact_order() -> None:
         (1, 1),
         (5, 1, 3),
         (1, 4, 1, 2),
+        (5, 5, 5),  # triggers argsort strategy (n_z/n_total > 4)
     ],
 )
 def test_morton_is_permutation(shape: tuple[int, ...]) -> None:


### PR DESCRIPTION
This PR changes the CI workflows such that the benchmarking test suite is not run on every environment in the matrix.

## What changed

  - Add `--ignore tests/benchmarks` to `run-coverage` and `run-coverage-html` hatch scripts so the main test matrix no longer runs benchmark tests                                      
  - Add a `benchmarks` job to the test workflow that runs benchmarks in parallel with the other test jobs
  - `test-complete` gates on the new `benchmarks` job                                                                                                                                   

## Motivation

Benchmark tests (especially sharded morton indexing) take 15-22s each and dominate wall time when included in the main test suite. Running them as a separate parallel job avoids blocking the test matrix while still catching breakage on every PR. The assumption here is that these tests are not necessary to run on every OS and dependency set.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
