### PR TITLE
Revert "chore: update pre-commit hooks"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.4
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.1
     hooks:
       - id: codespell
         args: ["-L", "fo,ihs,kake,te", "-S", "fixture"]
@@ -28,7 +28,7 @@ repos:
         exclude: mkdocs.yml
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         files: src|tests
@@ -47,7 +47,7 @@ repos:
           - hypothesis
           - s3fs
   - repo: https://github.com/scientific-python/cookie
-    rev: 2026.04.04
+    rev: 2026.03.02
     hooks:
       - id: sp-repo-review
   - repo: https://github.com/numpy/numpydoc


### PR DESCRIPTION
Reverts zarr-developers/zarr-python#3876

zarr-developers/zarr-python#3876 caused the CI to fail, since it bumped the linters without applying fixes. I also think we should apply a policy to not bump dependencies that are <1 week old, given the number of recent supply chain attacks. I've opened #3878 to discuss that proposal.