### PR TITLE
fix: simplify and fix codspeed workflow

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,10 +27,6 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: "3.11"
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:
@@ -39,4 +35,4 @@ jobs:
       uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4.12.1
       with:
           mode: walltime
-          run: hatch run test.py3.11-minimal:pytest tests/benchmarks --codspeed
+          run: hatch run test.py3.12-minimal:pytest tests/benchmarks --codspeed


### PR DESCRIPTION
codspeed workflows are [failing](https://github.com/zarr-developers/zarr-python/actions/runs/24181463848/job/70575233873) because the workflow file refers to a nonexistent hatch environment. Also, the workflow installs python, which is not necessary at all. This PR fixes both things.
