### PR TITLE
test: add tests for version info in zarr

### DIFF
--- a/changes/3917.misc.md
+++ b/changes/3917.misc.md
@@ -1,0 +1,1 @@
+Add tests to verify that the Zarr version attribute (`__version__`) is always present, is a string, and follows the expected format.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,26 +1,25 @@
 """Tests for zarr._version module"""
-import pytest
-import importlib
-import sys
 
 
-def test_version_is_available():
+def test_version_is_available() -> None:
     """Test that __version__ is available and is a string."""
     from zarr import __version__
+
     assert __version__ is not None
     assert isinstance(__version__, str)
     assert len(__version__) > 0
 
 
-def test_version_format():
+def test_version_format() -> None:
     """Test that version follows basic format."""
     from zarr import __version__
+
     assert isinstance(__version__, str)
     # Basic check: should contain a dot or dash
-    assert '.' in __version__ or '-' in __version__
+    assert "." in __version__ or "-" in __version__
 
 
-def test_version_is_not_unknown_in_normal_case():
+def test_version_is_not_unknown_in_normal_case() -> None:
     from zarr import __version__
-    assert __version__ != "unknown"
 
+    assert __version__ != "unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+"""Tests for zarr._version module"""
+import pytest
+import importlib
+import sys
+
+
+def test_version_is_available():
+    """Test that __version__ is available and is a string."""
+    from zarr import __version__
+    assert __version__ is not None
+    assert isinstance(__version__, str)
+    assert len(__version__) > 0
+
+
+def test_version_format():
+    """Test that version follows basic format."""
+    from zarr import __version__
+    assert isinstance(__version__, str)
+    # Basic check: should contain a dot or dash
+    assert '.' in __version__ or '-' in __version__
+
+
+def test_version_is_not_unknown_in_normal_case():
+    from zarr import __version__
+    assert __version__ != "unknown"
+


### PR DESCRIPTION
What does this PR do?
This pull request adds a new test file, test_version.py, to check that the __version__ attribute in Zarr is always present, is a string, and follows the expected format. This helps make sure version info is always available for bug reports and package management.

Why is this needed?
I noticed there weren’t direct tests for version info. Having these tests will help catch any accidental changes to version reporting and improve reliability.

How did I test this?
I ran the new tests with pytest and confirmed they all pass.

Checklist:
 Added new tests
 All tests pass locally