### PR TITLE
fix: make upstream tests pass

### DIFF
--- a/changes/3920.bugfix.md
+++ b/changes/3920.bugfix.md
@@ -1,0 +1,1 @@
+Use the unit associated with the `Datetime64` data type when creating the default `Nat` scalar value.

--- a/examples/custom_dtype/custom_dtype.py
+++ b/examples/custom_dtype/custom_dtype.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "zarr @ git+https://github.com/zarr-developers/zarr-python.git@main",
-#   "ml_dtypes==0.5.1",
+#   "ml_dtypes==0.5.4",
 #   "pytest==8.4.1"
 # ]
 # ///

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -851,7 +851,7 @@ class DateTime64(TimeDTypeBase[np.dtypes.DateTime64DType, np.datetime64], HasEnd
             The default scalar value, which is a 'Not-a-Time' (NaT) value
         """
 
-        return np.datetime64("NaT")
+        return np.datetime64("NaT", self.unit)
 
     def from_json_scalar(self, data: JSON, *, zarr_format: ZarrFormat) -> np.datetime64:
         """

--- a/tests/test_dtype/test_npy/test_time.py
+++ b/tests/test_dtype/test_npy/test_time.py
@@ -66,7 +66,7 @@ class TestDateTime64(_TestTimeBase):
     cast_value_params = (
         (DateTime64(unit="Y", scale_factor=1), "1", np.datetime64("1", "Y")),
         (DateTime64(unit="s", scale_factor=1), "2005-02-25", np.datetime64("2005-02-25", "s")),
-        (DateTime64(unit="ns", scale_factor=1), "NaT", np.datetime64("NaT")),
+        (DateTime64(unit="ns", scale_factor=1), "NaT", np.datetime64("NaT", "ns")),
     )
     invalid_scalar_params = (
         (DateTime64(unit="Y", scale_factor=1), 1.3),


### PR DESCRIPTION
We have 2 failures in our upstream tests. One is caused by NumPy deprecating the creation of a `NaT` datetime without an explicitly declared unit, and the fix is to declare a unit when creating a `NaT` datetime. The second failure has an unknown cause but was fixed by bumping the version of ml_dtypes used in an example script.
