### PR TITLE
fix: CastValue wrap validation bug 

### DIFF
--- a/src/zarr/codecs/cast_value.py
+++ b/src/zarr/codecs/cast_value.py
@@ -54,20 +54,31 @@ class ScalarMap(TypedDict, total=False):
 
 
 # see https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/cast_value
-PERMITTED_DATA_TYPE_NAMES: Final[set[str]] = {
+CAST_VALUE_INT_DTYPES: Final[set[str]] = {
+    # signed
     "int2",
     "int4",
     "int8",
     "int16",
     "int32",
     "int64",
-    "int64uint2",
+    # unsigned
+    "uint2",
     "uint4",
     "uint8",
     "uint16",
     "uint32",
     "uint64",
-    "uint64float4_e2m1fn",
+}
+"""Integer dtype identifiers permitted as the source or target of `cast_value`.
+
+Membership in this set drives the `out_of_range="wrap"` rule, which the
+spec restricts to integral targets that use two's-complement representation
+for modular arithmetic.
+"""
+
+CAST_VALUE_FLOAT_DTYPES: Final[set[str]] = {
+    "float4_e2m1fn",
     "float6_e2m3fn",
     "float6_e3m2fn",
     "float8_e3m4",
@@ -82,6 +93,10 @@ PERMITTED_DATA_TYPE_NAMES: Final[set[str]] = {
     "float32",
     "float64",
 }
+"""Floating-point dtype identifiers permitted as the source or target of `cast_value`."""
+
+PERMITTED_DATA_TYPE_NAMES: Final[set[str]] = CAST_VALUE_INT_DTYPES | CAST_VALUE_FLOAT_DTYPES
+"""All dtype identifiers the `cast_value` codec is defined for."""
 
 
 def parse_scalar_map(obj: ScalarMapJSON | ScalarMap) -> ScalarMap:
@@ -240,15 +255,22 @@ class CastValue(ArrayArrayCodec):
         dtype: ZDType[TBaseDType, TBaseScalar],
         chunk_grid: ChunkGridMetadata,
     ) -> None:
-        target_name = dtype.to_json(zarr_format=3)
-        if target_name not in PERMITTED_DATA_TYPE_NAMES:
+        # `dtype` is the source (the array's dtype); `self.dtype` is the
+        # cast target. The spec requires both to be permitted, and rules
+        # like `out_of_range="wrap"` apply to the target.
+        source_name = dtype.to_json(zarr_format=3)
+        target_name = self.dtype.to_json(zarr_format=3)
+        for role, name in (("source", source_name), ("target", target_name)):
+            if name not in PERMITTED_DATA_TYPE_NAMES:
+                raise ValueError(
+                    f"The cast_value codec only supports integer and floating-point data types. "
+                    f"Got {role} dtype {name}."
+                )
+        if self.out_of_range == "wrap" and target_name not in CAST_VALUE_INT_DTYPES:
             raise ValueError(
-                f"The cast_value codec only supports integer and floating-point data types. "
-                f"Got dtype {target_name}."
+                f"out_of_range='wrap' is only valid for integer target types. "
+                f"Got target dtype {target_name}."
             )
-        target_native = dtype.to_native_dtype()
-        if self.out_of_range == "wrap" and not np.issubdtype(target_native, np.integer):
-            raise ValueError("out_of_range='wrap' is only valid for integer target types.")
 
         if self.scalar_map is not None:
             self._validate_scalar_map(dtype, self.dtype)

--- a/tests/test_codecs/test_cast_value.py
+++ b/tests/test_codecs/test_cast_value.py
@@ -139,7 +139,7 @@ def test_construction_rejects_invalid_target_dtype() -> None:
             exception_cls=ValueError,
         ),
         ExpectErr(
-            input={"dtype": "float32", "target": "int32", "out_of_range": "wrap"},
+            input={"dtype": "int32", "target": "float64", "out_of_range": "wrap"},
             msg="only valid for integer",
             exception_cls=ValueError,
         ),
@@ -163,6 +163,29 @@ def test_validation_rejects_invalid(case: ExpectErr[dict[str, Any]]) -> None:
             compressors=None,
             fill_value=0,
         )
+
+
+@pytest.mark.parametrize(
+    ("source_dtype", "target_dtype"),
+    [
+        ("float16", "int8"),
+        ("float32", "int32"),
+        ("float64", "int64"),
+        ("int32", "uint8"),
+    ],
+)
+def test_validation_accepts_wrap_with_integer_target(source_dtype: str, target_dtype: str) -> None:
+    """Regression for #3936: `out_of_range="wrap"` is permitted when the
+    cast TARGET (not the source array dtype) is an integer type."""
+    zarr.create_array(
+        store={},
+        shape=(1,),
+        dtype=source_dtype,
+        chunks=(1,),
+        filters=[CastValue(data_type=target_dtype, out_of_range="wrap")],
+        compressors=None,
+        fill_value=0,
+    )
 
 
 def test_zero_itemsize_raises() -> None:


### PR DESCRIPTION
the fix ensures that we check the _target_ dtype instead of the source dtype when validating a pair of dtypes against a cast_value codec configuration

closes #3936 
