### PR TITLE
fix: defer to fsspec for memory url scheme

### DIFF
--- a/changes/3944.bugfix.md
+++ b/changes/3944.bugfix.md
@@ -1,0 +1,4 @@
+Fixed breakage in existing fsspec-dependent workflows caused by associating the "memory" URL scheme with
+instances of `ManagedMemoryStore` instead of fsspec's memory-backed store. After this change, store URLs with a "memory" scheme are handled differently when `fsspec` is installed:
+with `fsspec`, a `FsspecStore` backed by a `MemoryFileSystem` is used. Without `fsspec`,
+a `ManagedMemoryStore` is used.

--- a/src/zarr/storage/_common.py
+++ b/src/zarr/storage/_common.py
@@ -369,7 +369,7 @@ async def make_store(
         return await LocalStore.open(root=store_like, mode=mode, read_only=_read_only)
 
     elif isinstance(store_like, str) and parsed is not None:
-        if parsed.scheme == "memory":
+        if parsed.scheme == "memory" and not _has_fsspec:
             # Create or get a ManagedMemoryStore
             return ManagedMemoryStore(name=parsed.name, path=parsed.path, read_only=_read_only)
         elif parsed.scheme == "file" or not parsed.scheme:

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -16,6 +16,7 @@ from zarr.core.buffer import Buffer, cpu, default_buffer_prototype
 from zarr.core.sync import _collect_aiterator, sync
 from zarr.errors import ZarrUserWarning
 from zarr.storage import FsspecStore
+from zarr.storage._common import make_store
 from zarr.storage._fsspec import _make_async
 from zarr.testing.store import StoreTests
 
@@ -544,3 +545,10 @@ async def test_with_read_only_auto_mkdir(tmp_path: Path) -> None:
 
     store_w = FsspecStore.from_url(f"file://{tmp_path}", storage_options={"auto_mkdir": False})
     _ = store_w.with_read_only()
+
+
+async def test_memory_scheme() -> None:
+    """Test that the "memory" scheme creates a `MemoryFileSystem`-backed store"""
+    store = await make_store("memory://test")
+    assert isinstance(store, FsspecStore)
+    assert store.fs.protocol == "memory"

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -547,6 +547,10 @@ async def test_with_read_only_auto_mkdir(tmp_path: Path) -> None:
     _ = store_w.with_read_only()
 
 
+@pytest.mark.skipif(
+    parse_version(fsspec.__version__) < parse_version("2024.12.0"),
+    reason="No AsyncFileSystemWrapper",
+)
 async def test_memory_scheme() -> None:
     """Test that the "memory" scheme creates a `MemoryFileSystem`-backed store"""
     store = await make_store("memory://test")


### PR DESCRIPTION
Only associate the "memory" scheme with `ManagedMemoryStore` when fsspec is not installed.

closes #3939 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
