### PR TITLE
Allow s3 testing in face of ambient AWS credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -365,7 +365,9 @@ ignore = [
 python_version = "3.12"
 ignore_missing_imports = true
 namespace_packages = false
-
+pretty = true
+show_error_code_links = true
+show_error_context = true
 strict = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
@@ -378,7 +380,6 @@ module = [
     "tests.test_config",
     "tests.test_store.test_zip",
     "tests.test_store.test_local",
-    "tests.test_store.test_fsspec",
     "tests.test_store.test_memory",
     "tests.test_codecs.test_codecs",
     "tests.test_metadata.*",
@@ -394,6 +395,7 @@ strict = false
 # and fix the errors
 [[tool.mypy.overrides]]
 module = [
+    "tests.test_store.test_fsspec",
     "tests.test_group",
     "tests.test_indexing",
     "tests.test_properties",

--- a/tests/test_store/test_fsspec.py
+++ b/tests/test_store/test_fsspec.py
@@ -80,7 +80,13 @@ def s3_base() -> Generator[None, None, None]:
 def get_boto3_client() -> botocore.client.BaseClient:
     # NB: we use the sync botocore client for setup
     session = botocore.session.Session()
-    return session.create_client("s3", endpoint_url=endpoint_url)
+
+    # Prevent IllegalLocationConstraintException by explicitly setting region to
+    # "us-east-1", which does not require configuring LocationConstraint during
+    # bucket creation. (It is, in fact, forbidden for that region.)  Necessary
+    # in the face of "ambient" AWS configuration in a development environment
+    # where the default region might be configured differently.
+    return session.create_client("s3", endpoint_url=endpoint_url, region_name="us-east-1")
 
 
 @pytest.fixture(autouse=True)
@@ -100,7 +106,14 @@ def s3(s3_base: None) -> Generator[s3fs.S3FileSystem, None, None]:
     client = get_boto3_client()
     client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
     s3fs.S3FileSystem.clear_instance_cache()
-    s3 = s3fs.S3FileSystem(anon=False, client_kwargs={"endpoint_url": endpoint_url})
+    s3 = s3fs.S3FileSystem(
+        anon=False,
+        client_kwargs={"endpoint_url": endpoint_url},
+        # Prevent "AssertionError: Session was never entered" from aiobotocore
+        # at end of test execution.  Using clear_instance_cache is insufficient,
+        # although still necessary.
+        skip_instance_cache=True,
+    )
     session = sync(s3.set_session())
     s3.invalidate_cache()
     yield s3


### PR DESCRIPTION
This PR allows tests that use s3fs to run successfully in environments where there are "ambient" AWS credentials (i.e., either `AWS_*` env vars set or presence of `~/.aws/config`) and the AWS region is set to something other than `"us-east-1"`.  In such cases, tests using s3fs fail with `IllegalLocationConstraintException`.

This PR allows tests to succeed in such environments (i.e., typically a local dev setup).  Further, since mypy was failing during pre-commit for code in the module `tests.test_store.test_fsspec`, it also adds that module to the mypy "ignore" list in `pyproject.toml` until mypy configuration can be addressed to avoid the problem (to be addressed in a separate PR that will make mypy execution more robust/consistent).  In the process of diagnosing the mypy error, I updated the mypy configuration to provide more informative output.

Finally, I adjusted a test fixture to eliminate the "noise" of the "AssertionError: Session was never entered" message (and traceback) upon completion of test execution, which is disconcerting and confusing (made me wonder how the tests all passed while showing a traceback).

TODO:

* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
