### PR TITLE
chore(zarr-metadata): bump version to 0.1.1

### DIFF
--- a/packages/zarr-metadata/pyproject.toml
+++ b/packages/zarr-metadata/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zarr-metadata"
-version = "0.1.0"
+version = "0.1.1"
 description = "Spec-defined metadata types for Zarr v2 and v3."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/packages/zarr-metadata/pyproject.toml
+++ b/packages/zarr-metadata/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",

--- a/packages/zarr-metadata/src/zarr_metadata/__init__.py
+++ b/packages/zarr-metadata/src/zarr_metadata/__init__.py
@@ -13,7 +13,7 @@ from zarr_metadata.v3.array import ArrayMetadataV3, ExtensionFieldV3
 from zarr_metadata.v3.consolidated import ConsolidatedMetadataV3
 from zarr_metadata.v3.group import GroupMetadataV3
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 """Hardcoded package version. Must match the `version` field in
 `pyproject.toml`; the sync is enforced by `tests/test_version.py`."""
 


### PR DESCRIPTION
version 0.1.0 is burned on pypi in order to namesquat the package. so the first version we can publish will be 0.1.1.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
