### PR TITLE
chore: fix ability to run mypy via hatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ version.source = "vcs"
 [tool.hatch.build]
 hooks.vcs.version-file = "src/zarr/_version.py"
 
+[tool.hatch.envs.dev]
+dependency-groups = ["dev"]
+
 [tool.hatch.envs.test]
 dependency-groups = ["test"]
 
@@ -184,7 +187,6 @@ run-coverage-html = [
 ]
 run = "pytest --ignore tests/benchmarks"
 run-verbose = "run-coverage --verbose"
-run-mypy = "mypy src"
 run-hypothesis = [
     "coverage run --source=src -m pytest -nauto --run-slow-hypothesis tests/test_properties.py tests/test_store/test_stateful* {args:}",
     "coverage xml",
@@ -362,6 +364,7 @@ ignore = [
 "tests/**" = ["ANN001", "ANN201", "RUF029", "SIM117", "SIM300"]
 
 [tool.mypy]
+files = ["src", "tests"]
 python_version = "3.12"
 ignore_missing_imports = true
 namespace_packages = false


### PR DESCRIPTION
The test script for running mypy via hatch was broken because mypy is a dev dep, not a test dep. This means that this was broken because `mypy` could not be found:

```plain
hatch env run --env test run-mypy
```

This PR adds a dev env that depends on the dev dep group so that we can now run the following:

```plain
hatch env run --env dev mypy
```

Note, however, that the output from the command above will expose numerous mypy errors that are currently masked by the equivalent pre-commit hook because the pre-commit hook pins numpy to an earlier version.

As far as I can tell, numpy is pinned to an earlier version in the pre-commit hook precisely because of a slew of new typing errors that were initially raised when a newer version of numpy was pulled into the dep tree. Thus pinning to an earlier version is currently masking/deferring the typing issues.

Note also that the script is now simply `mypy`, not `run-mypy` because there's no need for an explicit script entry in pyproject.toml in this case.

For now, this is not in the CI path, so will not cause builds to fail. Rather it allows us to manually produce a complete list of masked typing issues, so we can separately address the issues, as we see fit.

TODO:

* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
