### PR TITLE
chore(zarr-metadata): set up a changelog

### DIFF
--- a/.github/workflows/check_changelogs.yml
+++ b/.github/workflows/check_changelogs.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Check changelog entries
+      - name: Check zarr-python changelog entries
         run: uv run --no-sync python ci/check_changelog_entries.py
+
+      - name: Check zarr-metadata changelog entries
+        run: uv run --no-sync python ci/check_changelog_entries.py packages/zarr-metadata/changes

--- a/ci/check_changelog_entries.py
+++ b/ci/check_changelog_entries.py
@@ -1,12 +1,18 @@
 """
 Check changelog entries have the correct filename structure.
+
+Usage:
+    python check_changelog_entries.py [DIRECTORY]
+
+DIRECTORY defaults to the repo-root `changes/`.
 """
 
 import sys
 from pathlib import Path
 
 VALID_CHANGELOG_TYPES = ["feature", "bugfix", "doc", "removal", "misc"]
-CHANGELOG_DIRECTORY = (Path(__file__).parent.parent / "changes").resolve()
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+DEFAULT_DIRECTORY = REPO_ROOT / "changes"
 
 
 def is_int(s: str) -> bool:
@@ -18,34 +24,47 @@ def is_int(s: str) -> bool:
         return True
 
 
-if __name__ == "__main__":
-    print(f"Looking for changelog entries in {CHANGELOG_DIRECTORY}")
-    entries = CHANGELOG_DIRECTORY.glob("*")
+def check(directory: Path) -> int:
+    print(f"Looking for changelog entries in {directory}")
+    entries = list(directory.glob("*"))
     entries = [e for e in entries if e.name not in [".gitignore", "README.md"]]
     print(f"Found {len(entries)} entries")
     print()
 
     bad_suffix = [e for e in entries if e.suffix != ".md"]
     bad_issue_no = [e for e in entries if not is_int(e.name.split(".")[0])]
-    bad_type = [e for e in entries if e.name.split(".")[1] not in VALID_CHANGELOG_TYPES]
+    # Only flag bad_type for files that have already passed the prior two
+    # checks; otherwise `e.name.split(".")[1]` may raise IndexError on a
+    # malformed name like `notes.md`.
+    bad_type = [
+        e
+        for e in entries
+        if e.suffix == ".md"
+        and is_int(e.name.split(".")[0])
+        and e.name.split(".")[1] not in VALID_CHANGELOG_TYPES
+    ]
 
-    if len(bad_suffix) or len(bad_issue_no) or len(bad_type):
-        if len(bad_suffix):
+    if bad_suffix or bad_issue_no or bad_type:
+        if bad_suffix:
             print("Changelog entries without .md suffix")
             print("-------------------------------------")
-            print("\n".join([p.name for p in bad_suffix]))
+            print("\n".join(p.name for p in bad_suffix))
             print()
-        if len(bad_issue_no):
+        if bad_issue_no:
             print("Changelog entries without integer issue number")
             print("----------------------------------------------")
-            print("\n".join([p.name for p in bad_issue_no]))
+            print("\n".join(p.name for p in bad_issue_no))
             print()
-        if len(bad_type):
+        if bad_type:
             print("Changelog entries without valid type")
             print("------------------------------------")
-            print("\n".join([p.name for p in bad_type]))
+            print("\n".join(p.name for p in bad_type))
             print(f"Valid types are: {VALID_CHANGELOG_TYPES}")
             print()
-        sys.exit(1)
+        return 1
+    return 0
 
-    sys.exit(0)
+
+if __name__ == "__main__":
+    directory = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else DEFAULT_DIRECTORY
+    sys.exit(check(directory))

--- a/packages/zarr-metadata/CHANGELOG.md
+++ b/packages/zarr-metadata/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Release notes
+
+<!-- towncrier release notes start -->
+
+## 0.2.0 (2026-05-11)
+
+### Bugfixes
+
+- `GzipCodecConfiguration.level` is now required, and `GzipCodecMetadata`
+  no longer accepts the bare-string `"gzip"` form. The codec's compressed
+  output depends on `level`, so metadata that omits it cannot reproducibly
+  identify the chunk bytes produced by a writer. **Breaking** for consumers
+  that previously typed gzip codec metadata as the bare string or
+  constructed a `GzipCodecConfiguration` without `level`.
+  ([#3978](https://github.com/zarr-developers/zarr-python/issues/3978))
+- `BytesCodecObject.configuration` is now `NotRequired`. The configuration
+  has no required keys (`endian` is conditionally required at runtime
+  based on data type), so the object form may omit it entirely — matching
+  the bare-string short-hand. **Soft-breaking** for consumers that
+  previously relied on `configuration` always being present.
+  ([#3978](https://github.com/zarr-developers/zarr-python/issues/3978))
+- Better modelling of Zarr v2 stored metadata. Zarr v2 splits a node's
+  metadata across two JSON documents (`.zarray`/`.zgroup` and `.zattrs`),
+  but `GroupMetadataV2` had no `attributes` field while `ArrayMetadataV2`
+  did — an inconsistency. `GroupMetadataV2` now also has an optional
+  `attributes` field, and `ArrayMetadataV2.attributes` is now
+  `NotRequired` for symmetry. **Soft-breaking** for consumers that
+  relied on `ArrayMetadataV2.attributes` always being present.
+  ([#3962](https://github.com/zarr-developers/zarr-python/issues/3962))
+
+### Features
+
+- Added three new top-level types modelling the **strict on-disk** shape
+  of Zarr v2 metadata documents: `ZArrayMetadata` (the `.zarray` file),
+  `ZGroupMetadata` (the `.zgroup` file), and `ZAttrsMetadata` (the
+  `.zattrs` file). Use these when you want a type that faithfully matches
+  what's stored on disk; use the merged `ArrayMetadataV2`/`GroupMetadataV2`
+  when you want the in-memory representation a Python program typically
+  works with.
+  ([#3962](https://github.com/zarr-developers/zarr-python/issues/3962))
+- Added typed constants exposing the spec-permitted values of constrained
+  Literal fields, importable at the per-codec module level. For example,
+  `from zarr_metadata.v3.codec.bytes import ENDIAN` provides
+  `("little", "big")` as a tuple, enabling runtime iteration or validator
+  generation without re-stating the Literal values by hand.
+  ([#3978](https://github.com/zarr-developers/zarr-python/issues/3978))
+
+## 0.1.1 (2026-05-06)
+
+### Misc
+
+- First usable release on PyPI. Version 0.1.0 was uploaded then deleted to
+  reserve the project name; this version is the first one PyPI will install.
+  No source changes from 0.1.0.
+  ([#3949](https://github.com/zarr-developers/zarr-python/issues/3949))
+
+## 0.1.0 (2026-05-01)
+
+### Features
+
+- Initial release. Provides `TypedDict` definitions and `Literal` aliases
+  for the JSON shapes specified by Zarr v2 and v3 metadata, plus a subset
+  of `zarr-extensions` types and the un-specified-but-widely-used
+  consolidated metadata documents. Pair with a runtime validator like
+  `pydantic` to check JSON loaded from disk.
+  ([#3919](https://github.com/zarr-developers/zarr-python/issues/3919))

--- a/packages/zarr-metadata/changes/README.md
+++ b/packages/zarr-metadata/changes/README.md
@@ -1,0 +1,25 @@
+Writing a changelog entry for `zarr-metadata`
+---------------------------------------------
+
+Fragments in **this** directory are released notes for the `zarr-metadata`
+package only — kept separate from the parent zarr-python `changes/`
+directory so a PR touching only `packages/zarr-metadata/` produces a
+release note for this package only.
+
+Please put a new file in this directory named `xxxx.<type>.md`, where
+
+- `xxxx` is the pull request number associated with this entry
+- `<type>` is one of:
+  - feature
+  - bugfix
+  - doc
+  - removal
+  - misc
+
+Inside the file, please write a short description of what you have
+changed, and how it impacts users of `zarr-metadata`.
+
+A `zarr-metadata` release runs `towncrier build` in `packages/zarr-metadata/`,
+which consumes the fragments here and updates `CHANGELOG.md`. Fragments
+that describe parent zarr-python changes (not the metadata package)
+belong in the top-level `changes/` directory, not here.

--- a/packages/zarr-metadata/pyproject.toml
+++ b/packages/zarr-metadata/pyproject.toml
@@ -74,3 +74,15 @@ include = ["src"]
 enableExperimentalFeatures = true
 typeCheckingMode = "strict"
 pythonVersion = "3.11"
+
+[tool.towncrier]
+# Fragments for this package live alongside the package source, separate
+# from the parent zarr-python `changes/` directory, so a PR touching only
+# `packages/zarr-metadata/` produces a release note for this package only.
+directory = "changes"
+filename = "CHANGELOG.md"
+package = "zarr_metadata"
+underlines = ["", "", ""]
+title_format = "## {version} ({project_date})"
+issue_format = "[#{issue}](https://github.com/zarr-developers/zarr-python/issues/{issue})"
+start_string = "<!-- towncrier release notes start -->\n"


### PR DESCRIPTION
Sets up changelog infrastructure for `zarr-metadata`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
