### PR TITLE
chore(zarr-metadata): prepare for 0.2.0 release

### DIFF
--- a/packages/zarr-metadata/CHANGELOG.md
+++ b/packages/zarr-metadata/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- towncrier release notes start -->
 
-## 0.2.0 (2026-05-11)
+## 0.2.0 (2026-05-19)
 
 ### Bugfixes
 
@@ -30,6 +30,15 @@
 
 ### Features
 
+- Added `ArrayMetadataV3Partial`, `GroupMetadataV3Partial`,
+  `ArrayMetadataV2Partial`, and `GroupMetadataV2Partial` — sibling
+  TypedDicts to the existing full metadata types, declared with
+  `total=False` so every field is `NotRequired`. Use these when typing
+  dicts that intentionally hold a subset of a complete metadata document
+  (test fixtures, fragment templates, in-progress builders). An
+  equivalence test pins each `Partial` to the keys and value types of
+  its full sibling so the two cannot drift.
+  ([#3982](https://github.com/zarr-developers/zarr-python/issues/3982))
 - Added three new top-level types modelling the **strict on-disk** shape
   of Zarr v2 metadata documents: `ZArrayMetadata` (the `.zarray` file),
   `ZGroupMetadata` (the `.zgroup` file), and `ZAttrsMetadata` (the

--- a/packages/zarr-metadata/pyproject.toml
+++ b/packages/zarr-metadata/pyproject.toml
@@ -16,18 +16,31 @@ authors = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
+keywords = ["zarr"]
 dependencies = [
     "typing_extensions>=4.13",
 ]
+
+[project.urls]
+Homepage = "https://github.com/zarr-developers/zarr-python"
+Source = "https://github.com/zarr-developers/zarr-python/tree/main/packages/zarr-metadata"
+Issues = "https://github.com/zarr-developers/zarr-python/issues"
+Changelog = "https://github.com/zarr-developers/zarr-python/blob/main/packages/zarr-metadata/CHANGELOG.md"
+Documentation = "https://github.com/zarr-developers/zarr-python/blob/main/packages/zarr-metadata/README.md"
 
 [dependency-groups]
 test = ["pytest", "pydantic>=2"]


### PR DESCRIPTION
this PR updates the changelog entries for zarr-metadata and adds a few helpful missing fields from `pyproject.toml` to ensure that our pypi page has useful content.

if this is merged, I would issue a release by pushing the zarr-metadata-v0.2.0 tag to `main`.

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
