### PR TITLE
Do not install CuPy on darwin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ remote = [
     "obstore>=0.5.1",
 ]
 gpu = [
-    "cupy-cuda12x",
+    "cupy-cuda12x; sys_platform != 'darwin'",
 ]
 cast-value-rs = ["cast-value-rs"]
 cli = ["typer"]

--- a/uv.lock
+++ b/uv.lock
@@ -3945,7 +3945,7 @@ cli = [
     { name = "typer" },
 ]
 gpu = [
-    { name = "cupy-cuda12x" },
+    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin'" },
 ]
 optional = [
     { name = "universal-pathlib" },
@@ -4046,7 +4046,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cast-value-rs", marker = "extra == 'cast-value-rs'" },
-    { name = "cupy-cuda12x", marker = "extra == 'gpu'" },
+    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin' and extra == 'gpu'" },
     { name = "donfig", specifier = ">=0.8" },
     { name = "fsspec", marker = "extra == 'remote'", specifier = ">=2023.10.0" },
     { name = "google-crc32c", specifier = ">=1.5" },


### PR DESCRIPTION
CUDA isn't available on macOS, so don't attempt to install it. This allows running "uv sync --all-extras" without error on macOS.