### PR TITLE
Widen ChunksLike type alias

### DIFF
--- a/changes/3990.misc.md
+++ b/changes/3990.misc.md
@@ -1,0 +1,5 @@
+Widen `ChunksLike` type alias to use `Iterable` instead of `Sequence`, and also
+remove `None` from the type union.  This supports a broader range of types,
+removing the necessity to "materialize" iterable values simply to satisfy type
+annotations.  It also allows use of `ChunksLike` in cases where `None` should
+not be permitted.

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -4397,11 +4397,8 @@ async def init_array(
         chunk_key_encoding, zarr_format=zarr_format
     )
 
-    if overwrite:
-        if store_path.store.supports_deletes:
-            await store_path.delete_dir()
-        else:
-            await ensure_no_existing_node(store_path, zarr_format=zarr_format)
+    if overwrite and store_path.store.supports_deletes:
+        await store_path.delete_dir()
     else:
         await ensure_no_existing_node(store_path, zarr_format=zarr_format)
 
@@ -4417,14 +4414,12 @@ async def init_array(
             )
 
     # Normalize the user's chunks into canonical ChunksTuple form
-    if chunks is None or chunks == "auto":
-        chunks_normalized = guess_chunks(
-            shape_parsed,
-            item_size,
-            max_bytes=SHARDED_INNER_CHUNK_MAX_BYTES if shards is not None else None,
-        )
-    else:
-        chunks_normalized = normalize_chunks_nd(chunks, shape_parsed)
+    max_bytes = None if shards is None else SHARDED_INNER_CHUNK_MAX_BYTES
+    chunks_normalized = (
+        guess_chunks(shape_parsed, item_size, max_bytes=max_bytes)
+        if chunks == "auto"
+        else normalize_chunks_nd(chunks, shape_parsed)
+    )
 
     # Resolve chunks + shards into outer_chunks (grid metadata) and
     # inner (sub-chunk structure for ShardingCodec, None if no sharding)

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -4414,12 +4414,12 @@ async def init_array(
             )
 
     # Normalize the user's chunks into canonical ChunksTuple form
-    max_bytes = None if shards is None else SHARDED_INNER_CHUNK_MAX_BYTES
-    chunks_normalized = (
-        guess_chunks(shape_parsed, item_size, max_bytes=max_bytes)
-        if chunks == "auto"
-        else normalize_chunks_nd(chunks, shape_parsed)
-    )
+
+    if chunks == "auto":
+        max_bytes = None if shards is None else SHARDED_INNER_CHUNK_MAX_BYTES
+        chunks_normalized = guess_chunks(shape_parsed, item_size, max_bytes=max_bytes)
+    else:
+        chunks_normalized = normalize_chunks_nd(chunks, shape_parsed)
 
     # Resolve chunks + shards into outer_chunks (grid metadata) and
     # inner (sub-chunk structure for ShardingCodec, None if no sharding)

--- a/src/zarr/core/common.py
+++ b/src/zarr/core/common.py
@@ -37,7 +37,7 @@ ZMETADATA_V2_JSON = ".zmetadata"
 
 BytesLike = bytes | bytearray | memoryview
 ShapeLike = Iterable[int | np.integer[Any]] | int | np.integer[Any]
-ChunksLike = ShapeLike | Sequence[Sequence[int]] | None
+ChunksLike = ShapeLike | Iterable[Iterable[int]]
 # For backwards compatibility
 ChunkCoords = tuple[int, ...]
 ZarrFormat = Literal[2, 3]


### PR DESCRIPTION
Widen `ChunksLike` type alias to use `Iterable` instead of `Sequence`, and also remove `None` from the union.

Fixes #3869

TODO:

* ~~[ ] Add unit tests and/or doctests in docstrings~~
* ~~[ ] Add docstrings and API docs for any new/modified user-facing classes and functions~~
* ~~[ ] New/modified features documented in `docs/user-guide/*.md`~~
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
