### PR TITLE
fix: use hatch's `default` env so the uv installer is inherited

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   LD_LIBRARY_PATH: /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64
+  # Use the uv from astral-sh/setup-uv instead of hatch's bundled (pyapp) uv.
+  HATCH_ENV_TYPE_VIRTUAL_UV_PATH: uv
 
 permissions:
   contents: read

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -59,6 +59,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -18,6 +18,8 @@ concurrency:
 
 env:
   FORCE_COLOR: 3
+  # Use the uv from astral-sh/setup-uv instead of hatch's bundled (pyapp) uv.
+  HATCH_ENV_TYPE_VIRTUAL_UV_PATH: uv
 
 jobs:
 

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -54,6 +54,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Use the uv from astral-sh/setup-uv; without an explicit path hatch
+  # bootstraps its own (pyapp) uv, which fails on non-3.12 runners.
+  HATCH_ENV_TYPE_VIRTUAL_UV_PATH: uv
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:
@@ -109,6 +111,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:
@@ -144,6 +148,8 @@ jobs:
       with:
         python-version: '3.13'
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:
@@ -168,6 +174,8 @@ jobs:
       with:
         python-version: '3.13'
         cache: 'pip'
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
       uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
-      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
-      with:
-        version: '1.16.5'
+      run: python -m pip install hatch==1.16.5
     - name: Set Up Hatch Env
       env:
         HATCH_ENV: test.py${{ matrix.python-version }}-${{ matrix.dependency-set }}
@@ -119,9 +117,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
-      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
-      with:
-        version: '1.16.5'
+      run: python -m pip install hatch==1.16.5
     - name: Set Up Hatch Env
       env:
         HATCH_ENV: ${{ matrix.dependency-set }}
@@ -156,9 +152,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
-      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
-      with:
-        version: '1.16.5'
+      run: python -m pip install hatch==1.16.5
     - name: Set Up Hatch Env
       run: |
         hatch run doctest:pip list
@@ -182,9 +176,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
     - name: Install Hatch
-      uses: pypa/hatch@257e27e51a6a5616ed08a39a408a21c35c9931bc
-      with:
-        version: '1.16.5'
+      run: python -m pip install hatch==1.16.5
     - name: Run Benchmarks
       run: |
         hatch env run --env "test.py3.13-minimal" run-benchmark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ extra-dependencies = [
     'obstore==0.5.*',
 ]
 
-[tool.hatch.envs.defaults]
+[tool.hatch.envs.default]
 installer = "uv"
 
 [tool.hatch.envs.docs]


### PR DESCRIPTION
## Summary

`[tool.hatch.envs.defaults]` (plural) was a typo. Hatch's inherited base environment is `default` (singular), so the intended `installer = "uv"` was never applied to any environment — `test`, `docs`, etc. silently used the default `virtualenv`/pip backend. This renames it to `default`, plus the CI changes required for the now-active uv installer to work.

## Changes

- **`pyproject.toml`**: `[tool.hatch.envs.defaults]` → `[tool.hatch.envs.default]`
- **`.github/workflows/{test,gpu_test,hypothesis}.yml`**: add `astral-sh/setup-uv` and set `HATCH_ENV_TYPE_VIRTUAL_UV_PATH=uv` so hatch uses that uv directly instead of bootstrapping its own
- **`.github/workflows/test.yml`**: install hatch via `pip install hatch==1.16.5` (as `docs/contributing.md` prescribes) instead of the `pypa/hatch` (pyapp) action

## Why the CI changes are needed

Activating the uv installer for the first time means hatch needs a uv binary, which CI never provided. On Linux, `setup-uv` + the explicit uv path is enough. On **macOS**, hatch's pyapp (standalone) build ships a `pip` whose shebang points at a non-existent `python3.12`; with the uv installer active hatch invokes it and fails (`exit 126`). Installing hatch via `pip` runs it on the runner's normal Python with a working pip on every OS. `.python-version` is not involved.

## Verification

All CI green across the full matrix (macOS / Ubuntu / Windows × Python 3.12 / 3.13 / 3.14 × optional / minimal), plus GPU, Slow Hypothesis, doctests, docs, lint, wheels, codecov.

## Note for reviewers

The `default` rename applies `installer = "uv"` to **every** hatch environment. That's the evident original intent, but it's the behavioral change worth a conscious sign-off.

Closes #4022.