### PR TITLE
fix: handle ObjectStore.list_dir when prefix-like object exists

### DIFF
--- a/src/zarr/storage/_obstore.py
+++ b/src/zarr/storage/_obstore.py
@@ -267,7 +267,14 @@ async def _transform_list_dir(
     for path in chain(
         list_result["common_prefixes"], map(itemgetter("path"), list_result["objects"])
     ):
-        yield _relativize_path(path=path, prefix=prefix)
+        # Skip entries that exactly match the prefix or are the prefix with a trailing slash.
+        # These represent the prefix itself rather than children.
+        if path == prefix or path == f"{prefix}/":
+            continue
+        relative = _relativize_path(path=path, prefix=prefix)
+        if relative == "":
+            continue
+        yield relative
 
 
 class _BoundedRequest(TypedDict):

--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -104,7 +104,7 @@ class TestObjectStore(StoreTests[ObjectStore[LocalStore], cpu.Buffer]):
         # list_dir("g") should not raise even though "g/" looks like the prefix itself.
         result = [k async for k in store.list_dir("g")]
         # The entry should not appear as an empty string or raise.
-        assert "" not in result
+        assert result == []
 
 
 @pytest.mark.slow_hypothesis

--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -96,6 +96,16 @@ class TestObjectStore(StoreTests[ObjectStore[LocalStore], cpu.Buffer]):
         total_size = await store.getsize_prefix("c")
         assert total_size == len(buf) * 2
 
+    async def test_list_dir_prefix_object(self, store: ObjectStore[LocalStore]) -> None:
+        """list_dir should not raise ValueError when an object keyed like the prefix exists."""
+        buf = cpu.Buffer.from_bytes(b"\x00")
+        # Create an object whose key is exactly the prefix with a trailing slash.
+        await self.set(store, "g/", buf)
+        # list_dir("g") should not raise even though "g/" looks like the prefix itself.
+        result = [k async for k in store.list_dir("g")]
+        # The entry should not appear as an empty string or raise.
+        assert "" not in result
+
 
 @pytest.mark.slow_hypothesis
 def test_zarr_hierarchy() -> None:


### PR DESCRIPTION
This PR fixes #4032 by filtering out entries that exactly match the prefix (or the prefix with a trailing slash) in `_transform_list_dir`.

Previously, if an object keyed exactly like the prefix existed (e.g., `"g/"` when listing `"g"`), `_relativize_path` would either raise `ValueError` or yield an empty string, because it expects paths to start with `prefix + "/"`.

## Changes
- In `_transform_list_dir`, skip entries where `path == prefix` or `path == prefix + "/"`.
- Skip empty-string results after relativization.

## Tests
- Added `test_list_dir_prefix_object` to verify that `list_dir("g")` does not raise when an object keyed `"g/"` exists.

## PR Checklist
- [x] I have read the contributing guide.
- [x] I have written tests for my changes.
- [x] My changes generate no new warnings.
- [x] I have signed all my commits with DCO (`git commit -s`).