### PR TITLE
fix: allow opening non-existent ZipStore in read mode

### DIFF
--- a/src/zarr/storage/_zip.py
+++ b/src/zarr/storage/_zip.py
@@ -94,6 +94,18 @@ class ZipStore(Store):
 
         self._lock = threading.RLock()
 
+        if self._zmode == "r" and not self.path.exists():
+            # zipfile.ZipFile requires the file to exist in read mode,
+            # but other stores can be opened in read mode without IO.
+            # create an empty zip file so that the store can be opened.
+            with zipfile.ZipFile(
+                self.path,
+                mode="w",
+                compression=self.compression,
+                allowZip64=self.allowZip64,
+            ):
+                pass
+
         self._zf = zipfile.ZipFile(
             self.path,
             mode=self._zmode,

--- a/tests/test_store/test_zip.py
+++ b/tests/test_store/test_zip.py
@@ -177,3 +177,21 @@ class TestZipStore(StoreTests[ZipStore, cpu.Buffer]):
         assert destination.exists()
         assert not origin.exists()
         assert np.array_equal(array[...], np.arange(10))
+
+    async def test_fresh_zip_store_read_mode(self, tmp_path: Path) -> None:
+        # See: https://github.com/zarr-developers/zarr-python/issues/2450
+        # A fresh ZipStore should be openable in read mode without error.
+        zip_path = tmp_path / "fresh.zip"
+        assert not zip_path.exists()
+
+        store = await ZipStore.open(path=zip_path, mode="r")
+        assert store._is_open
+        assert store.read_only
+
+        keys = [k async for k in store.list()]
+        assert keys == []
+
+        assert await store.get("nonexistent", default_buffer_prototype()) is None
+        assert not await store.exists("nonexistent")
+
+        store.close()


### PR DESCRIPTION
## Summary

Currently, opening a non-existent ZipStore in mode `r` fails because `zipfile.ZipFile` raises an exception when the file does not exist. This is inconsistent with other Store classes which can be opened in `r` mode without issues.

## Changes

- Handle the case where a ZipStore is opened in `r` mode but the file does not yet exist.

## Testing

- Added test verifying that a fresh ZipStore can be opened in `r` mode.

Fixes zarr-developers/zarr-python#2450