### PR TITLE
Modify custom dtype example to use only public API

### DIFF
--- a/changes/4052.doc.md
+++ b/changes/4052.doc.md
@@ -1,0 +1,21 @@
+Updated the custom dtype example in `examples/custom_dtype/custom_dtype.py` to
+use only the public API, eliminating all non-public imports, illustrating what
+users should do.
+
+To better support this, the following types and functions were made available
+from public modules:
+
+| Type/Function             | Non-public module        | Public module |
+| ------------------------- | ------------------------ | ------------- |
+| `DataTypeValidationError` | `zarr.core.dtype.common` | `zarr.errors` |
+| `JSON`                    | `zarr.core.common`       | `zarr.types`  |
+| `ZarrFormat`              | `zarr.core.common`       | `zarr.types`  |
+| `DTypeConfig_V2`          | `zarr.core.dtype.common` | `zarr.types`  |
+| `DTypeJSON`               | `zarr.core.dtype.common` | `zarr.types`  |
+| `DTypeSpec_V2`            | `zarr.core.dtype.common` | `zarr.dtype`  |
+| `check_dtype_spec_v2`     | `zarr.core.dtype.common` | `zarr.dtype`  |
+
+`DataTypeValidationError` was *moved* to `zarr.errors`. Importing it from
+`zarr.core.dtype.common` (its original location), `zarr.core.dtype`, or
+`zarr.dtype` still works but now raises a `ZarrDeprecationWarning`. The remaining
+types and functions are simply re-exported from the listed public module.

--- a/examples/custom_dtype/custom_dtype.py
+++ b/examples/custom_dtype/custom_dtype.py
@@ -25,11 +25,11 @@ import zarr
 from zarr.core.common import JSON, ZarrFormat
 from zarr.core.dtype import ZDType, data_type_registry
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     check_dtype_spec_v2,
 )
+from zarr.errors import DataTypeValidationError
 
 # This is the int2 array data type
 int2_dtype_cls = type(np.dtype("int2"))

--- a/examples/custom_dtype/custom_dtype.py
+++ b/examples/custom_dtype/custom_dtype.py
@@ -23,12 +23,12 @@ import pytest
 
 import zarr
 from zarr.core.common import JSON, ZarrFormat
-from zarr.core.dtype import ZDType, data_type_registry
 from zarr.core.dtype.common import (
     DTypeConfig_V2,
     DTypeJSON,
     check_dtype_spec_v2,
 )
+from zarr.dtype import ZDType, data_type_registry
 from zarr.errors import DataTypeValidationError
 
 # This is the int2 array data type
@@ -120,7 +120,7 @@ class Int2(ZDType[int2_dtype_cls, int2_scalar_cls]):
         msg = f"Invalid JSON representation of {cls.__name__}. Got {data!r}, expected the string {cls._zarr_v3_name!r}"
         raise DataTypeValidationError(msg)
 
-    @overload  # type: ignore[override]
+    @overload
     def to_json(self, zarr_format: Literal[2]) -> DTypeConfig_V2[Literal["int2"], None]: ...
 
     @overload
@@ -145,7 +145,7 @@ class Int2(ZDType[int2_dtype_cls, int2_scalar_cls]):
         """
         if zarr_format == 2:
             return {"name": "int2", "object_codec_id": None}
-        elif zarr_format == 3:
+        if zarr_format == 3:
             return self._zarr_v3_name
         raise ValueError(f"zarr_format must be 2 or 3, got {zarr_format}")  # pragma: no cover
 
@@ -191,9 +191,11 @@ class Int2(ZDType[int2_dtype_cls, int2_scalar_cls]):
         """
         # We could add a type check here, but we don't need to for this example
         val: int = int(data)  # type: ignore[call-overload]
-        if val not in (-2, -1, 0, 1):
-            raise ValueError("Invalid value. Expected -2, -1, 0, or 1.")
-        return val
+
+        if val in {-2, -1, 0, 1}:
+            return val
+
+        raise ValueError("Invalid value. Expected -2, -1, 0, or 1.")
 
     def from_json_scalar(self, data: JSON, *, zarr_format: ZarrFormat) -> ml_dtypes.int2:
         """
@@ -220,7 +222,11 @@ data_type_registry.register(Int2._zarr_v3_name, Int2)
 def test_custom_dtype(tmp_path: Path, zarr_format: ZarrFormat) -> None:
     # create array and write values
     z_w = zarr.create_array(
-        store=tmp_path, shape=(4,), dtype="int2", zarr_format=zarr_format, compressors=None
+        store=tmp_path,
+        shape=(4,),
+        dtype="int2",
+        zarr_format=zarr_format,
+        compressors=None,
     )
     z_w[:] = [-1, -2, 0, 1]
 
@@ -230,10 +236,7 @@ def test_custom_dtype(tmp_path: Path, zarr_format: ZarrFormat) -> None:
     print(z_r.info_complete())
 
     # look at the array metadata
-    if zarr_format == 2:
-        meta_file = tmp_path / ".zarray"
-    else:
-        meta_file = tmp_path / "zarr.json"
+    meta_file = tmp_path / (".zarray" if zarr_format == 2 else "zarr.json")
     print(json.dumps(json.loads(meta_file.read_text()), indent=2))
 
 
@@ -242,4 +245,16 @@ if __name__ == "__main__":
     # Without the dummy configuration file, at test time pytest will attempt to use the
     # configuration file in the project root, which will error because Zarr is using some
     # plugins that are not installed in this example.
-    sys.exit(pytest.main(["-s", __file__, f"-c {__file__}"]))
+    sys.exit(
+        pytest.main(
+            [
+                "-s",
+                __file__,
+                f"-c {__file__}",
+                # Suppress: "PytestAssertRewriteWarning: Module already imported so
+                # cannot be rewritten; zarr"
+                "-W",
+                "ignore::pytest.PytestAssertRewriteWarning",
+            ]
+        )
+    )

--- a/examples/custom_dtype/custom_dtype.py
+++ b/examples/custom_dtype/custom_dtype.py
@@ -22,8 +22,7 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr.core.dtype.common import check_dtype_spec_v2
-from zarr.dtype import ZDType, data_type_registry
+from zarr.dtype import ZDType, check_dtype_spec_v2, data_type_registry
 from zarr.errors import DataTypeValidationError
 from zarr.types import JSON, DTypeConfig_V2, DTypeJSON, ZarrFormat
 

--- a/examples/custom_dtype/custom_dtype.py
+++ b/examples/custom_dtype/custom_dtype.py
@@ -22,14 +22,10 @@ import numpy as np
 import pytest
 
 import zarr
-from zarr.core.common import JSON, ZarrFormat
-from zarr.core.dtype.common import (
-    DTypeConfig_V2,
-    DTypeJSON,
-    check_dtype_spec_v2,
-)
+from zarr.core.dtype.common import check_dtype_spec_v2
 from zarr.dtype import ZDType, data_type_registry
 from zarr.errors import DataTypeValidationError
+from zarr.types import JSON, DTypeConfig_V2, DTypeJSON, ZarrFormat
 
 # This is the int2 array data type
 int2_dtype_cls = type(np.dtype("int2"))

--- a/src/zarr/core/dtype/__init__.py
+++ b/src/zarr/core/dtype/__init__.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Final
 
-from zarr.core.dtype.common import (
-    DataTypeValidationError,
-    DTypeJSON,
-)
 from zarr.core.dtype.npy.bool import Bool
 from zarr.core.dtype.npy.bytes import (
     NullTerminatedBytes,
@@ -39,6 +35,7 @@ from zarr.core.dtype.npy.time import (
 
 if TYPE_CHECKING:
     from zarr.core.common import ZarrFormat
+    from zarr.core.dtype.common import DTypeJSON
 
 from collections.abc import Mapping
 
@@ -61,7 +58,6 @@ __all__ = [
     "Complex64",
     "Complex128",
     "DataTypeRegistry",
-    "DataTypeValidationError",
     "DateTime64",
     "DateTime64JSON_V2",
     "DateTime64JSON_V3",
@@ -287,3 +283,19 @@ def parse_dtype(
     # otherwise, we have either a numpy dtype string, or a zarr v3 dtype string, and in either case
     # we can create a native dtype from it, and do the dtype inference from that
     return get_data_type_from_native_dtype(dtype_spec)  # type: ignore[arg-type]
+
+
+def __getattr__(name: str) -> object:
+    if name == "DataTypeValidationError":
+        import warnings
+
+        from zarr.errors import DataTypeValidationError, ZarrDeprecationWarning
+
+        warnings.warn(
+            "Importing DataTypeValidationError from zarr.core.dtype is deprecated. "
+            "Use zarr.errors.DataTypeValidationError instead.",
+            ZarrDeprecationWarning,
+            stacklevel=2,
+        )
+        return DataTypeValidationError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/zarr/core/dtype/common.py
+++ b/src/zarr/core/dtype/common.py
@@ -146,7 +146,20 @@ def unpack_dtype_json(data: DTypeSpec_V2 | DTypeSpec_V3) -> DTypeJSON:
     return data
 
 
-class DataTypeValidationError(ValueError): ...
+def __getattr__(name: str) -> object:
+    if name == "DataTypeValidationError":
+        import warnings
+
+        from zarr.errors import DataTypeValidationError, ZarrDeprecationWarning
+
+        warnings.warn(
+            "Importing DataTypeValidationError from zarr.core.dtype.common is deprecated. "
+            "Use zarr.errors.DataTypeValidationError or zarr.dtype.DataTypeValidationError instead.",
+            ZarrDeprecationWarning,
+            stacklevel=2,
+        )
+        return DataTypeValidationError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class ScalarTypeValidationError(ValueError): ...

--- a/src/zarr/core/dtype/npy/bool.py
+++ b/src/zarr/core/dtype/npy/bool.py
@@ -6,13 +6,13 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeGuard, overload
 import numpy as np
 
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasItemSize,
     check_dtype_spec_v2,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/bytes.py
+++ b/src/zarr/core/dtype/npy/bytes.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from zarr.core.common import JSON, NamedConfig, ZarrFormat
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasItemSize,
@@ -20,6 +19,7 @@ from zarr.core.dtype.common import (
 )
 from zarr.core.dtype.npy.common import check_json_str
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 BytesLike = np.bytes_ | str | bytes | int
 

--- a/src/zarr/core/dtype/npy/complex.py
+++ b/src/zarr/core/dtype/npy/complex.py
@@ -13,7 +13,6 @@ from typing import (
 import numpy as np
 
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasEndianness,
@@ -32,6 +31,7 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/float.py
+++ b/src/zarr/core/dtype/npy/float.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeGuard, overload
 import numpy as np
 
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasEndianness,
@@ -26,6 +25,7 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/int.py
+++ b/src/zarr/core/dtype/npy/int.py
@@ -15,7 +15,6 @@ from typing import (
 import numpy as np
 
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasEndianness,
@@ -30,6 +29,7 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/string.py
+++ b/src/zarr/core/dtype/npy/string.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from zarr.core.common import NamedConfig
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasEndianness,
@@ -33,6 +32,7 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/structured.py
+++ b/src/zarr/core/dtype/npy/structured.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from zarr.core.common import NamedConfig
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasItemSize,
@@ -23,6 +22,7 @@ from zarr.core.dtype.npy.common import (
     check_json_str,
 )
 from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/npy/time.py
+++ b/src/zarr/core/dtype/npy/time.py
@@ -19,7 +19,6 @@ from typing_extensions import ReadOnly
 
 from zarr.core.common import NamedRequiredConfig
 from zarr.core.dtype.common import (
-    DataTypeValidationError,
     DTypeConfig_V2,
     DTypeJSON,
     HasEndianness,
@@ -34,6 +33,7 @@ from zarr.core.dtype.npy.common import (
     get_endianness_from_numpy_dtype,
 )
 from zarr.core.dtype.wrapper import TBaseDType, ZDType
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from zarr.core.common import JSON, ZarrFormat

--- a/src/zarr/core/dtype/registry.py
+++ b/src/zarr/core/dtype/registry.py
@@ -6,15 +6,13 @@ from typing import TYPE_CHECKING, Self
 
 import numpy as np
 
-from zarr.core.dtype.common import (
-    DataTypeValidationError,
-    DTypeJSON,
-)
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
 
     from zarr.core.common import ZarrFormat
+    from zarr.core.dtype.common import DTypeJSON
     from zarr.core.dtype.wrapper import TBaseDType, TBaseScalar, ZDType
 
 

--- a/src/zarr/dtype.py
+++ b/src/zarr/dtype.py
@@ -2,7 +2,6 @@ from zarr.core.dtype import (
     Bool,
     Complex64,
     Complex128,
-    DataTypeValidationError,
     DateTime64,
     DateTime64JSON_V2,
     DateTime64JSON_V3,
@@ -50,7 +49,6 @@ __all__ = [
     "Bool",
     "Complex64",
     "Complex128",
-    "DataTypeValidationError",
     "DateTime64",
     "DateTime64JSON_V2",
     "DateTime64JSON_V3",
@@ -90,3 +88,19 @@ __all__ = [
     "data_type_registry",
     "parse_dtype",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "DataTypeValidationError":
+        import warnings
+
+        from zarr.errors import DataTypeValidationError, ZarrDeprecationWarning
+
+        warnings.warn(
+            "Importing DataTypeValidationError from zarr.dtype is deprecated. "
+            "Use zarr.errors.DataTypeValidationError instead.",
+            ZarrDeprecationWarning,
+            stacklevel=2,
+        )
+        return DataTypeValidationError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/zarr/dtype.py
+++ b/src/zarr/dtype.py
@@ -44,11 +44,13 @@ from zarr.core.dtype import (
     parse_data_type,  # noqa: F401
     parse_dtype,
 )
+from zarr.core.dtype.common import DTypeSpec_V2, check_dtype_spec_v2
 
 __all__ = [
     "Bool",
     "Complex64",
     "Complex128",
+    "DTypeSpec_V2",
     "DateTime64",
     "DateTime64JSON_V2",
     "DateTime64JSON_V3",
@@ -85,6 +87,7 @@ __all__ = [
     "VariableLengthUTF8",
     "VariableLengthUTF8JSON_V2",
     "ZDType",
+    "check_dtype_spec_v2",
     "data_type_registry",
     "parse_dtype",
 ]

--- a/src/zarr/errors.py
+++ b/src/zarr/errors.py
@@ -7,6 +7,7 @@ __all__ = [
     "ContainsArrayAndGroupError",
     "ContainsArrayError",
     "ContainsGroupError",
+    "DataTypeValidationError",
     "GroupNotFoundError",
     "MetadataValidationError",
     "NegativeStepError",
@@ -82,6 +83,9 @@ class ContainsArrayAndGroupError(BaseZarrError):
         "Only one of these files may be present in a given directory / prefix. "
         "Remove the .zarray file, or the .zgroup file, or both."
     )
+
+
+class DataTypeValidationError(ValueError): ...
 
 
 class MetadataValidationError(BaseZarrError):

--- a/src/zarr/types.py
+++ b/src/zarr/types.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from zarr.core.array import Array, AsyncArray
+from zarr.core.common import JSON, ZarrFormat
+from zarr.core.dtype.common import DTypeConfig_V2, DTypeJSON
 from zarr.core.metadata.v2 import ArrayV2Metadata
 from zarr.core.metadata.v3 import ArrayV3Metadata
 
@@ -21,3 +23,16 @@ type ArrayV2 = Array[ArrayV2Metadata]
 
 type ArrayV3 = Array[ArrayV3Metadata]
 """A Zarr format 3 `Array`"""
+
+__all__ = (
+    "JSON",
+    "AnyArray",
+    "AnyAsyncArray",
+    "ArrayV2",
+    "ArrayV3",
+    "AsyncArrayV2",
+    "AsyncArrayV3",
+    "DTypeConfig_V2",
+    "DTypeJSON",
+    "ZarrFormat",
+)

--- a/tests/package_with_entrypoint/__init__.py
+++ b/tests/package_with_entrypoint/__init__.py
@@ -9,8 +9,8 @@ import zarr.core.buffer
 from zarr.abc.codec import ArrayBytesCodec, CodecInput, CodecPipeline
 from zarr.codecs import BytesCodec
 from zarr.core.buffer import Buffer, NDBuffer
-from zarr.core.dtype.common import DataTypeValidationError, DTypeJSON, DTypeSpec_V2
 from zarr.core.dtype.npy.bool import Bool
+from zarr.errors import DataTypeValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from zarr.core.array_spec import ArraySpec
     from zarr.core.common import ZarrFormat
+    from zarr.core.dtype.common import DTypeJSON, DTypeSpec_V2
 
 
 class TestEntrypointCodec(ArrayBytesCodec):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,13 +1,17 @@
 """Test errors"""
 
+import pytest
+
 from zarr.errors import (
     ArrayNotFoundError,
     ContainsArrayAndGroupError,
     ContainsArrayError,
     ContainsGroupError,
+    DataTypeValidationError,
     GroupNotFoundError,
     MetadataValidationError,
     NodeTypeValidationError,
+    ZarrDeprecationWarning,
 )
 
 
@@ -76,3 +80,22 @@ def test_node_type_validation_error() -> None:
     """
     err = NodeTypeValidationError("a", "b", "c")
     assert str(err) == "Invalid value for 'a'. Expected 'b'. Got 'c'."
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "zarr.core.dtype.common",
+        "zarr.core.dtype",
+        "zarr.dtype",
+    ],
+)
+def test_data_type_validation_error_deprecated_import(module_name: str) -> None:
+    import importlib
+
+    module = importlib.import_module(module_name)
+
+    with pytest.warns(ZarrDeprecationWarning, match=f"{module_name}"):
+        cls = module.DataTypeValidationError
+
+    assert cls is DataTypeValidationError


### PR DESCRIPTION
Modify custom dtype example to use only public API.  As part of this effort, move/deprecate any types or functions currently inaccessible from the public API, but should be.

- Internally change all imports of `DataTypeValidationError` to import from `zarr.errors` and deprecate imports of `DataTypeValidationError` from all other modules.

TODO:

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [x] Changes documented as a new file in `changes/`
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
