### PR TITLE
fix: copy attributes passed from the user to avoid mutation

### DIFF
--- a/changes/4059.bugfix.md
+++ b/changes/4059.bugfix.md
@@ -1,0 +1,1 @@
+Prevents mutation of the attributes dict provided by the user by copying them instead of keeping the reference

--- a/src/zarr/core/group.py
+++ b/src/zarr/core/group.py
@@ -105,7 +105,7 @@ def parse_attributes(data: Any) -> dict[str, Any]:
     if data is None:
         return {}
     elif isinstance(data, dict) and all(isinstance(k, str) for k in data):
-        return data
+        return dict(data)
     msg = f"Expected dict with string keys. Got {type(data)} instead."
     raise TypeError(msg)
 

--- a/src/zarr/core/metadata/common.py
+++ b/src/zarr/core/metadata/common.py
@@ -10,4 +10,4 @@ def parse_attributes(data: dict[str, JSON] | None) -> dict[str, JSON]:
     if data is None:
         return {}
 
-    return data
+    return dict(data)


### PR DESCRIPTION
This PR fixes #4059 


TODO:
* [x] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes)
