### PR TITLE
Fix save/load for scalar arrays

### DIFF
--- a/changes/3469.bugfix.md
+++ b/changes/3469.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `save_array`, `Group.__setitem__`, and `load` for 0-dimensional arrays.

--- a/src/zarr/api/asynchronous.py
+++ b/src/zarr/api/asynchronous.py
@@ -304,7 +304,7 @@ async def load(
 
     obj = await open(store=store, path=path, zarr_format=zarr_format)
     if isinstance(obj, AsyncArray):
-        return await obj.getitem(slice(None))
+        return await obj.getitem(Ellipsis)
     else:
         raise NotImplementedError("loading groups not yet supported")
 
@@ -482,7 +482,7 @@ async def save_array(
         overwrite=overwrite,
         **kwargs,
     )
-    await new.setitem(slice(None), arr)
+    await new.setitem(Ellipsis, arr)
 
 
 async def save_group(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -396,6 +396,22 @@ def test_save(store: Store, n_args: int, n_kwargs: int, path: None | str) -> Non
         assert group.nmembers() == n_args + n_kwargs
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.array(42, dtype=np.int64),
+        np.array("teststr", dtype=np.bytes_),
+    ],
+)
+@pytest.mark.filterwarnings("ignore::zarr.errors.UnstableSpecificationWarning")
+def test_group_setitem_loads_scalar_arrays(sync_store: Store, data: np.ndarray) -> None:
+    root = zarr.open_group(store=sync_store)
+    root["test"] = data
+
+    assert_array_equal(root["test"][...], data)
+    assert_array_equal(zarr.load(store=sync_store, path="test"), data)
+
+
 def test_save_errors() -> None:
     with pytest.raises(ValueError, match="at least one array must be provided"):
         # no arrays provided


### PR DESCRIPTION
Fixes #3469.

`save_array()` and `load()` used `slice(None)` as the full-array selection. That works for arrays with at least one dimension, but for 0-dimensional arrays it is interpreted as one index and raises `IndexError: too many indices for array; expected 0, got 1`.

This changes both paths to use `Ellipsis`, which still means full-array selection for N-dimensional arrays and normalizes to an empty selection for scalar arrays. The regression test covers `Group.__setitem__` with both an integer scalar array and a bytes scalar array, then verifies direct indexing and `zarr.load()`.

TODO:
* [x] Add unit tests and/or doctests in docstrings
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)

Local verification:
* `uv run --frozen pytest tests/test_api.py::test_group_setitem_loads_scalar_arrays -q`
* `uv run --frozen pytest tests/test_api.py::test_save tests/test_api.py::test_load_array tests/test_api.py::test_load_local tests/test_api.py::test_load_zip -q`
* `uv run --frozen ruff check src/zarr/api/asynchronous.py tests/test_api.py`
* `uv run --frozen ruff format --check src/zarr/api/asynchronous.py tests/test_api.py`
* `uv run --frozen python -m compileall -q src/zarr/api/asynchronous.py tests/test_api.py`
* `git diff --check`