### PR TITLE
docs: add reviewer guidance and author attestation to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!-- The PR title becomes the squash-merge commit on main. Please use a descriptive,
+     Conventional Commits-style title, e.g. "fix: handle empty chunk in v3 reader".
+     This is the commit type (feat/fix/docs/chore/...), not the changelog category.
+     See https://www.conventionalcommits.org/en/v1.0.0/ -->
+
 ## Summary
 
 [Describe what this PR changes and why, in your own words.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- The PR title becomes the squash-merge commit on main. Please use a descriptive,
-     Conventional Commits-style title, e.g. "fix: handle empty chunk in v3 reader".
+     Conventional Commits-style title, e.g. "fix: handle 0-d arrays in `save_array`".
      This is the commit type (feat/fix/docs/chore/...), not the changelog category.
      See https://www.conventionalcommits.org/en/v1.0.0/ -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,19 @@
-[Description of PR]
+## Summary
 
-TODO:
+[Describe what this PR changes and why, in your own words.]
+
+## For reviewers
+
+[What would you most value a second look at? What are you already confident in? For a refactor, say whether behavior is meant to be unchanged.]
+
+## Author attestation
+
+- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.
+
+AI coding assistance is welcome, but a human must be the author and is responsible for the contents of the PR. The description and any review responses must be in your own words. Please read [AI-assisted contributions](https://zarr.readthedocs.io/en/stable/contributing/#ai-assisted-contributions) before opening.
+
+## TODO
+
 * [ ] Add unit tests and/or doctests in docstrings
 * [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
 * [ ] New/modified features documented in `docs/user-guide/*.md`


### PR DESCRIPTION
This PR seeks to make it clear who is responsible for the changes in a PR in a self-describing way via a simple author-attestation checkbox. It's not a perfect system as we're still figuring out how to adapt to AI assisted coding, but I think a helpful improvement.


TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
