### PR TITLE
docs: document authentication for private remote stores via storage_options

### DIFF
--- a/changes/2995.doc.md
+++ b/changes/2995.doc.md
@@ -1,0 +1,1 @@
+Document how to authenticate to private remote stores (e.g. S3 / MinIO) by passing credentials through `storage_options`, and clarify that credentials such as `key` and `secret` are top-level keys rather than `client_kwargs` entries.

--- a/docs/user-guide/storage.md
+++ b/docs/user-guide/storage.md
@@ -151,6 +151,43 @@ store = zarr.storage.FsspecStore(fs)
 print(store)
 ```
 
+#### Authentication
+
+The examples above use anonymous access (`anon=True`) to a public bucket. To read from or write
+to a **private** bucket — for example a private AWS S3 bucket or a self-hosted, S3-compatible
+service such as [MinIO](https://min.io/) — pass your credentials through `storage_options`. These
+options are forwarded to the underlying fsspec filesystem (for S3 that is
+[`s3fs`](https://s3fs.readthedocs.io/)), so the accepted keys are the ones that filesystem
+understands; for S3 the most common are `key`, `secret`, `token`, and `endpoint_url`:
+
+```python
+import zarr
+
+store = zarr.storage.FsspecStore.from_url(
+    's3://my-private-bucket/path',
+    storage_options={
+        'key': '<ACCESS_KEY_ID>',
+        'secret': '<SECRET_ACCESS_KEY>',
+        # 'token': '<SESSION_TOKEN>',  # optional, for temporary credentials
+        # 'endpoint_url': 'https://my-minio.example.com',  # for S3-compatible services like MinIO
+    },
+)
+group = zarr.open_group(store=store, mode='r')
+```
+
+!!! note
+    Credentials are **top-level** keys in `storage_options`; they map directly to
+    [`s3fs.S3FileSystem`](https://s3fs.readthedocs.io/en/latest/api.html) arguments. Do not nest
+    them inside `client_kwargs` — that dictionary is forwarded to the underlying
+    `aiobotocore`/`aiohttp` client session, which does not accept `key`/`secret` and will raise an
+    error such as `TypeError: ClientSession._request() got an unexpected keyword argument 'secret'`.
+    Use `client_kwargs` only for additional client-session settings such as `region_name`.
+
+If you prefer not to pass credentials explicitly, `s3fs`/`botocore` will also automatically discover
+the standard AWS credential sources — environment variables (`AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`), the shared credentials file (`~/.aws/credentials`), or an instance/role
+profile — in which case the credential keys in `storage_options` can be omitted.
+
 
 ### Memory Store
 

--- a/docs/user-guide/storage.md
+++ b/docs/user-guide/storage.md
@@ -160,7 +160,7 @@ options are forwarded to the underlying fsspec filesystem (for S3 that is
 [`s3fs`](https://s3fs.readthedocs.io/)), so the accepted keys are the ones that filesystem
 understands; for S3 the most common are `key`, `secret`, `token`, and `endpoint_url`:
 
-```python
+```python exec="false" reason="requires private S3 credentials not available in the docs build environment"
 import zarr
 
 store = zarr.storage.FsspecStore.from_url(


### PR DESCRIPTION
## Summary

Closes #2995.

The storage user-guide only showed anonymous (`anon=True`) access examples for remote
stores, leaving users to guess which keys to put inside `storage_options` when accessing
a private S3 bucket or an S3-compatible service like MinIO. A common wrong guess — nesting
credentials inside `client_kwargs` — routes them to the underlying `aiohttp`/`aiobotocore`
`ClientSession`, which produces a cryptic `TypeError: ClientSession._request() got an
unexpected keyword argument 'secret'`.

This PR adds a short **Authentication** subsection under `### Remote Store` that:

1. Shows how to pass `key`, `secret`, `token`, and `endpoint_url` as **top-level** keys in
   `storage_options` (they map directly to `s3fs.S3FileSystem` arguments, not to the inner
   client session).
2. Explains with a `!!! note` admonition exactly why `client_kwargs` is the wrong place for
   credentials (aiohttp `ClientSession` does not accept them), so the connection between the
   error message and the fix is clear.
3. Notes that credentials can be omitted if the standard AWS auto-discovery path is used
   (env vars, `~/.aws/credentials`, instance/role profile).

The code example is a plain (non-executed) `python` block deliberately — the surrounding
examples use `exec="true"` (markdown-exec runs them at build time), but we cannot connect
to a private bucket in CI.

## For reviewers

The main thing I'd like a second look at is whether the `s3fs.S3FileSystem` API description
is accurate and complete enough. I verified the top-level keys (`key`, `secret`, `token`,
`endpoint_url`) by inspecting the installed signature of `s3fs` v2026.4.0 in a local dev
environment, but I'd welcome a check from someone more familiar with the fsspec/s3fs
interaction. I'm confident the prose style matches the existing admonition usage in the doc,
and that the non-executed block won't break the CI build.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change
  and can explain why each is correct.

## TODO

* [x] ~~Add unit tests and/or doctests in docstrings~~ — N/A, docs-only change
* [x] ~~Add docstrings and API docs for any new/modified user-facing classes and functions~~ — N/A
* [x] New/modified features documented in `docs/user-guide/*.md`
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [x] ~~Test coverage is 100% (Codecov passes)~~ — N/A, no code changed
