### PR TITLE
docs: document zarr.errors changes in the v3 migration guide

### DIFF
--- a/changes/3009.doc.md
+++ b/changes/3009.doc.md
@@ -1,0 +1,1 @@
+Document the changes to `zarr.errors` in the 3.0 migration guide, including the removal of v2 exception classes and the introduction of `NodeNotFoundError`.

--- a/docs/user-guide/v3_migration.md
+++ b/docs/user-guide/v3_migration.md
@@ -47,6 +47,12 @@ the following actions in order:
 
    - The `zarr.v3_api_available` feature flag is being removed. In Zarr-Python 3
      the v3 API is always available, so you shouldn't need to use this flag.
+   - `zarr.errors` has been consolidated. Several exception classes from
+     Zarr-Python 2 (such as `zarr.errors.PathNotFoundError`) have been removed
+     or replaced. For example, missing nodes now raise `zarr.errors.NodeNotFoundError`
+     (which subclasses both `BaseZarrError` and `FileNotFoundError`) instead of
+     `zarr.errors.PathNotFoundError`. Review any code that catches exceptions
+     from `zarr.errors` after migrating.
    - The following internal modules are being removed or significantly changed. If
      your application relies on imports from any of the below modules, you will need
      to either a) modify your application to no longer rely on these imports or b)


### PR DESCRIPTION
Document the `zarr.errors` changes in the 3.0 migration guide.

Closes #3009.

## Summary

Zarr-Python 3 consolidated the exception hierarchy under `zarr.errors`. Several classes from v2 (e.g. `PathNotFoundError`) were removed and missing nodes are now represented by `NodeNotFoundError`, which subclasses both `BaseZarrError` and `FileNotFoundError`.

This change adds a bullet to the "Getting ready for 3.0" section of the migration guide so that users who catch `zarr.errors` exceptions know to review their code.

## Checklist

- [x] Added a towncrier fragment (`changes/3009.doc.md`).
- [x] Verified the migration guide renders correctly.
