### PR TITLE
fix: keep element order when writing F-contiguous chunks with vlen codecs

### DIFF
--- a/changes/4116.bugfix.md
+++ b/changes/4116.bugfix.md
@@ -1,1 +1,1 @@
-Fixed writing Fortran-ordered (F-contiguous) arrays to variable-length string and bytes arrays. The vlen codec wrappers now pass a C-contiguous chunk to numcodecs, whose `order='A'` flattening previously stored the elements of an F-contiguous chunk in transposed order.
+Fixed writing Fortran-ordered (F-contiguous) arrays through the variable-length string and bytes codecs and through numcodecs array-array filters such as `Delta`, `FixedScaleOffset` and `PackBits`. Chunks are now passed to numcodecs as C-contiguous arrays, so elements are no longer stored in transposed order.

--- a/changes/4116.bugfix.md
+++ b/changes/4116.bugfix.md
@@ -1,0 +1,1 @@
+Fixed writing Fortran-ordered (F-contiguous) arrays to variable-length string and bytes arrays. The vlen codec wrappers now pass a C-contiguous chunk to numcodecs, whose `order='A'` flattening previously stored the elements of an F-contiguous chunk in transposed order.

--- a/src/zarr/codecs/numcodecs/_codecs.py
+++ b/src/zarr/codecs/numcodecs/_codecs.py
@@ -162,7 +162,9 @@ class _NumcodecsArrayArrayCodec(_NumcodecsCodec, ArrayArrayCodec):
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out.reshape(chunk_spec.shape))
 
     async def _encode_single(self, chunk_data: NDBuffer, chunk_spec: ArraySpec) -> NDBuffer:
-        chunk_ndarray = chunk_data.as_ndarray_like()
+        # numcodecs codecs flatten with order="A", so an F-contiguous chunk
+        # would be encoded in transposed element order (gh-3558)
+        chunk_ndarray = np.ascontiguousarray(chunk_data.as_ndarray_like())
         out = await asyncio.to_thread(self._codec.encode, chunk_ndarray)
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out)
 
@@ -177,7 +179,9 @@ class _NumcodecsArrayBytesCodec(_NumcodecsCodec, ArrayBytesCodec):
         return chunk_spec.prototype.nd_buffer.from_ndarray_like(out.reshape(chunk_spec.shape))
 
     async def _encode_single(self, chunk_data: NDBuffer, chunk_spec: ArraySpec) -> Buffer:
-        chunk_ndarray = chunk_data.as_ndarray_like()
+        # numcodecs codecs flatten with order="A", so an F-contiguous chunk
+        # would be encoded in transposed element order (gh-3558)
+        chunk_ndarray = np.ascontiguousarray(chunk_data.as_ndarray_like())
         out = await asyncio.to_thread(self._codec.encode, chunk_ndarray)
         return chunk_spec.prototype.buffer.from_bytes(out)
 

--- a/src/zarr/codecs/vlen_utf8.py
+++ b/src/zarr/codecs/vlen_utf8.py
@@ -67,8 +67,10 @@ class VLenUTF8Codec(ArrayBytesCodec):
         chunk_spec: ArraySpec,
     ) -> Buffer | None:
         assert isinstance(chunk_array, NDBuffer)
+        # numcodecs vlen codecs flatten with order="A", so an F-contiguous chunk
+        # would be encoded in transposed element order (gh-3558)
         return chunk_spec.prototype.buffer.from_bytes(
-            _vlen_utf8_codec.encode(chunk_array.as_numpy_array())
+            _vlen_utf8_codec.encode(np.ascontiguousarray(chunk_array.as_numpy_array()))
         )
 
     async def _encode_single(
@@ -125,8 +127,10 @@ class VLenBytesCodec(ArrayBytesCodec):
         chunk_spec: ArraySpec,
     ) -> Buffer | None:
         assert isinstance(chunk_array, NDBuffer)
+        # numcodecs vlen codecs flatten with order="A", so an F-contiguous chunk
+        # would be encoded in transposed element order (gh-3558)
         return chunk_spec.prototype.buffer.from_bytes(
-            _vlen_bytes_codec.encode(chunk_array.as_numpy_array())
+            _vlen_bytes_codec.encode(np.ascontiguousarray(chunk_array.as_numpy_array()))
         )
 
     async def _encode_single(

--- a/tests/test_codecs/test_numcodecs.py
+++ b/tests/test_codecs/test_numcodecs.py
@@ -163,6 +163,40 @@ def test_generic_filter(
     np.testing.assert_array_equal(data, b[:, :])
 
 
+@pytest.mark.parametrize(
+    ("codec_class", "codec_config", "dtype"),
+    [
+        (_numcodecs.Delta, {"dtype": "int64"}, "int64"),
+        (_numcodecs.FixedScaleOffset, {"offset": 0, "scale": 1}, "int64"),
+        (_numcodecs.PackBits, {}, "bool"),
+    ],
+    ids=["delta", "fixedscaleoffset", "packbits"],
+)
+def test_generic_filter_f_contiguous(
+    codec_class: type[_numcodecs._NumcodecsArrayArrayCodec],
+    codec_config: dict[str, JSON],
+    dtype: str,
+) -> None:
+    # gh-3558: F-contiguous chunks were handed to numcodecs filters as is, and
+    # numcodecs flattens in memory order, so the elements came back transposed
+    if dtype == "bool":
+        data = np.asfortranarray(np.tril(np.ones((16, 16), dtype=bool)))
+    else:
+        data = np.asfortranarray(np.arange(256, dtype=dtype).reshape(16, 16))
+
+    a = create_array(
+        {},
+        shape=data.shape,
+        chunks=(16, 16),
+        dtype=data.dtype,
+        fill_value=0,
+        filters=[codec_class(**codec_config)],
+    )
+
+    a[:, :] = data
+    np.testing.assert_array_equal(data, a[:, :])
+
+
 def test_generic_filter_bitround() -> None:
     data = np.linspace(0, 1, 256, dtype="float32").reshape((16, 16))
 

--- a/tests/test_codecs/test_vlen.py
+++ b/tests/test_codecs/test_vlen.py
@@ -9,7 +9,7 @@ from zarr.abc.codec import Codec, SupportsSyncCodec
 from zarr.abc.store import Store
 from zarr.codecs import ZstdCodec
 from zarr.codecs.vlen_utf8 import VLenBytesCodec, VLenUTF8Codec
-from zarr.core.dtype import get_data_type_from_native_dtype
+from zarr.core.dtype import VariableLengthBytes, get_data_type_from_native_dtype
 from zarr.core.metadata.v3 import ArrayV3Metadata
 from zarr.storage import StorePath
 
@@ -65,6 +65,35 @@ def test_vlen_string(
     assert np.array_equal(data, b[:, :])
     assert b.metadata.data_type == get_data_type_from_native_dtype(data.dtype)
     assert a.dtype == data.dtype
+
+
+@pytest.mark.parametrize("store", ["memory"], indirect=["store"])
+@pytest.mark.parametrize("chunks", [(3, 3), (2, 2)])
+def test_vlen_string_f_contiguous(store: Store, chunks: tuple[int, int]) -> None:
+    # gh-3558: F-contiguous chunks were encoded in transposed element order
+    data = np.asarray(
+        np.array([f"S{i:05}" for i in range(9)], dtype=object).reshape(3, 3), order="F"
+    )
+    sp = StorePath(store, path="string-f-contiguous")
+    a = zarr.create_array(sp, shape=data.shape, chunks=chunks, dtype=str, fill_value="")
+    a[:, :] = data
+    assert np.array_equal(data, np.asarray(a[:, :], dtype=object))
+
+
+@pytest.mark.filterwarnings("ignore::zarr.core.dtype.common.UnstableSpecificationWarning")
+@pytest.mark.parametrize("store", ["memory"], indirect=["store"])
+@pytest.mark.parametrize("chunks", [(3, 3), (2, 2)])
+def test_vlen_bytes_f_contiguous(store: Store, chunks: tuple[int, int]) -> None:
+    # gh-3558: F-contiguous chunks were encoded in transposed element order
+    data = np.asarray(
+        np.array([b"%05d" % i for i in range(9)], dtype=object).reshape(3, 3), order="F"
+    )
+    sp = StorePath(store, path="bytes-f-contiguous")
+    a = zarr.create_array(
+        sp, shape=data.shape, chunks=chunks, dtype=VariableLengthBytes(), fill_value=b""
+    )
+    a[:, :] = data
+    assert np.array_equal(data, np.asarray(a[:, :], dtype=object))
 
 
 def test_vlen_utf8_codec_supports_sync() -> None:


### PR DESCRIPTION
## Summary

Fixes #3558. Writing an F-contiguous object-dtype array to a chunked string or bytes array scrambles the stored data whenever a chunk is covered exactly by the selection: the write path passes the chunk view to numcodecs without a copy, numcodecs flattens it with order='A' (column-major for F-contiguous input), and decode reshapes in C order. The wrappers in codecs/vlen_utf8.py now pass np.ascontiguousarray(...) to the codec, a no-op for C-contiguous chunks and a copy of the object-pointer array otherwise. Regression tests cover vlen-utf8 and vlen-bytes at both the exact-cover and partial-chunk shapes; the exact-cover cases fail on current main.

## For reviewers

The one design question is the fix layer: this could live in numcodecs instead (change the flatten to C order), but that touches the v2 out= decode path where the old behavior was self-consistent for F-ordered arrays, so I kept the change on the zarr side where decode already commits to C order. The repro and codec-level probe are in #3558.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

## TODO

* [x] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions (no user-facing API change)
* [ ] New/modified features documented in `docs/user-guide/*.md` (not applicable)
* [x] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
