### PR TITLE
test: consolidate vlen F-contiguous regression tests

### DIFF
--- a/tests/test_codecs/test_vlen.py
+++ b/tests/test_codecs/test_vlen.py
@@ -9,7 +9,7 @@ from zarr.abc.codec import Codec, SupportsSyncCodec
 from zarr.abc.store import Store
 from zarr.codecs import ZstdCodec
 from zarr.codecs.vlen_utf8 import VLenBytesCodec, VLenUTF8Codec
-from zarr.core.dtype import VariableLengthBytes, get_data_type_from_native_dtype
+from zarr.core.dtype import get_data_type_from_native_dtype
 from zarr.core.metadata.v3 import ArrayV3Metadata
 from zarr.storage import StorePath
 
@@ -67,30 +67,29 @@ def test_vlen_string(
     assert a.dtype == data.dtype
 
 
-@pytest.mark.parametrize("store", ["memory"], indirect=["store"])
-@pytest.mark.parametrize("chunks", [(3, 3), (2, 2)])
-def test_vlen_string_f_contiguous(store: Store, chunks: tuple[int, int]) -> None:
-    # gh-3558: F-contiguous chunks were encoded in transposed element order
-    data = np.asarray(
-        np.array([f"S{i:05}" for i in range(9)], dtype=object).reshape(3, 3), order="F"
-    )
-    sp = StorePath(store, path="string-f-contiguous")
-    a = zarr.create_array(sp, shape=data.shape, chunks=chunks, dtype=str, fill_value="")
-    a[:, :] = data
-    assert np.array_equal(data, np.asarray(a[:, :], dtype=object))
-
-
 @pytest.mark.filterwarnings("ignore::zarr.core.dtype.common.UnstableSpecificationWarning")
 @pytest.mark.parametrize("store", ["memory"], indirect=["store"])
-@pytest.mark.parametrize("chunks", [(3, 3), (2, 2)])
-def test_vlen_bytes_f_contiguous(store: Store, chunks: tuple[int, int]) -> None:
-    # gh-3558: F-contiguous chunks were encoded in transposed element order
-    data = np.asarray(
-        np.array([b"%05d" % i for i in range(9)], dtype=object).reshape(3, 3), order="F"
-    )
-    sp = StorePath(store, path="bytes-f-contiguous")
+@pytest.mark.parametrize(
+    ("dtype", "fill_value", "elements"),
+    [
+        pytest.param("string", "", [f"S{i:05}" for i in range(9)], id="string"),
+        pytest.param("variable_length_bytes", b"", [b"%05d" % i for i in range(9)], id="bytes"),
+    ],
+)
+def test_vlen_f_contiguous(
+    store: Store, dtype: str, fill_value: str | bytes, elements: list[str] | list[bytes]
+) -> None:
+    """An F-contiguous chunk written through a vlen codec round-trips in the original
+    element order rather than the transposed memory order (gh-3558)."""
+    # reshape(order="F") gives an F-contiguous view directly, so the whole-array write
+    # below hands an F-contiguous chunk to the codec; assert it to guard the precondition.
+    data = np.array(elements, dtype=object).reshape((3, 3), order="F")
+    assert data.flags.f_contiguous
+    sp = StorePath(store, path="vlen-f-contiguous")
+    # chunks == shape so the write is a single complete chunk, which the codec pipeline
+    # forwards to the codec untouched; a partial-chunk layout would be recopied to C order.
     a = zarr.create_array(
-        sp, shape=data.shape, chunks=chunks, dtype=VariableLengthBytes(), fill_value=b""
+        sp, shape=data.shape, chunks=data.shape, dtype=dtype, fill_value=fill_value
     )
     a[:, :] = data
     assert np.array_equal(data, np.asarray(a[:, :], dtype=object))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up test-quality cleanup for the gh-3558 fix merged in #4116. No source changes — the fix itself is already on `main`; this only tidies the regression tests it added.

## What and why

The `test_vlen_string_f_contiguous` / `test_vlen_bytes_f_contiguous` tests added in #4116 had a few issues surfaced in review:

- **The `chunks=(2,2)` case never exercised the F-contiguous path.** With `(3,3)` data, a `(2,2)` chunking produces only partial chunks, which `_merge_chunk_array` recopies into a fresh C-order buffer before the codec sees them — so that parametrization gave false coverage confidence. Only the whole-array (`chunks == shape`) case actually hands an F-contiguous buffer to the codec. This PR keeps just that case.
- **The F-order input was built indirectly** (`np.asarray(np.array(...).reshape(3, 3), order="F")`), so a future "simplification" dropping the outer `np.asarray` could silently stop testing the F path. Now it's built directly with `reshape((3, 3), order="F")` and guarded with `assert data.flags.f_contiguous`.
- **The two tests were near copy-paste**, differing only in dtype/fill_value/data — now one test parametrized over `(dtype, fill_value, elements)`, matching the parametrized style of `test_vlen_string` in the same file.
- **Added a docstring** stating the verified behavior.

## Verification

- `pytest tests/test_codecs/test_vlen.py -k f_contiguous` → 2 passed (string + bytes).
- `prek run mypy --all-files`, `ruff check`, `ruff format --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
