### PR TITLE
test: fix broken `test_docstring_consistent_parameters` and mark `xfail`

### DIFF
--- a/tests/test_api/test_synchronous.py
+++ b/tests/test_api/test_synchronous.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import Final
+from typing import TYPE_CHECKING, Any, Final
 
 import pytest
 from numpydoc.docscrape import NumpyDocString
 
+import zarr
 from zarr.api import asynchronous, synchronous
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 MATCHED_EXPORT_NAMES: Final[tuple[str, ...]] = tuple(
     sorted(set(synchronous.__all__) | set(asynchronous.__all__))
@@ -35,3 +39,109 @@ def test_docstrings_match(callable_name: str) -> None:
             if a != b:
                 mismatch.append((idx, (a, b)))
         assert mismatch == []
+
+
+# NOTE: this test used to always pass silently due to a bug — it compared a
+# tuple like ("store", "path") against a dict keyed by single names, so the
+# check never actually ran. Fixed by looping over each name separately.
+# Now that it runs for real, it fails: the docstrings really are inconsistent
+# across create/create_array/create_group/Group.create_array. Marked xfail
+# for now so CI stays green but the issue is tracked, not forgotten.
+# See #4225
+@pytest.mark.xfail(
+    reason=(
+        "Docstrings for shared parameters (store, path, filters, codecs, "
+        "compressors, compressor, chunks, shape, dtype, shards, fill_value) "
+        "are inconsistent across create/create_array/create_group/"
+        "Group.create_array. Test was previously a silent no-op due to a bug; "
+        "now fixed and failing as expected. See #XXXX."
+    ),
+    strict=True,
+)
+@pytest.mark.parametrize(
+    ("parameter_name", "array_creation_routines"),
+    [
+        pytest.param(
+            ("store", "path"),
+            (
+                asynchronous.create_array,
+                synchronous.create_array,
+                asynchronous.create_group,
+                synchronous.create_group,
+                zarr.AsyncGroup.create_array,
+                zarr.Group.create_array,
+            ),
+            id="store-path-create_array_group",
+        ),
+        pytest.param(
+            (
+                "store",
+                "path",
+            ),
+            (
+                asynchronous.create,
+                synchronous.create,
+                zarr.Group.create,
+            ),
+            id="store-path-create",
+        ),
+        pytest.param(
+            (
+                (
+                    "filters",
+                    "codecs",
+                    "compressors",
+                    "compressor",
+                    "chunks",
+                    "shape",
+                    "dtype",
+                    "shards",
+                    "fill_value",
+                )
+            ),
+            (
+                asynchronous.create,
+                synchronous.create,
+                asynchronous.create_array,
+                synchronous.create_array,
+                zarr.AsyncGroup.create_array,
+                zarr.Group.create_array,
+            ),
+            id="encoding-params-create_and_array",
+        ),
+    ],
+)
+def test_docstring_consistent_parameters(
+    parameter_name: tuple[str, ...], array_creation_routines: tuple[Callable[[Any], Any], ...]
+) -> None:
+    """
+    Tests that array and group creation routines document the same parameters consistently.
+    This test inspects the docstrings of sets of callables and generates two dicts:
+
+    - a dict where the keys are parameter descriptions and the values are the names of the routines with those
+    descriptions
+    - a dict where the keys are parameter types and the values are the names of the routines with those types
+
+    If each dict has just 1 value, then the parameter description and type in the docstring must be
+    identical across different routines. But if these dicts have multiple values, then there must be
+    routines that use the same parameter but document it differently, which will trigger a test failure.
+    """
+    descs: dict[tuple[str, ...], tuple[str, ...]] = {}
+    types: dict[str, tuple[str, ...]] = {}
+    for routine in array_creation_routines:
+        key = f"{routine.__module__}.{routine.__qualname__}"
+        docstring = NumpyDocString(routine.__doc__)
+        param_dict = {d.name: d for d in docstring["Parameters"]}
+        for name in parameter_name:
+            if name in param_dict:
+                val = param_dict[name]
+                if tuple(val.desc) in descs:
+                    descs[tuple(val.desc)] = descs[tuple(val.desc)] + (key,)
+                else:
+                    descs[tuple(val.desc)] = (key,)
+                if val.type in types:
+                    types[val.type] = types[val.type] + (key,)
+                else:
+                    types[val.type] = (key,)
+    assert len(descs) <= 1
+    assert len(types) <= 1

--- a/tests/test_api/test_synchronous.py
+++ b/tests/test_api/test_synchronous.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final
+from typing import Final
 
 import pytest
 from numpydoc.docscrape import NumpyDocString
 
-import zarr
 from zarr.api import asynchronous, synchronous
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 MATCHED_EXPORT_NAMES: Final[tuple[str, ...]] = tuple(
     sorted(set(synchronous.__all__) | set(asynchronous.__all__))
@@ -39,90 +35,3 @@ def test_docstrings_match(callable_name: str) -> None:
             if a != b:
                 mismatch.append((idx, (a, b)))
         assert mismatch == []
-
-
-@pytest.mark.parametrize(
-    ("parameter_name", "array_creation_routines"),
-    [
-        pytest.param(
-            ("store", "path"),
-            (
-                asynchronous.create_array,
-                synchronous.create_array,
-                asynchronous.create_group,
-                synchronous.create_group,
-                zarr.AsyncGroup.create_array,
-                zarr.Group.create_array,
-            ),
-            id="store-path-create_array_group",
-        ),
-        pytest.param(
-            (
-                "store",
-                "path",
-            ),
-            (
-                asynchronous.create,
-                synchronous.create,
-                zarr.Group.create,
-            ),
-            id="store-path-create",
-        ),
-        pytest.param(
-            (
-                (
-                    "filters",
-                    "codecs",
-                    "compressors",
-                    "compressor",
-                    "chunks",
-                    "shape",
-                    "dtype",
-                    "shardsfill_value",
-                )
-            ),
-            (
-                asynchronous.create,
-                synchronous.create,
-                asynchronous.create_array,
-                synchronous.create_array,
-                zarr.AsyncGroup.create_array,
-                zarr.Group.create_array,
-            ),
-            id="encoding-params-create_and_array",
-        ),
-    ],
-)
-def test_docstring_consistent_parameters(
-    parameter_name: str, array_creation_routines: tuple[Callable[[Any], Any], ...]
-) -> None:
-    """
-    Tests that array and group creation routines document the same parameters consistently.
-    This test inspects the docstrings of sets of callables and generates two dicts:
-
-    - a dict where the keys are parameter descriptions and the values are the names of the routines with those
-    descriptions
-    - a dict where the keys are parameter types and the values are the names of the routines with those types
-
-    If each dict has just 1 value, then the parameter description and type in the docstring must be
-    identical across different routines. But if these dicts have multiple values, then there must be
-    routines that use the same parameter but document it differently, which will trigger a test failure.
-    """
-    descs: dict[tuple[str, ...], tuple[str, ...]] = {}
-    types: dict[str, tuple[str, ...]] = {}
-    for routine in array_creation_routines:
-        key = f"{routine.__module__}.{routine.__qualname__}"
-        docstring = NumpyDocString(routine.__doc__)
-        param_dict = {d.name: d for d in docstring["Parameters"]}
-        if parameter_name in param_dict:
-            val = param_dict[parameter_name]
-            if tuple(val.desc) in descs:
-                descs[tuple(val.desc)] = descs[tuple(val.desc)] + (key,)
-            else:
-                descs[tuple(val.desc)] = (key,)
-            if val.type in types:
-                types[val.type] = types[val.type] + (key,)
-            else:
-                types[val.type] = (key,)
-    assert len(descs) <= 1
-    assert len(types) <= 1


### PR DESCRIPTION
<!-- The PR title becomes the squash-merge commit on main. Please use a descriptive,
     Conventional Commits-style title, e.g. "fix: handle 0-d arrays in `save_array`".
     This is the commit type (feat/fix/docs/chore/...), not the changelog category.
     See https://www.conventionalcommits.org/en/v1.0.0/ -->

## Summary

Towards #3989 

- ~Removed `test_docstring_consistent_parameters` from `tests/test_api/test_synchronous.py`. as i find its already covered here~
- also `test_docstrings_match` checks almost the exact same thing (name/type/description)- for docstring coverage

https://github.com/zarr-developers/zarr-python/blob/a994a4fc972fed428eab6a26d4f14bb95d22c144/tests/test_api.py#L1437

https://github.com/zarr-developers/zarr-python/blob/a994a4fc972fed428eab6a26d4f14bb95d22c144/tests/test_group.py#L1792

please feel free to point out if i'm missing something

[Describe what this PR changes and why, in your own words.]

## For reviewers

[What would you most value a second look at? What are you already confident in? For a refactor, say whether behavior is meant to be unchanged.]

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

<!-- AI coding assistance is welcome, but a human must be the author and is responsible for the contents of the PR. The description and any review responses must be in your own words. Please read [AI-assisted contributions](https://zarr.readthedocs.io/en/stable/contributing/#ai-assisted-contributions) before opening. -->

## TODO

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
