### PR TITLE
build(zarr-metadata): give the sdist an explicit include allowlist

### DIFF
--- a/packages/zarr-metadata/pyproject.toml
+++ b/packages/zarr-metadata/pyproject.toml
@@ -71,6 +71,26 @@ raw-options = { root = "../..", git_describe_command = "git describe --dirty --t
 [tool.hatch.build.targets.wheel]
 packages = ["src/zarr_metadata"]
 
+# An allowlist, so nothing that merely happens to sit in the package directory
+# — a scratch script, a stray notebook — can ride along in a release. The list
+# keeps an sdist self-testing and self-documenting: every fixture this suite
+# reads is a JSON file sitting next to the test module that loads it, so
+# `/tests` is the whole test dependency, and `/docs` plus `/mkdocs.yml` are a
+# self-contained site (mkdocstrings reads `src`, nothing reaches outside the
+# package) so `just docs-check` runs from an unpacked sdist too. `changes/`
+# and `.readthedocs.yaml` are deliberately absent: towncrier fragments are
+# repo bookkeeping, and the RTD config addresses paths from the repo root.
+# `pyproject.toml`, `README.md` and `LICENSE.txt` are added by hatchling itself.
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+    "/docs",
+    "/mkdocs.yml",
+    "/justfile",
+    "/CHANGELOG.md",
+]
+
 [tool.ruff]
 extend = "../../pyproject.toml"
 target-version = "py311"


### PR DESCRIPTION

claude wrote this, original PR against my fork is here: https://github.com/d-v-b/zarr-python/pull/284

this change ensures that we have an allowlist for the contents of the source distribution (sdist) when we publish. without this configuration, anything in the package root could get sucked into the sdist and then published, which opens a lot of bad outcomes.

## Summary

build(zarr-metadata): the sdist ships an allowlist, not whatever is lying around

hatchling had no sdist configuration here either, so a source distribution carried everything in the package directory. Building from a working tree with scratch files in it put `.env.local`, a notebook and a `__scratch/` dump in the tarball. A tagged release builds from a fresh CI checkout and so was never actually at risk, but nothing made that a property of the package rather than of the runner.

The list is derived from this package rather than copied from zarr-indexing, which needed `docs/snippets` and `examples/` because its suite executes them. Nothing here does: every fixture is a JSON file next to the test module that reads it, so `/tests` is the whole test dependency. `/docs` and `/mkdocs.yml` ride along because they are self-contained — mkdocstrings reads `src` and the config reaches nowhere outside the package — so the sdist documents itself as well as tests itself. `changes/` and `.readthedocs.yaml` are left out: towncrier fragments are repo bookkeeping, and the RTD config addresses paths from the repo root, where an unpacked sdist is not.

Verified by unpacking the built sdist into a bare venv and working from there: 595 tests pass and `mkdocs build --strict` succeeds.

Assisted-by: ClaudeCode:claude-opus-5

## For reviewers

[What would you most value a second look at? What are you already confident in? For a refactor, say whether behavior is meant to be unchanged.]

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

<!-- AI coding assistance is welcome, but a human must be the author and is responsible for the contents of the PR. The description and any review responses must be in your own words. Please read [AI-assisted contributions](https://zarr.readthedocs.io/en/stable/contributing/#ai-assisted-contributions) before opening. -->

## TODO

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
