### PR TITLE
fix(docs): build subpackage docs from the package directory

### DIFF
--- a/packages/zarr-http-server/.readthedocs.yaml
+++ b/packages/zarr-http-server/.readthedocs.yaml
@@ -24,7 +24,20 @@ build:
       - pip install ./packages/zarr-http-server --group packages/zarr-http-server/pyproject.toml:docs
     build:
       html:
-        - mkdocs build --strict -f packages/zarr-http-server/mkdocs.yml --site-dir $READTHEDOCS_OUTPUT/html
+        # Build from inside the package rather than pointing `-f` at its config
+        # from the repo root. mkdocs resolves some settings relative to the
+        # current working directory rather than to the config file, so building
+        # from elsewhere looks for them in the wrong place -- and silently, since
+        # the paths are valid, just wrong. zarr-indexing hit this: with
+        # `pymdownx.snippets` and a relative `base_path`, its snippets were
+        # searched for under the repo-root docs/ and the build failed with
+        # SnippetMissingError, while `just docs-check` passed because it runs
+        # from here. Building from the package directory makes this identical to
+        # the local and CI invocations, so a green build there means a green
+        # build here.
+        #
+        # $READTHEDOCS_OUTPUT is absolute, so the cd does not affect it.
+        - cd packages/zarr-http-server && mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html
 
 mkdocs:
   configuration: packages/zarr-http-server/mkdocs.yml

--- a/packages/zarr-indexing/.readthedocs.yaml
+++ b/packages/zarr-indexing/.readthedocs.yaml
@@ -24,7 +24,20 @@ build:
       - pip install ./packages/zarr-indexing --group packages/zarr-indexing/pyproject.toml:docs
     build:
       html:
-        - mkdocs build --strict -f packages/zarr-indexing/mkdocs.yml --site-dir $READTHEDOCS_OUTPUT/html
+        # Build from inside the package rather than pointing `-f` at its config
+        # from the repo root. mkdocs resolves some settings relative to the
+        # current working directory rather than to the config file, so building
+        # from elsewhere looks for them in the wrong place -- and silently, since
+        # the paths are valid, just wrong. zarr-indexing hit this: with
+        # `pymdownx.snippets` and a relative `base_path`, its snippets were
+        # searched for under the repo-root docs/ and the build failed with
+        # SnippetMissingError, while `just docs-check` passed because it runs
+        # from here. Building from the package directory makes this identical to
+        # the local and CI invocations, so a green build there means a green
+        # build here.
+        #
+        # $READTHEDOCS_OUTPUT is absolute, so the cd does not affect it.
+        - cd packages/zarr-indexing && mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html
 
 mkdocs:
   configuration: packages/zarr-indexing/mkdocs.yml

--- a/packages/zarr-metadata/.readthedocs.yaml
+++ b/packages/zarr-metadata/.readthedocs.yaml
@@ -24,7 +24,20 @@ build:
       - pip install ./packages/zarr-metadata --group packages/zarr-metadata/pyproject.toml:docs
     build:
       html:
-        - mkdocs build --strict -f packages/zarr-metadata/mkdocs.yml --site-dir $READTHEDOCS_OUTPUT/html
+        # Build from inside the package rather than pointing `-f` at its config
+        # from the repo root. mkdocs resolves some settings relative to the
+        # current working directory rather than to the config file, so building
+        # from elsewhere looks for them in the wrong place -- and silently, since
+        # the paths are valid, just wrong. zarr-indexing hit this: with
+        # `pymdownx.snippets` and a relative `base_path`, its snippets were
+        # searched for under the repo-root docs/ and the build failed with
+        # SnippetMissingError, while `just docs-check` passed because it runs
+        # from here. Building from the package directory makes this identical to
+        # the local and CI invocations, so a green build there means a green
+        # build here.
+        #
+        # $READTHEDOCS_OUTPUT is absolute, so the cd does not affect it.
+        - cd packages/zarr-metadata && mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html
 
 mkdocs:
   configuration: packages/zarr-metadata/mkdocs.yml


### PR DESCRIPTION
My description: this unbreaks docs builds for subpackages by ensuring that RTD builds in the subpackage directory. Claude wrote the fix.

AI description:

Read the Docs pointed `-f` at each package's mkdocs.yml from the repo root. mkdocs resolves some settings relative to the current working directory rather than to the config file, so building from elsewhere looks for them in the wrong place -- and silently, because the paths are valid, just wrong.

zarr-indexing hit this at v0.2.0: `pymdownx.snippets` has a relative `base_path` of `[docs, examples]`, so `--8<-- "snippets/canonical_slice.py"` resolved against the repo root and searched zarr-python's own docs/ rather than the package's. The build failed with SnippetMissingError while `just docs-check` passed, because that runs from the package directory.

Building from the package directory makes the Read the Docs invocation identical to the local and CI ones, so a green build there means a green build here. $READTHEDOCS_OUTPUT is absolute, so the cd does not affect where the site lands.

Applied to all three packages. Only zarr-indexing is failing today; zarr-metadata and zarr-http-server do not use snippets, so for them this is preventive -- the hazard is any config resolved against the working directory, and it would show up only on Read the Docs.

Assisted-by: ClaudeCode:claude-opus-5

## For reviewers

[What would you most value a second look at? What are you already confident in? For a refactor, say whether behavior is meant to be unchanged.]

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

<!-- AI coding assistance is welcome, but a human must be the author and is responsible for the contents of the PR. The description and any review responses must be in your own words. Please read [AI-assisted contributions](https://zarr.readthedocs.io/en/stable/contributing/#ai-assisted-contributions) before opening. -->

## TODO

* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
