### PR TITLE
fix: make the nightly hypothesis failure alarm able to file issues

### DIFF
--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -25,6 +25,9 @@ jobs:
 
   hypothesis:
     name: Slow Hypothesis Tests
+    permissions:
+      contents: read
+      issues: write
     environment:
       name: codecov-upload
       deployment: false
@@ -83,6 +86,7 @@ jobs:
       id: status
       env:
         HATCH_ENV: test.py${{ matrix.python-version }}-${{ matrix.dependency-set }}
+        PYTEST_ADDOPTS: "--report-log=output-${{ matrix.python-version }}-log.jsonl"
       run: |
         echo "Using Hypothesis profile: $HYPOTHESIS_PROFILE"
         hatch env run --env "$HATCH_ENV" run-hypothesis
@@ -113,4 +117,4 @@ jobs:
       with:
         log-path: output-${{ matrix.python-version }}-log.jsonl
         issue-title: "Nightly Hypothesis tests failed"
-        issue-label: "topic-hypothesis"
+        issue-label: "automated issue"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ test = [
     "pytest-accept==0.3.0",
     "numpydoc==1.10.0",
     "hypothesis==6.165.2",
+    "pytest-reportlog==0.4.0",
     "pytest-xdist==3.8.0",
     "pytest-benchmark==5.2.3",
     "pytest-codspeed==5.0.3",


### PR DESCRIPTION
## Summary

Fixes #4273. The nightly hypothesis workflow's failure-reporting step has never been able to file its "Nightly Hypothesis tests failed" issue. Three small changes make it work:

- **Write the report log the action reads**: `pytest-reportlog` added to the `test` dependency group and `--report-log` passed via `PYTEST_ADDOPTS` on the test step (the reporting step was adapted from xarray, where the pytest invocation carries this flag).
- **Grant the job `issues: write`**: the workflow-level `contents: read` from #3742 leaves the token unable to create issues; this uses the same job-level pattern as `links.yml` and `issue-metrics.yml`, whose auto-issues do land.
- **Use the existing `automated issue` label**: the configured `topic-hypothesis` label doesn't exist, and `gh issue new` errors on unknown labels rather than creating them. `automated issue` is what the Link Checker reports already use.

Demonstrated on a fork at this exact configuration: a forced nightly-style failure auto-files the issue ([run](https://github.com/glaziermag/zarr-python/actions/runs/32308238989) → [auto-created issue](https://github.com/glaziermag/zarr-python/issues/2), label applied), and the suite stays green with reportlog enabled ([run](https://github.com/glaziermag/zarr-python/actions/runs/32308240938)).

Prepared with Claude (AI) and submitted at my direction, per the invitation on #4273.

## For reviewers

Two choices you may want differently: a dedicated `topic-hypothesis` label instead of reusing `automated issue` (it would need creating before merge), and whether the flag should live in the `run-hypothesis` hatch script rather than `PYTEST_ADDOPTS` on the workflow step.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

## TODO

* [x] GitHub Actions have all passed
* Unit tests / docstrings / user-guide docs / `changes/` entry: n/a — CI-only change (same as #4023)

