### PR TITLE
docs: state the rectilinear-flag consequence of #4272 and qualify nchunks_initialized

### DIFF
--- a/changes/4272.bugfix.md
+++ b/changes/4272.bugfix.md
@@ -10,6 +10,17 @@ regular grid, nested sequences produce a rectilinear grid. Rectilinear grids
 remain gated behind `zarr.config.set({"array.rectilinear_chunks": True})`.
 See #4174 for the accompanying O(1) chunk normalization change.
 
+One consequence for users who never enable rectilinear chunks: because a
+nested sequence now always requests a rectilinear grid, a per-dimension
+sequence of edge lengths that happens to be uniform — for example the
+`((4,), (4,))` or `[[3, 3, 1]]` form that a dask array's `.chunks` attribute
+produces — is no longer quietly accepted as a regular grid when the
+`array.rectilinear_chunks` option is off. Such input raises
+`ValueError: Rectilinear chunk grids are experimental and disabled by default`,
+exactly as it did in 3.2.x; the silent acceptance existed only in 3.3.0. Pass
+one integer per dimension (e.g. `chunks=(4, 4)`, or a dask array's
+`.chunksize`) to request a regular grid.
+
 `zarr.from_array` with the default `chunks="keep"` / `shards="keep"` now
 reproduces the source's stored grid exactly: a rectilinear grid is passed
 through in O(number of dimensions), with uniform dimensions keeping their
@@ -21,7 +32,7 @@ a rectilinear shard grid `Array.info` no longer raises — it reports the shard
 shape as `<variable>` — while `Array.nchunks_initialized` counts the chunks of
 each initialized shard individually instead of raising.
 
-Everything described here concerns rectilinear chunk grids, which remain an
-experimental feature gated behind
-`zarr.config.set({"array.rectilinear_chunks": True})`; arrays with regular
-chunk grids are unaffected.
+Apart from the nested-sequence input form noted above, everything described
+here concerns rectilinear chunk grids, which remain an experimental feature
+gated behind `zarr.config.set({"array.rectilinear_chunks": True})`; arrays
+with regular chunk grids are unaffected.

--- a/src/zarr/core/array.py
+++ b/src/zarr/core/array.py
@@ -1224,9 +1224,12 @@ class AsyncArray[T_ArrayMetadata: (ArrayV2Metadata, ArrayV3Metadata)]:
         Calculate the number of chunks that have been initialized in storage.
 
         This value is calculated as the sum of the number of chunks in every initialized shard
-        (shard sizes can vary when the shard grid is rectilinear). For arrays that do not use
-        sharding, each stored object holds one chunk, so the number of chunks initialized is the
-        same as the number of stored objects associated with an array.
+        (shard sizes can vary when the shard grid is rectilinear). Each initialized shard is
+        counted at its full declared size, so for an edge shard that extends beyond the array
+        extent this includes chunks that lie entirely outside the array, and the result can
+        exceed `nchunks`. For arrays that do not use sharding, each stored object holds one
+        chunk, so the number of chunks initialized is the same as the number of stored objects
+        associated with an array.
 
         Returns
         -------
@@ -2347,9 +2350,13 @@ class Array[T_ArrayMetadata: (ArrayV2Metadata, ArrayV3Metadata)]:
         Calculate the number of chunks that have been initialized in storage.
 
         This value is calculated as the sum of the number of chunks in every initialized shard
-        (shard sizes can vary when the shard grid is rectilinear). For arrays that do not use sharding,
-        each stored object holds one chunk, so the number of chunks initialized is the same as the number
-        of stored objects associated with an array. For a direct count of the number of initialized stored objects, see `nshards_initialized`.
+        (shard sizes can vary when the shard grid is rectilinear). Each initialized shard is
+        counted at its full declared size, so for an edge shard that extends beyond the array
+        extent this includes chunks that lie entirely outside the array, and the result can
+        exceed `nchunks`. For arrays that do not use sharding, each stored object holds one
+        chunk, so the number of chunks initialized is the same as the number of stored objects
+        associated with an array. For a direct count of the number of initialized stored
+        objects, see `nshards_initialized`.
 
         Returns
         -------
@@ -5423,9 +5430,12 @@ async def _nchunks_initialized(
     Calculate the number of chunks that have been initialized in storage.
 
     This value is calculated as the sum of the number of chunks in every initialized shard
-    (shard sizes can vary when the shard grid is rectilinear). For arrays that do not use
-    sharding, each stored object holds one chunk, so the number of chunks initialized is the
-    same as the number of stored objects associated with an array.
+    (shard sizes can vary when the shard grid is rectilinear). Each initialized shard is
+    counted at its full declared size, so for an edge shard that extends beyond the array
+    extent this includes chunks that lie entirely outside the array, and the result can
+    exceed `nchunks`. For arrays that do not use sharding, each stored object holds one
+    chunk, so the number of chunks initialized is the same as the number of stored objects
+    associated with an array.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR updates the documentation about changes to the parsing of nested sequences of ints in the context of different chunk grids, documenting specifically that when the rectilinear chunks feature is disabled, then nested sequences of ints that describe a regular grid will be parsed as a regular _rectilinear_ grid and error. on 3.3.0 this input generated a regular chunk grid, but on earlier versions it was an error. 

This documents a very minor breaking change, which is arguably reverting an wart in the 3.3.0 release.

:robot: _AI text below_ :robot:

## Summary

Two documentation corrections surfaced by a pre-release review of everything merged since v3.3.0, ahead of the 3.4.0 changelog build (#4256).

`changes/4272.bugfix.md` describes the fix that makes explicit per-chunk size lists always request a rectilinear grid, but it never says what that means for users who leave `array.rectilinear_chunks` off: a uniform nested sequence such as `((4,), (4,))` or `[[3, 3, 1]]` — the shape of a dask array's `.chunks` — was silently accepted as a regular grid in 3.3.0 and now raises the "experimental and disabled by default" error, as it did in 3.2.x. The fragment now states that explicitly and points at the integer-per-dimension form to use instead. Its closing "arrays with regular chunk grids are unaffected" sentence is qualified accordingly.

The `nchunks_initialized` docstrings (both `Array` classes and the module-level helper) were rewritten in #4218 to read as an exact count, but each initialized shard is counted at its full declared size, so an edge shard that overhangs the array contributes chunks that lie entirely outside it and the result can exceed `nchunks` (e.g. `shape=(10,)`, `chunks=(2,)`, `shards=(8,)` fully written reports 8 with `nchunks == 5`). That behavior is unchanged from 3.3.0; the docstrings now say so.

## For reviewers

No code changes — only a changelog fragment and three docstrings. The claim that the nested-sequence input raised in 3.2.x was verified against an installed 3.2.1.

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

## TODO

* [x] Add unit tests and/or doctests in docstrings (n/a — documentation only)
* [x] Add docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/user-guide/*.md` (n/a)
* [x] Changes documented as a new file in `changes/` (edits the existing #4272 fragment)
* [ ] GitHub Actions have all passed
* [x] Test coverage is 100% (Codecov passes) (n/a)
