### PR TITLE
fix: remove attribute nesting depth limit

### DIFF
--- a/changes/3285.feature.md
+++ b/changes/3285.feature.md
@@ -1,8 +1,8 @@
 JSON metadata validation now delegates to ``msgspec.convert`` for the type
 coercions it supports (``Literal`` membership, ``int`` / ``bool`` strictness,
 list-to-tuple), replacing the per-field hand-written ``parse_*`` logic.
-User-defined attributes retain their existing JSON handling without an additional
-nesting-depth limit. A latent generator-exhaustion bug in
+User-defined attributes retain their existing JSON handling. 
+A latent generator-exhaustion bug in
 ``parse_storage_transformers`` is also fixed. See #3285.
 
 As a result some metadata inputs are now parsed more strictly. The previous

--- a/changes/3285.feature.md
+++ b/changes/3285.feature.md
@@ -1,9 +1,9 @@
 JSON metadata validation now delegates to ``msgspec.convert`` for the type
 coercions it supports (``Literal`` membership, ``int`` / ``bool`` strictness,
-list-to-tuple), replacing the per-field hand-written ``parse_*`` logic. A small
-fallback validates the recursive JSON values msgspec cannot, now with an
-explicit nesting-depth limit, and a latent generator-exhaustion bug in
-``parse_storage_transformers`` is fixed. See #3285.
+list-to-tuple), replacing the per-field hand-written ``parse_*`` logic.
+User-defined attributes retain their existing JSON handling without an additional
+nesting-depth limit. A latent generator-exhaustion bug in
+``parse_storage_transformers`` is also fixed. See #3285.
 
 As a result some metadata inputs are now parsed more strictly. The previous
 per-field checks compared values with ``==``, which accepts any numerically

--- a/src/zarr/core/json_parse.py
+++ b/src/zarr/core/json_parse.py
@@ -5,7 +5,7 @@ Most JSON metadata validation is delegated to
 needs (``Literal`` membership, ``int``/``bool`` strictness, list-to-tuple,
 ``TypedDict`` with ``NotRequired``). ``convert`` is a thin wrapper that
 translates [`msgspec.ValidationError`][msgspec.ValidationError] into the
-``TypeError`` the rest of the codebase already raises.
+``ValueError`` the rest of the codebase already raises.
 
 msgspec cannot handle two things in Zarr's metadata types:
 
@@ -13,24 +13,17 @@ msgspec cannot handle two things in Zarr's metadata types:
   schema-build time, and
 * PEP 728 ``extra_items=`` extension fields, which it silently drops.
 
-``validate_json_value`` is the small hand-written fallback for the first of
-those. See https://github.com/zarr-developers/zarr-python/issues/3285.
+User-defined attributes are left to the JSON reader and writer rather than
+recursively validated here. See https://github.com/zarr-developers/zarr-python/issues/3285.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Final, cast, get_origin
+from typing import Any, get_origin
 
 import msgspec
 
-if TYPE_CHECKING:
-    from zarr.core.common import JSON
-
-__all__ = ["MAX_JSON_DEPTH", "convert", "parse_field", "validate_json_value"]
-
-MAX_JSON_DEPTH: Final = 64
-"""Maximum nesting depth accepted by ``validate_json_value``."""
+__all__ = ["convert", "parse_field"]
 
 
 def _type_name(type_: Any) -> str:
@@ -75,29 +68,3 @@ def parse_field(
         raise error(
             f"Failed to parse input for {field!r}: expected {_type_name(type_)}, got {data!r}."
         ) from exc
-
-
-def validate_json_value(value: object, *, max_depth: int = MAX_JSON_DEPTH, _depth: int = 0) -> JSON:
-    """Check that ``value`` is a JSON value and return it unchanged.
-
-    msgspec cannot build a schema for Zarr's recursive ``JSON`` / ``JSONValue``
-    aliases, so this covers the fields typed that way (``attributes``,
-    ``fill_value``, extension-field values). Unlike the previous per-field
-    parsers it also enforces ``max_depth``: a pathologically nested document
-    could otherwise exhaust the interpreter stack.
-    """
-    if _depth > max_depth:
-        raise ValueError(f"JSON value nesting exceeds the maximum depth of {max_depth}.")
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return cast("JSON", value)
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            validate_json_value(item, max_depth=max_depth, _depth=_depth + 1)
-        return cast("JSON", value)
-    if isinstance(value, Mapping):
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(f"JSON object keys must be str, got {type(key).__name__}.")
-            validate_json_value(item, max_depth=max_depth, _depth=_depth + 1)
-        return cast("JSON", value)
-    raise TypeError(f"Value {value!r} is not a valid JSON value.")

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -34,7 +34,7 @@ from zarr.core.common import (
 from zarr.core.config import config
 from zarr.core.dtype import VariableLengthUTF8, ZDType, get_data_type_from_json
 from zarr.core.dtype.common import check_dtype_spec_v3
-from zarr.core.json_parse import parse_field, validate_json_value
+from zarr.core.json_parse import parse_field
 from zarr.core.metadata.common import parse_attributes
 from zarr.errors import MetadataValidationError, NodeTypeValidationError
 from zarr.registry import get_codec_class
@@ -673,7 +673,7 @@ class ArrayV3Metadata(Metadata):
             chunk_grid=_data_typed["chunk_grid"],  # type: ignore[arg-type]
             chunk_key_encoding=_data_typed["chunk_key_encoding"],  # type: ignore[arg-type]
             codecs=_data_typed["codecs"],
-            attributes=validate_json_value(_data_typed.get("attributes", {})),  # type: ignore[arg-type]
+            attributes=_data_typed.get("attributes", {}),  # type: ignore[arg-type]
             dimension_names=_data_typed.get("dimension_names", None),
             fill_value=fill_value_parsed,
             data_type=data_type,

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -673,6 +673,11 @@ class ArrayV3Metadata(Metadata):
             chunk_grid=_data_typed["chunk_grid"],  # type: ignore[arg-type]
             chunk_key_encoding=_data_typed["chunk_key_encoding"],  # type: ignore[arg-type]
             codecs=_data_typed["codecs"],
+            # Attributes are user data with no schema of their own: anything the
+            # JSON decoder produced is a valid value, so there is nothing to
+            # validate beyond `parse_attributes` checking that it is a mapping
+            # (done in `__init__`). Recursing into them here only to enforce a
+            # nesting limit rejected documents this library itself had written.
             attributes=_data_typed.get("attributes", {}),  # type: ignore[arg-type]
             dimension_names=_data_typed.get("dimension_names", None),
             fill_value=fill_value_parsed,

--- a/src/zarr/core/metadata/v3.py
+++ b/src/zarr/core/metadata/v3.py
@@ -673,11 +673,8 @@ class ArrayV3Metadata(Metadata):
             chunk_grid=_data_typed["chunk_grid"],  # type: ignore[arg-type]
             chunk_key_encoding=_data_typed["chunk_key_encoding"],  # type: ignore[arg-type]
             codecs=_data_typed["codecs"],
-            # Attributes are user data with no schema of their own: anything the
-            # JSON decoder produced is a valid value, so there is nothing to
-            # validate beyond `parse_attributes` checking that it is a mapping
-            # (done in `__init__`). Recursing into them here only to enforce a
-            # nesting limit rejected documents this library itself had written.
+            # Attribute values are arbitrary JSON, so they have no field-specific
+            # schema to validate. `__init__` checks the outer dict via `parse_attributes`.
             attributes=_data_typed.get("attributes", {}),  # type: ignore[arg-type]
             dimension_names=_data_typed.get("dimension_names", None),
             fill_value=fill_value_parsed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 from hypothesis import HealthCheck, Verbosity, settings
+from hypothesis import strategies as st
 
 import zarr.registry
 from zarr import AsyncGroup, config
@@ -294,6 +295,33 @@ settings.register_profile(
 )
 
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
+
+
+@st.composite
+def json_attributes(draw: st.DrawFn, *, depth: int) -> dict[str, JSON]:
+    """Generate JSON attribute dictionaries with additional nested object/array layers."""
+    keys = st.text(max_size=8)
+    scalars = (
+        st.none()
+        | st.booleans()
+        | st.integers()
+        | st.floats(allow_nan=False, allow_infinity=False)
+        | st.text(max_size=8)
+    )
+    values = st.recursive(
+        scalars,
+        lambda children: (
+            st.lists(children, max_size=3) | st.dictionaries(keys, children, max_size=3)
+        ),
+        max_leaves=8,
+    )
+    attributes: dict[str, JSON] = draw(st.dictionaries(keys, values, max_size=3))
+    if depth:
+        value: JSON = attributes
+        for is_object in draw(st.lists(st.booleans(), min_size=depth, max_size=depth)):
+            value = {draw(keys): value} if is_object else [value]
+        attributes = {draw(keys): value}
+    return attributes
 
 
 # TODO: uncomment these overrides when we can get mypy to accept them

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -487,6 +487,24 @@ async def test_nbytes_stored_async() -> None:
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])
+@pytest.mark.parametrize("depth", [0, 65, 100])
+@pytest.mark.parametrize("container", ["object", "array"])
+def test_reopen_nested_attributes(zarr_format: ZarrFormat, depth: int, container: str) -> None:
+    """Attributes accepted when creating an array must survive reopening it."""
+    value: JSON = "leaf"
+    for _ in range(depth):
+        value = {"nested": value} if container == "object" else [value]
+    attributes = {"payload": value}
+    store = MemoryStore()
+    sync_api.create_array(
+        store, shape=(1,), dtype="int32", attributes=attributes, zarr_format=zarr_format
+    )
+
+    reopened = sync_api.open_array(store, mode="r", zarr_format=zarr_format)
+    assert dict(reopened.attrs) == attributes
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
 def test_update_attrs(zarr_format: ZarrFormat) -> None:
     # regression test for https://github.com/zarr-developers/zarr-python/issues/2328
     store = MemoryStore()

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -487,24 +487,6 @@ async def test_nbytes_stored_async() -> None:
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])
-@pytest.mark.parametrize("depth", [0, 65, 100])
-@pytest.mark.parametrize("container", ["object", "array"])
-def test_reopen_nested_attributes(zarr_format: ZarrFormat, depth: int, container: str) -> None:
-    """Attributes accepted when creating an array must survive reopening it."""
-    value: JSON = "leaf"
-    for _ in range(depth):
-        value = {"nested": value} if container == "object" else [value]
-    attributes = {"payload": value}
-    store = MemoryStore()
-    sync_api.create_array(
-        store, shape=(1,), dtype="int32", attributes=attributes, zarr_format=zarr_format
-    )
-
-    reopened = sync_api.open_array(store, mode="r", zarr_format=zarr_format)
-    assert dict(reopened.attrs) == attributes
-
-
-@pytest.mark.parametrize("zarr_format", [2, 3])
 def test_update_attrs(zarr_format: ZarrFormat) -> None:
     # regression test for https://github.com/zarr-developers/zarr-python/issues/2328
     store = MemoryStore()
@@ -513,9 +495,17 @@ def test_update_attrs(zarr_format: ZarrFormat) -> None:
     )
     arr.attrs["foo"] = "bar"
     assert arr.attrs["foo"] == "bar"
+    # Deeply nested values must survive the reopen too: metadata parsing once
+    # capped attribute nesting at 64 levels, rejecting arrays this library had
+    # itself written (regression test for the limit introduced in #4063).
+    deep: JSON = "leaf"
+    for _ in range(100):
+        deep = {"nested": [deep]}
+    arr.attrs["deep"] = deep
 
     arr2 = zarr.open_array(store=store, zarr_format=zarr_format)
     assert arr2.attrs["foo"] == "bar"
+    assert arr2.attrs["deep"] == deep
 
 
 @pytest.mark.parametrize(("chunks", "shards"), [((2, 2), None), ((2, 2), (4, 4))])

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -14,11 +14,13 @@ import numcodecs
 import numpy as np
 import numpy.typing as npt
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from packaging.version import Version
 
 import zarr.api.asynchronous
 import zarr.api.synchronous as sync_api
-from tests.conftest import skip_object_dtype
+from tests.conftest import json_attributes, skip_object_dtype
 from zarr import Array, Group
 from zarr.abc.store import Store
 from zarr.codecs import (
@@ -487,25 +489,22 @@ async def test_nbytes_stored_async() -> None:
 
 
 @pytest.mark.parametrize("zarr_format", [2, 3])
-def test_update_attrs(zarr_format: ZarrFormat) -> None:
+@pytest.mark.parametrize("depth", [0, 1, 8, 32, 65, 100])
+@settings(max_examples=20, deadline=None)
+@given(data=st.data())
+def test_update_attrs(zarr_format: ZarrFormat, depth: int, data: st.DataObject) -> None:
     # regression test for https://github.com/zarr-developers/zarr-python/issues/2328
     store = MemoryStore()
     arr = zarr.create_array(
         store=store, shape=(5,), chunks=(5,), dtype="f8", zarr_format=zarr_format
     )
-    arr.attrs["foo"] = "bar"
-    assert arr.attrs["foo"] == "bar"
-    # Deeply nested values must survive the reopen too: metadata parsing once
-    # capped attribute nesting at 64 levels, rejecting arrays this library had
-    # itself written (regression test for the limit introduced in #4063).
-    deep: JSON = "leaf"
-    for _ in range(100):
-        deep = {"nested": [deep]}
-    arr.attrs["deep"] = deep
+    attributes = data.draw(json_attributes(depth=depth))
+    for key, value in attributes.items():
+        arr.attrs[key] = value
+    assert dict(arr.attrs) == attributes
 
     arr2 = zarr.open_array(store=store, zarr_format=zarr_format)
-    assert arr2.attrs["foo"] == "bar"
-    assert arr2.attrs["deep"] == deep
+    assert dict(arr2.attrs) == attributes
 
 
 @pytest.mark.parametrize(("chunks", "shards"), [((2, 2), None), ((2, 2), (4, 4))])

--- a/tests/test_json_parse.py
+++ b/tests/test_json_parse.py
@@ -1,10 +1,8 @@
 """Tests for :mod:`zarr.core.json_parse`.
 
 ``convert`` delegates JSON type coercion to :func:`msgspec.convert` (translating
-``msgspec.ValidationError`` into ``TypeError``); ``validate_json_value`` is the
-hand-written fallback for the recursive ``JSON`` alias msgspec cannot build,
-including a nesting-depth limit. The final group is a regression test for the
-``parse_storage_transformers`` fix that motivated the depth limit work.
+``msgspec.ValidationError`` into ``ValueError``). The final group covers the
+``parse_storage_transformers`` generator-exhaustion regression.
 """
 
 from __future__ import annotations
@@ -13,7 +11,7 @@ from typing import Literal
 
 import pytest
 
-from zarr.core.json_parse import MAX_JSON_DEPTH, convert, parse_field, validate_json_value
+from zarr.core.json_parse import convert, parse_field
 from zarr.core.metadata.v3 import parse_storage_transformers
 
 
@@ -62,39 +60,6 @@ class TestParseField:
             parse_field(5, Literal["array"], "node_type", error=MyError)
         # the generic type error is chained as the cause
         assert isinstance(exc_info.value.__cause__, ValueError)
-
-
-class TestValidateJsonValue:
-    @pytest.mark.parametrize("value", [None, True, 1, 1.5, "s"])
-    def test_primitives(self, value: object) -> None:
-        assert validate_json_value(value) is value
-
-    def test_nested(self) -> None:
-        value = {"a": [1, 2.0, "x", True, None], "b": {"c": [{}]}}
-        assert validate_json_value(value) is value
-
-    def test_rejects_non_str_keys(self) -> None:
-        with pytest.raises(TypeError, match="keys must be str"):
-            validate_json_value({1: "x"})
-
-    def test_rejects_non_json_leaf(self) -> None:
-        with pytest.raises(TypeError, match="not a valid JSON value"):
-            validate_json_value(object())
-        with pytest.raises(TypeError, match="not a valid JSON value"):
-            validate_json_value({"a": object()})
-
-    def test_depth_limit(self) -> None:
-        def nest(depth: int) -> object:
-            v: object = "leaf"
-            for _ in range(depth):
-                v = {"k": v}
-            return v
-
-        # At the limit it passes; one level deeper it is rejected. This bound is
-        # new behavior the previous per-field parsers never had.
-        assert validate_json_value(nest(MAX_JSON_DEPTH)) is not None
-        with pytest.raises(ValueError, match="maximum depth"):
-            validate_json_value(nest(MAX_JSON_DEPTH + 1))
 
 
 class TestStorageTransformersRegression:

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -174,6 +174,11 @@ def test_array_metadata_keys_matches_typeddict() -> None:
 # Codecs after evolution for single-byte (uint8) and multi-byte (float64) types.
 _UINT8_CODECS = ({"name": "bytes"},)
 _FLOAT64_CODECS = ({"name": "bytes", "configuration": {"endian": "little"}},)
+# 100 alternating object/array levels: deeper than the 64-level cap that
+# from_dict once enforced on attributes.
+_DEEP_ATTRIBUTES: dict[str, Any] = {"payload": "leaf"}
+for _ in range(100):
+    _DEEP_ATTRIBUTES = {"payload": [_DEEP_ATTRIBUTES]}
 
 
 @pytest.mark.parametrize(
@@ -248,6 +253,14 @@ _FLOAT64_CODECS = ({"name": "bytes", "configuration": {"endian": "little"}},)
                 extra_fields={"my_ext": {"must_understand": False, "data": [1, 2, 3]}},
             ),
             id="extra_fields",
+        ),
+        Expect(
+            # Attributes are not depth-limited: 100 levels once tripped a 64-level
+            # cap in from_dict that create_array never applied, so arrays this
+            # library wrote could not be reopened.
+            input={"attributes": _DEEP_ATTRIBUTES},
+            output=minimal_metadata_dict_v3(attributes=_DEEP_ATTRIBUTES, codecs=_UINT8_CODECS),
+            id="deeply_nested_attributes",
         ),
     ],
     ids=lambda case: case.id,

--- a/tests/test_metadata/test_v3.py
+++ b/tests/test_metadata/test_v3.py
@@ -174,11 +174,6 @@ def test_array_metadata_keys_matches_typeddict() -> None:
 # Codecs after evolution for single-byte (uint8) and multi-byte (float64) types.
 _UINT8_CODECS = ({"name": "bytes"},)
 _FLOAT64_CODECS = ({"name": "bytes", "configuration": {"endian": "little"}},)
-# 100 alternating object/array levels: deeper than the 64-level cap that
-# from_dict once enforced on attributes.
-_DEEP_ATTRIBUTES: dict[str, Any] = {"payload": "leaf"}
-for _ in range(100):
-    _DEEP_ATTRIBUTES = {"payload": [_DEEP_ATTRIBUTES]}
 
 
 @pytest.mark.parametrize(
@@ -253,14 +248,6 @@ for _ in range(100):
                 extra_fields={"my_ext": {"must_understand": False, "data": [1, 2, 3]}},
             ),
             id="extra_fields",
-        ),
-        Expect(
-            # Attributes are not depth-limited: 100 levels once tripped a 64-level
-            # cap in from_dict that create_array never applied, so arrays this
-            # library wrote could not be reopened.
-            input={"attributes": _DEEP_ATTRIBUTES},
-            output=minimal_metadata_dict_v3(attributes=_DEEP_ATTRIBUTES, codecs=_UINT8_CODECS),
-            id="deeply_nested_attributes",
         ),
     ],
     ids=lambda case: case.id,


### PR DESCRIPTION
An AI-written PR that reverts a regression introduced in #4063, which limited the contents of `attributes` to a nest depth of 64. 

:robot: ai text below :robot:

## Summary

A Zarr v3 array can be created with attributes nested more than 64 levels deep, but reopening the same array fails with `ValueError: JSON value nesting exceeds the maximum depth of 64`. This restriction was introduced in #4063 and regresses the behavior in 3.3.0.

Remove the recursive attribute validator and its depth limit, restoring the existing attribute handling through the JSON reader/writer and the metadata constructor. Keep msgspec validation for structured metadata fields. Update the unreleased changelog entry and add create/reopen regression coverage for nested objects and arrays at depths 0, 65, and 100, for both Zarr formats.

## For reviewers

Please check that the restored attribute handling is consistent with array creation and group metadata. This draft is awaiting the human author's edits and review before it is marked ready.

Validation on current upstream main plus this fix: 2,188 tests passed and 48 skipped across the JSON parsing, metadata, group, and array suites in the Python 3.12 minimal Hatch environment. Ruff lint and formatting checks and `git diff --check` passed.

## Author attestation

- [ ] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

## TODO

- [x] Add regression tests
- [x] Update the existing unreleased changelog entry
- [ ] Human author edits the description and reviews the changes
- [ ] GitHub Actions have all passed
- [ ] Codecov passes
